### PR TITLE
fix: blog frontmatter compilation + pre-landing review nits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,4 @@ tsconfig.tsbuildinfo
 /blob-report/
 /playwright/.cache/
 .gstack/
+.vercel

--- a/content-collections.ts
+++ b/content-collections.ts
@@ -215,6 +215,7 @@ export const HelpPost = defineCollection({
           "overview",
           "getting-started",
           "terms",
+          "for-investors",
           "analysis",
           "valuation",
         ]),

--- a/src/app/(blog)/blog/(post)/[slug]/page.tsx
+++ b/src/app/(blog)/blog/(post)/[slug]/page.tsx
@@ -87,9 +87,6 @@ export async function generateMetadata({
   });
 }
 
-// Priority categories that should be shown first
-const PRIORITY_CATEGORIES = ["real-estate", "landscaping"];
-
 export default async function BlogArticle({
   params,
 }: {
@@ -115,19 +112,9 @@ export default async function BlogArticle({
     ),
   ]);
 
-  // First try to find a priority category (industry category)
-  let category = PRIORITY_CATEGORIES.filter((cat) =>
-    data.categories.includes(cat as any)
-  )
+  const category = data.categories
     .map((cat) => BLOG_CATEGORIES.find((c) => c.slug === cat))
     .find((cat) => cat !== undefined);
-
-  // If no priority category found, fall back to any valid category
-  if (!category) {
-    category = data.categories
-      .map((cat) => BLOG_CATEGORIES.find((c) => c.slug === cat))
-      .find((cat) => cat !== undefined);
-  }
 
   if (!category) {
     console.error(`No valid category found for post: ${data.slug}`);

--- a/src/components/blog/mdx.tsx
+++ b/src/components/blog/mdx.tsx
@@ -69,20 +69,20 @@ function AnimatedCTA(props: {
       />
       <div className="relative flex h-full flex-col items-center justify-center gap-6 text-center">
         {props.badge && (
-          <span className="inline-flex items-center rounded-full border border-warm-grey-2/20 bg-warm-grey-2/10 px-3 py-1 text-xs font-medium text-warm-grey/80 dark:text-warm-white/80">
+          <span className="inline-flex items-center rounded-full border border-warm-grey-2/20 bg-warm-grey-2/10 px-3 py-1 text-xs font-medium text-warm-grey/80">
             {props.badge}
           </span>
         )}
-        <h3 className="text-2xl font-semibold tracking-tight text-warm-grey dark:text-warm-white">
+        <h3 className="text-2xl font-semibold tracking-tight text-warm-grey">
           {props.title}
         </h3>
-        <p className="text-warm-grey/80 dark:text-warm-white/80">{props.description}</p>
+        <p className="text-warm-grey/80">{props.description}</p>
         {(props.primaryAction || props.secondaryAction) && (
           <div className="flex gap-4">
             {props.primaryAction && (
               <Link
                 href={props.primaryAction.href}
-                className="inline-flex items-center justify-center rounded-full bg-warm-grey-2/20 px-6 py-2 font-medium text-warm-grey dark:text-warm-white transition-colors hover:bg-warm-grey-2/30"
+                className="inline-flex items-center justify-center rounded-full bg-warm-grey-2/20 px-6 py-2 font-medium text-warm-grey transition-colors hover:bg-warm-grey-2/30"
               >
                 {props.primaryAction.label}
               </Link>
@@ -90,7 +90,7 @@ function AnimatedCTA(props: {
             {props.secondaryAction && (
               <Link
                 href={props.secondaryAction.href}
-                className="inline-flex items-center justify-center gap-2 rounded-full px-6 py-2 font-medium text-warm-grey/80 dark:text-warm-white/80 ring-1 ring-warm-grey-2/20 transition-colors hover:bg-warm-grey-2/10 hover:text-warm-grey dark:hover:text-warm-white"
+                className="inline-flex items-center justify-center gap-2 rounded-full px-6 py-2 font-medium text-warm-grey/80 ring-1 ring-warm-grey-2/20 transition-colors hover:bg-warm-grey-2/10 hover:text-warm-grey"
               >
                 {props.secondaryAction.label}
                 <span aria-hidden="true">→</span>
@@ -106,49 +106,49 @@ function AnimatedCTA(props: {
 const components = {
   h2: (props: any) => (
     <h2
-      className="mb-4 mt-8 text-2xl font-semibold text-warm-grey dark:text-warm-white underline-offset-4 hover:underline"
+      className="mb-4 mt-8 text-2xl font-semibold text-warm-grey underline-offset-4 hover:underline"
       {...props}
     />
   ),
   h3: (props: any) => (
     <h3
-      className="mb-3 mt-6 text-xl font-medium text-warm-grey dark:text-warm-white underline-offset-4 hover:underline"
+      className="mb-3 mt-6 text-xl font-medium text-warm-grey underline-offset-4 hover:underline"
       {...props}
     />
   ),
   a: (props: any) => (
     <CustomLink
-      className="font-medium text-warm-grey/80 dark:text-warm-white/80 underline underline-offset-4 hover:text-warm-grey dark:hover:text-warm-white"
+      className="font-medium text-warm-grey/80 underline underline-offset-4 hover:text-warm-grey"
       {...props}
     />
   ),
   code: (props: any) => (
     <code
-      className="rounded-md border border-warm-grey-2/20 bg-warm-grey-2/10 px-2 py-1 font-medium text-warm-grey dark:text-warm-white before:hidden after:hidden"
+      className="rounded-md border border-warm-grey-2/20 bg-warm-grey-2/10 px-2 py-1 font-medium text-warm-grey before:hidden after:hidden"
       {...props}
     />
   ),
   thead: (props: any) => (
-    <thead className="text-lg text-warm-grey dark:text-warm-white" {...props} />
+    <thead className="text-lg text-warm-grey" {...props} />
   ),
   th: (props: any) => (
-    <th className="p-4 text-left font-medium text-warm-grey dark:text-warm-white" {...props} />
+    <th className="p-4 text-left font-medium text-warm-grey" {...props} />
   ),
   td: (props: any) => (
     <td
-      className="border-t border-warm-grey-2/20 p-4 text-warm-grey/80 dark:text-warm-white/80"
+      className="border-t border-warm-grey-2/20 p-4 text-warm-grey/80"
       {...props}
     />
   ),
   p: (props: any) => (
     <p
-      className="my-4 text-base leading-relaxed text-warm-grey/80 dark:text-warm-white/80"
+      className="my-4 text-base leading-relaxed text-warm-grey/80"
       {...props}
     />
   ),
   li: (props: any) => (
     <li
-      className="mb-2 text-base leading-relaxed text-warm-grey/80 dark:text-warm-white/80 marker:text-warm-grey/60 dark:marker:text-warm-white/60"
+      className="mb-2 text-base leading-relaxed text-warm-grey/80 marker:text-warm-grey/60"
       {...props}
     />
   ),
@@ -174,7 +174,7 @@ const components = {
         )}
       >
         <div className="mt-1 flex items-start gap-3">
-          <div className="flex-1 text-warm-grey/80 dark:text-warm-white/80">{props.children}</div>
+          <div className="flex-1 text-warm-grey/80">{props.children}</div>
         </div>
       </div>
     )
@@ -197,7 +197,7 @@ const components = {
           height={80}
         />
       </div>
-      <p className="text-center text-lg leading-relaxed text-warm-grey/80 dark:text-warm-white/80 [text-wrap:balance]">
+      <p className="text-center text-lg leading-relaxed text-warm-grey/80 [text-wrap:balance]">
         &ldquo;{props.text}&rdquo;
       </p>
       <div className="flex items-center justify-center space-x-4">
@@ -209,8 +209,8 @@ const components = {
           height={48}
         />
         <div className="flex flex-col">
-          <p className="font-semibold text-warm-grey dark:text-warm-white">{props.author}</p>
-          <p className="text-sm text-warm-grey/80 dark:text-warm-white/80">{props.title}</p>
+          <p className="font-semibold text-warm-grey">{props.author}</p>
+          <p className="text-sm text-warm-grey/80">{props.title}</p>
         </div>
       </div>
     </div>
@@ -218,11 +218,11 @@ const components = {
   Prerequisites: (props: { children: React.ReactNode }) => (
     <div className="my-8 rounded-xl border border-warm-grey-2/20 bg-warm-grey-2/10 p-6 backdrop-blur-sm">
       <div className="mb-4 flex items-center gap-3">
-        <h4 className="font-display text-lg font-semibold text-warm-grey dark:text-warm-white">
+        <h4 className="font-display text-lg font-semibold text-warm-grey">
           Forutsetninger
         </h4>
       </div>
-      <div className="prose prose-invert max-w-none">{props.children}</div>
+      <div className="prose max-w-none">{props.children}</div>
     </div>
   ),
   CopyBox,
@@ -271,30 +271,30 @@ const components = {
               className="group flex items-center justify-between rounded-lg px-2 py-3 transition-colors hover:bg-warm-grey-2/20 active:bg-warm-grey-2/30 sm:px-4"
             >
               <div>
-                <p className="text-xs font-medium text-warm-grey/60 dark:text-warm-white/60 group-hover:text-warm-grey/80 dark:group-hover:text-warm-white/80">
+                <p className="text-xs font-medium text-warm-grey/60 group-hover:text-warm-grey/80">
                   {formatDate(post.publishedAt)}
                 </p>
-                <h3 className="my-px text-base font-medium text-warm-grey dark:text-warm-white">
+                <h3 className="my-px text-base font-medium text-warm-grey">
                   {post.title}
                 </h3>
-                <p className="line-clamp-1 text-sm text-warm-grey/80 dark:text-warm-white/80 group-hover:text-warm-grey dark:group-hover:text-warm-white">
+                <p className="line-clamp-1 text-sm text-warm-grey/80 group-hover:text-warm-grey">
                   {post.summary}
                 </p>
               </div>
-              <ExpandingArrow className="-ml-4 h-4 w-4 text-warm-grey/60 dark:text-warm-white/60 group-hover:text-warm-grey/80 dark:group-hover:text-warm-white/80" />
+              <ExpandingArrow className="-ml-4 h-4 w-4 text-warm-grey/60 group-hover:text-warm-grey/80" />
             </Link>
           </li>
         ))}
     </ul>
   ),
   strong: (props: any) => (
-    <strong className="font-semibold text-warm-grey dark:text-warm-white" {...props} />
+    <strong className="font-semibold text-warm-grey" {...props} />
   ),
   Info: (props: any) => (
     <div className="my-6 flex items-start gap-4 rounded-lg border border-warm-grey-2/20 bg-warm-grey-2/10 p-6 backdrop-blur-sm">
       <div className="flex-1 text-[0.95rem] leading-relaxed">
-        <div className="font-medium text-warm-grey dark:text-warm-white">Fun fact:</div>
-        <div className="mt-1 text-warm-grey/80 dark:text-warm-white/80">{props.children}</div>
+        <div className="font-medium text-warm-grey">Fun fact:</div>
+        <div className="mt-1 text-warm-grey/80">{props.children}</div>
       </div>
     </div>
   ),
@@ -311,7 +311,7 @@ const components = {
       )}
     >
       <div className="flex items-center gap-3">
-        <div className="text-lg font-medium text-warm-grey dark:text-warm-white">Formel</div>
+        <div className="text-lg font-medium text-warm-grey">Formel</div>
       </div>
       <div className="w-full overflow-x-auto">
         <div
@@ -328,7 +328,7 @@ const components = {
         </div>
       </div>
       {props.description && (
-        <p className="text-sm text-warm-grey/70 dark:text-warm-white/70">{props.description}</p>
+        <p className="text-sm text-warm-grey/70">{props.description}</p>
       )}
     </div>
   ),
@@ -351,7 +351,7 @@ const components = {
       )}
     >
       <div className="flex items-center gap-3">
-        <div className="text-lg font-medium text-warm-grey dark:text-warm-white">Formel</div>
+        <div className="text-lg font-medium text-warm-grey">Formel</div>
       </div>
       <div className="w-full overflow-x-auto">
         <div
@@ -368,7 +368,7 @@ const components = {
         </div>
       </div>
       {props.description && (
-        <p className="text-sm text-warm-grey/70 dark:text-warm-white/70">{props.description}</p>
+        <p className="text-sm text-warm-grey/70">{props.description}</p>
       )}
     </div>
   ),
@@ -398,15 +398,15 @@ const components = {
         {props.items.map((item, idx) => (
           <div key={idx} className="flex gap-6">
             <div className="flex-none">
-              <div className="flex h-8 w-8 items-center justify-center rounded-full border border-warm-grey-2/20 bg-warm-grey-2/10 text-lg font-semibold text-warm-grey dark:text-warm-white">
+              <div className="flex h-8 w-8 items-center justify-center rounded-full border border-warm-grey-2/20 bg-warm-grey-2/10 text-lg font-semibold text-warm-grey">
                 {idx + 1}
               </div>
             </div>
             <div className="flex-1 space-y-4">
-              <h3 className="text-xl font-semibold text-warm-grey dark:text-warm-white">
+              <h3 className="text-xl font-semibold text-warm-grey">
                 {item.title}
               </h3>
-              <div className="text-base text-warm-grey/80 dark:text-warm-white/80">{item.content}</div>
+              <div className="text-base text-warm-grey/80">{item.content}</div>
               {item.image && (
                 <div className="mt-4 overflow-hidden rounded-lg">
                   <MDXImage
@@ -443,7 +443,7 @@ const components = {
   }) => (
     <div className="my-8 rounded-xl border border-warm-grey-2/20 bg-warm-grey-2/10 p-6 backdrop-blur-sm">
       {props.title && (
-        <h4 className="font-display mb-4 text-lg font-semibold text-warm-grey dark:text-warm-white">
+        <h4 className="font-display mb-4 text-lg font-semibold text-warm-grey">
           {props.title}
         </h4>
       )}
@@ -456,13 +456,13 @@ const components = {
             })}
           >
             <div className="flex items-baseline justify-between">
-              <span className="text-warm-grey/80 dark:text-warm-white/80">{step.label}</span>
+              <span className="text-warm-grey/80">{step.label}</span>
               <span
                 className={cx(
                   "font-mono text-lg",
                   step.isResult
-                    ? "font-semibold text-warm-grey dark:text-warm-white"
-                    : "text-warm-grey/80 dark:text-warm-white/80",
+                    ? "font-semibold text-warm-grey"
+                    : "text-warm-grey/80",
                 )}
               >
                 {typeof step.value === "number"
@@ -471,7 +471,7 @@ const components = {
               </span>
             </div>
             {step.calculation && (
-              <div className="text-sm text-warm-grey/60 dark:text-warm-white/60">
+              <div className="text-sm text-warm-grey/60">
                 {step.calculation}
               </div>
             )}
@@ -491,7 +491,7 @@ const components = {
     return (
       <div className="my-8 rounded-xl border border-warm-grey-2/20 bg-warm-grey-2/10 p-6 backdrop-blur-sm">
         {props.title && (
-          <h4 className="font-display mb-6 text-xl font-semibold text-warm-grey dark:text-warm-white">
+          <h4 className="font-display mb-6 text-xl font-semibold text-warm-grey">
             {props.title}
           </h4>
         )}
@@ -502,10 +502,10 @@ const components = {
               className="flex flex-col space-y-2 rounded-lg border border-warm-grey-2/20 bg-warm-grey-2/5 p-4 backdrop-blur-sm"
             >
               <div className="flex items-center gap-3">
-                <h5 className="font-medium text-warm-grey dark:text-warm-white">{point.title}</h5>
+                <h5 className="font-medium text-warm-grey">{point.title}</h5>
               </div>
               {point.description && (
-                <p className="text-sm leading-relaxed text-warm-grey/70 dark:text-warm-white/70">
+                <p className="text-sm leading-relaxed text-warm-grey/70">
                   {point.description}
                 </p>
               )}
@@ -556,11 +556,11 @@ export function MDX({ code, images, className }: MDXProps) {
       data-mdx-container
       className={cx(
         "prose max-w-none transition-all",
-        "prose-headings:relative prose-headings:scroll-mt-20 prose-headings:font-display prose-headings:font-bold prose-headings:text-warm-grey dark:prose-headings:text-warm-white",
-        "prose-p:text-warm-grey/80 dark:prose-p:text-warm-white/80 prose-p:leading-relaxed prose-p:my-4",
-        "prose-a:text-warm-grey/80 dark:prose-a:text-warm-white/80 prose-a:underline prose-a:underline-offset-4 hover:prose-a:text-warm-grey dark:hover:prose-a:text-warm-white",
-        "prose-code:text-warm-grey dark:prose-code:text-warm-white prose-code:bg-warm-grey-2/10 prose-code:px-2 prose-code:py-1",
-        "prose-li:text-warm-grey/80 dark:prose-li:text-warm-white/80 prose-li:leading-relaxed prose-li:mb-2",
+        "prose-headings:relative prose-headings:scroll-mt-20 prose-headings:font-display prose-headings:font-bold prose-headings:text-warm-grey",
+        "prose-p:text-warm-grey/80 prose-p:leading-relaxed prose-p:my-4",
+        "prose-a:text-warm-grey/80 prose-a:underline prose-a:underline-offset-4 hover:prose-a:text-warm-grey",
+        "prose-code:text-warm-grey prose-code:bg-warm-grey-2/10 prose-code:px-2 prose-code:py-1",
+        "prose-li:text-warm-grey/80 prose-li:leading-relaxed prose-li:mb-2",
         "prose-ul:my-8 prose-ul:space-y-6",
         "prose-ol:my-4 prose-ol:space-y-2",
         className,

--- a/src/content/blog/dcf-analyse-naringseiendom.mdx
+++ b/src/content/blog/dcf-analyse-naringseiendom.mdx
@@ -1,5 +1,5 @@
 ---
-title: DCF-Analyse for Næringseiendom: Slik Beregner Du Nåverdi
+title: "DCF-Analyse for Næringseiendom: Slik Beregner Du Nåverdi"
 publishedAt: 2025-01-26
 summary: Lær hvordan du utfører DCF-analyse (diskontert kontantstrøm) for næringseiendom. Steg-for-steg guide med eksempler og vanlige feil å unngå.
 image: /building/pexels-expect-best-79873-351262.jpg

--- a/src/content/blog/esg-barekraft-naringseiendom.mdx
+++ b/src/content/blog/esg-barekraft-naringseiendom.mdx
@@ -1,5 +1,5 @@
 ---
-title: ESG og Bærekraft i Næringseiendom: Hva Betyr Det for Verdien?
+title: "ESG og Bærekraft i Næringseiendom: Hva Betyr Det for Verdien?"
 publishedAt: 2025-01-26
 summary: Lær hvordan ESG og bærekraft påvirker verdien av næringseiendom. Komplett guide til energieffektivitet, miljøkrav og hvordan du forbereder eiendommen din.
 image: /building/pexels-pixabay-248877.jpg

--- a/src/content/blog/handelslokaler-nord-norge.mdx
+++ b/src/content/blog/handelslokaler-nord-norge.mdx
@@ -1,5 +1,5 @@
 ---
-title: Handelslokaler i Nord-Norge: Investeringsmuligheter og Utfordringer
+title: "Handelslokaler i Nord-Norge: Investeringsmuligheter og Utfordringer"
 publishedAt: 2025-01-26
 summary: Komplett analyse av handelsmarkedet i Nord-Norge. Markedsforhold, beste områder, yield-forventninger og praktiske råd for investorer.
 image: /building/pexels-abshky-18566965.jpg

--- a/src/content/blog/investere-kontorlokaler-nord-norge.mdx
+++ b/src/content/blog/investere-kontorlokaler-nord-norge.mdx
@@ -1,5 +1,5 @@
 ---
-title: Investere i Kontorlokaler i Nord-Norge: Komplett Guide
+title: "Investere i Kontorlokaler i Nord-Norge: Komplett Guide"
 publishedAt: 2025-01-26
 summary: Komplett guide til investering i kontorlokaler i Nord-Norge. Markedsanalyse, beste områder, yield-forventninger og praktiske råd for investorer.
 image: /building/pexels-expect-best-79873-351262.jpg

--- a/src/content/blog/investere-naringseiendom-tromso.mdx
+++ b/src/content/blog/investere-naringseiendom-tromso.mdx
@@ -1,5 +1,5 @@
 ---
-title: Investere i Næringseiendom i Tromsø: En Komplett Guide
+title: "Investere i Næringseiendom i Tromsø: En Komplett Guide"
 publishedAt: 2025-01-26
 summary: Komplett guide til investering i næringseiendom i Tromsø. Markedsanalyse, beste områder, ROI-forventninger og praktiske råd for investorer.
 image: /building/pexels-pixabay-248877.jpg

--- a/src/content/blog/kjope-vs-leie-naringseiendom.mdx
+++ b/src/content/blog/kjope-vs-leie-naringseiendom.mdx
@@ -1,5 +1,5 @@
 ---
-title: Kjøpe vs. Leie Næringseiendom: Hva Er Best for Din Bedrift?
+title: "Kjøpe vs. Leie Næringseiendom: Hva Er Best for Din Bedrift?"
 publishedAt: 2025-01-26
 summary: Komplett sammenligning av kjøp vs. leie av næringseiendom. Lær om fordelene, ulempene og når hver løsning er best for din bedrift.
 image: /building/pexels-abshky-18566965.jpg

--- a/src/content/blog/komplett-guide-verdivurdering-naringseiendom.mdx
+++ b/src/content/blog/komplett-guide-verdivurdering-naringseiendom.mdx
@@ -1,7 +1,7 @@
 ---
 title: Komplett Guide til Verdivurdering av Næringseiendom i Nord-Norge
 publishedAt: 2025-01-26
-summary: Lær alt om verdivurdering av næringseiendom: metoder, prosess, kostnader og når du trenger en profesjonell verdsettelse. Spesialtilpasset for markedet i Nord-Norge.
+summary: "Lær alt om verdivurdering av næringseiendom: metoder, prosess, kostnader og når du trenger en profesjonell verdsettelse. Spesialtilpasset for markedet i Nord-Norge."
 image: /building/pexels-expect-best-79873-351262.jpg
 author: codehagen
 categories:

--- a/src/content/blog/lager-logistikkbygg-nord-norge.mdx
+++ b/src/content/blog/lager-logistikkbygg-nord-norge.mdx
@@ -1,5 +1,5 @@
 ---
-title: Lager og Logistikkbygg: Vekstmarkedet i Nord-Norge
+title: "Lager og Logistikkbygg: Vekstmarkedet i Nord-Norge"
 publishedAt: 2025-01-26
 summary: Analyser av lagermarkedet i Nord-Norge med fokus på vekstdrivere, beste områder og investeringsmuligheter. Komplett guide for investorer.
 image: /building/pexels-abshky-18566965.jpg

--- a/src/content/blog/naringseiendom-vs-bolig-investorer.mdx
+++ b/src/content/blog/naringseiendom-vs-bolig-investorer.mdx
@@ -1,5 +1,5 @@
 ---
-title: Næringseiendom vs. Bolig: Hva Er Forskjellen for Investorer?
+title: "Næringseiendom vs. Bolig: Hva Er Forskjellen for Investorer?"
 publishedAt: 2025-01-26
 summary: Sammenligning av investering i næringseiendom vs. bolig. Lær om forskjeller i avkastning, risiko, forvaltning og hva som passer deg best.
 image: /building/pexels-pixabay-248877.jpg

--- a/src/content/blog/naringseiendomsmarkedet-2025-nord-norge.mdx
+++ b/src/content/blog/naringseiendomsmarkedet-2025-nord-norge.mdx
@@ -1,5 +1,5 @@
 ---
-title: Næringseiendomsmarkedet 2025: Trender og Prognoser for Nord-Norge
+title: "Næringseiendomsmarkedet 2025: Trender og Prognoser for Nord-Norge"
 publishedAt: 2025-01-26
 summary: Omfattende analyse av næringseiendomsmarkedet i Nord-Norge 2025. Trender, priser, investeringsmuligheter og prognoser for fremtiden.
 image: /building/pexels-abshky-18566965.jpg

--- a/src/content/blog/naringseiendomsmarkedet-bodo-2025.mdx
+++ b/src/content/blog/naringseiendomsmarkedet-bodo-2025.mdx
@@ -1,5 +1,5 @@
 ---
-title: Næringseiendomsmarkedet i Bodø 2025: Trender og Muligheter
+title: "Næringseiendomsmarkedet i Bodø 2025: Trender og Muligheter"
 publishedAt: 2025-01-26
 summary: Dyptdykk i næringseiendomsmarkedet i Bodø 2025. Analyser av trender, priser, investeringsmuligheter og fremtidig utvikling for investorer og eiendomsbesittere.
 image: /building/pexels-expect-best-79873-351262.jpg

--- a/src/content/blog/naringseiendomsmarkedet-narvik.mdx
+++ b/src/content/blog/naringseiendomsmarkedet-narvik.mdx
@@ -1,5 +1,5 @@
 ---
-title: Næringseiendomsmarkedet i Narvik: Muligheter for Investorer
+title: "Næringseiendomsmarkedet i Narvik: Muligheter for Investorer"
 publishedAt: 2025-01-26
 summary: Analyser av næringseiendomsmarkedet i Narvik med fokus på industri, logistikk og investeringsmuligheter. Komplett oversikt over markedsforhold og trender.
 image: /building/pexels-pixabay-248877.jpg

--- a/src/content/blog/naringsmegler-vs-selge-selv.mdx
+++ b/src/content/blog/naringsmegler-vs-selge-selv.mdx
@@ -1,5 +1,5 @@
 ---
-title: Næringsmegler vs. Selge Selv: Hva Er Best for Deg?
+title: "Næringsmegler vs. Selge Selv: Hva Er Best for Deg?"
 publishedAt: 2025-01-26
 summary: Sammenligning av å bruke næringsmegler vs. å selge næringseiendom selv. Lær om fordelene, ulempene og når hver løsning er best.
 image: /building/pexels-abshky-18566965.jpg

--- a/src/content/blog/rentestigninger-naringseiendom.mdx
+++ b/src/content/blog/rentestigninger-naringseiendom.mdx
@@ -1,5 +1,5 @@
 ---
-title: Rentestigninger og Næringseiendom: Hvordan Det Påvirker Verdien
+title: "Rentestigninger og Næringseiendom: Hvordan Det Påvirker Verdien"
 publishedAt: 2025-01-26
 summary: Lær hvordan rentestigninger påvirker verdien av næringseiendom. Analyser av finansiering, verdivurdering og strategier for investorer.
 image: /building/pexels-pixabay-248877.jpg

--- a/src/content/blog/salg-naringseiendom-beste-pris.mdx
+++ b/src/content/blog/salg-naringseiendom-beste-pris.mdx
@@ -1,5 +1,5 @@
 ---
-title: Slik Selger Du Næringseiendom til Beste Pris: En Praktisk Guide
+title: "Slik Selger Du Næringseiendom til Beste Pris: En Praktisk Guide"
 publishedAt: 2025-01-26
 summary: Komplett guide til salg av næringseiendom i Nord-Norge. Lær hvordan du forbereder, prissetter, markedsfører og forhandler for å oppnå beste pris.
 image: /building/pexels-abshky-18566965.jpg

--- a/src/content/blog/sensitivitetsanalyse-naringseiendom.mdx
+++ b/src/content/blog/sensitivitetsanalyse-naringseiendom.mdx
@@ -1,5 +1,5 @@
 ---
-title: Sensitivitetsanalyse: Hvorfor Det Er Kritisk for Eiendomsinvesteringer
+title: "Sensitivitetsanalyse: Hvorfor Det Er Kritisk for Eiendomsinvesteringer"
 publishedAt: 2025-01-26
 summary: Lær hvordan sensitivitetsanalyse hjelper deg forstå risiko og usikkerhet i eiendomsinvesteringer. Praktisk guide med eksempler og tips.
 image: /building/pexels-expect-best-79873-351262.jpg

--- a/src/content/blog/utleie-naringseiendom-nord-norge.mdx
+++ b/src/content/blog/utleie-naringseiendom-nord-norge.mdx
@@ -1,5 +1,5 @@
 ---
-title: Utleie av Næringseiendom i Nord-Norge: Alt Du Trenger å Vite
+title: "Utleie av Næringseiendom i Nord-Norge: Alt Du Trenger å Vite"
 publishedAt: 2025-01-26
 summary: Komplett guide til utleie av næringseiendom i Nord-Norge. Lær om markedsforhold, prissetting, leieavtaler og hvordan du finner rette leietakere.
 image: /building/pexels-pixabay-248877.jpg

--- a/src/content/blog/yield-naringseiendom-hva-det-er.mdx
+++ b/src/content/blog/yield-naringseiendom-hva-det-er.mdx
@@ -1,7 +1,7 @@
 ---
-title: Yield på Næringseiendom: Hva Det Er og Hvorfor Det Betyr Alt
+title: "Yield på Næringseiendom: Hva Det Er og Hvorfor Det Betyr Alt"
 publishedAt: 2025-01-26
-summary: Lær alt om yield på næringseiendom: definisjon, beregning, normale nivåer i Nord-Norge og hvordan du kan forbedre yield på din eiendom.
+summary: "Lær alt om yield på næringseiendom: definisjon, beregning, normale nivåer i Nord-Norge og hvordan du kan forbedre yield på din eiendom."
 image: /building/pexels-expect-best-79873-351262.jpg
 author: codehagen
 categories:

--- a/tests/blog-content.spec.ts
+++ b/tests/blog-content.spec.ts
@@ -1,0 +1,57 @@
+import { test, expect } from "@playwright/test";
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+/**
+ * Blog content regression — proves every `.mdx` file in src/content/blog
+ * actually compiles into a reachable post.
+ *
+ * Content Collections silently DROPS a post when its YAML frontmatter fails
+ * to parse (e.g. an unquoted `title:`/`summary:` value containing a colon —
+ * "Nested mappings are not allowed in compact mappings"). A dropped post
+ * falls out of `allBlogPosts`, so `/blog/<slug>` 404s with no build error.
+ * This test fails loudly when that happens.
+ */
+
+const BLOG_DIR = path.join(process.cwd(), "src/content/blog");
+
+const slugs = readdirSync(BLOG_DIR)
+  .filter((f) => f.endsWith(".mdx"))
+  .map((f) => {
+    const raw = readFileSync(path.join(BLOG_DIR, f), "utf-8");
+    // Read the explicit `slug:` line with a plain regex — the files this test
+    // guards against are exactly the ones that fail to YAML-parse, so a real
+    // YAML parser can't be relied on. Normalize the scalar: strip an inline
+    // `# comment` and any surrounding quotes before using it as a URL segment.
+    const rawSlug = /^slug:\s*(.+?)\s*$/m.exec(raw)?.[1];
+    const explicit = rawSlug
+      ?.replace(/\s+#.*$/, "")
+      .replace(/^["']|["']$/g, "")
+      .trim();
+    return explicit || f.replace(/\.mdx$/, "");
+  });
+
+test("every blog .mdx compiles into a reachable post", async ({ page }) => {
+  // Crawls every blog post sequentially; each render may fetch external blur
+  // images. Matches the sitemap-crawl test's extended budget in routes.spec.ts.
+  test.setTimeout(120_000);
+
+  expect(slugs.length, "blog .mdx source file count").toBeGreaterThan(0);
+
+  const dropped: string[] = [];
+  for (const slug of slugs) {
+    const res = await page.goto(`/blog/${slug}`, {
+      waitUntil: "domcontentloaded",
+    });
+    if (!res || res.status() >= 400) {
+      dropped.push(`${slug} (HTTP ${res?.status() ?? "no response"})`);
+    }
+  }
+
+  expect(
+    dropped,
+    `Blog posts dropped — likely a frontmatter parse/validation failure: ${dropped.join(
+      ", ",
+    )}`,
+  ).toEqual([]);
+});


### PR DESCRIPTION
## Summary

Resolves two follow-ups left open after the editorial redesign ship (PR #4): 18 blog posts that were silently 404'ing in production, and the three pre-landing review code nits.

**Blog frontmatter fix (the headline)**
- 18 of 26 blog posts were silently dropped from `allBlogPosts` (live site showed 8). Root cause: an unquoted YAML `title:`/`summary:` value containing a colon-space (e.g. `Næringseiendom: Slik...`) makes `yaml@2` throw `Nested mappings are not allowed in compact mappings`. Content Collections caught the parse error, dropped the file before schema validation, and emitted no build error — so `/blog/<slug>` 404'd for 18 keyword-targeted guide articles.
- Fix: wrapped the offending `title`/`summary` values in double quotes across 18 `.mdx` files. `allBlogPosts` goes **8 → 26**. Rendered text is unchanged (YAML quotes don't appear in the parsed value).
- Added `tests/blog-content.spec.ts` — crawls every `.mdx` in `src/content/blog` and fails if any post is unreachable. Verified it fails without the fix (18 × HTTP 404) and passes with it.

**Pre-landing review nits**
- **Dead code:** removed `PRIORITY_CATEGORIES` from `blog/(post)/[slug]/page.tsx`. It was `["real-estate", "landscaping"]` — neither is a valid `BlogPost` category, so the priority filter always returned nothing and fell through to the fallback every render.
- **Schema mismatch:** added `for-investors` to the `HelpPost` category schema enum. `HELP_CATEGORIES` declares a "For Investorer" category, but the schema omitted it — any help article tagged with it would have been silently rejected by validation.
- **Dark-mode dead styling:** stripped 53 `dark:` Tailwind tokens + one `prose-invert` from `src/components/blog/mdx.tsx`. The redesign is light-only; these never activated, and `prose-invert` would have rendered light-on-light text in the Prerequisites box. This is the first file of the repo-wide dark-mode teardown (`TODOS.md` TODO 2 — that TODO remains open).

**Chore**
- `.gitignore` += `.vercel` (Vercel project link).

## Test Coverage

No new application code paths — the diff is content quoting, dead-code removal, a CSS-class strip, and a one-value enum addition. The one behavioral change (blog post compilation) is covered by the new `tests/blog-content.spec.ts`. Full suite: **30/30 passing** against a production build.

## Pre-Landing Review

No issues. Diff reviewed file by file: dead-code removal verified genuinely dead, `let`→`const` correct, enum addition consistent with the UI taxonomy, `dark:` removal leaves base classes intact.

## Adversarial Review (Codex)

Codex flagged 3 items, all on the new test file — 2 fixed in this PR:
- Added `test.setTimeout(120_000)` (the test crawls 26 posts sequentially with external blur-image fetches; matches the sitemap-crawl test's budget).
- Normalized the `slug:` regex capture (strips surrounding quotes / inline comments so a future quoted slug can't produce a false failure).
- The third (test file "untracked") was just the pre-commit state — it is committed here.

No production behavior break found in the YAML, category, or enum changes.

## Design Review

Frontend files touched (`mdx.tsx`, blog page) but the changes only *remove* inert dark-mode classes and dead code — no visual change on the light-only site, except the Prerequisites box no longer risks light-on-light text.

## Test plan

- [x] Full Playwright suite: 30/30 pass against `pnpm build && pnpm start`
- [x] `tests/blog-content.spec.ts` fails without the fix (18 × 404), passes with it
- [x] `content-collections` build regenerates `allBlogPosts` with all 26 posts
- [x] Production build type-checks clean (`ignoreBuildErrors: false`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "for-investors" category option for help content.

* **Improvements**
  * Updated blog styling with consistent theming across all components.
  * Enhanced blog content validation to ensure all posts remain accessible and properly rendered.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Codehagen/advantiestate/pull/5?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->