### PR TITLE
feat(eiendommer): listings index + detail pages

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -6,6 +6,44 @@ the AI SEO closure review (/plan-eng-review, 2026-05-24), and the AI-SEO researc
 
 ---
 
+## TODO 18 — Listings (eiendommer) feature — SHIPPED 2026-05-25
+
+- **What:** Public `/eiendommer` index + `/eiendommer/[slug]` detail pages.
+- **Outcome:** Shipped on branch `feat/eiendommer-listings`:
+  - New `ListingPost` content collection (typed frontmatter: status, type,
+    city, headline stats, gallery, facts, tenants, financials, location +
+    geo coords, downloads, megler).
+  - 9 listing MDX files seeded with explicit clean slugs (Sjøgata 7 with full
+    detail; 8 others with index-card data).
+  - `src/app/eiendommer/page.tsx` — SubHero + KPI band + sticky filter
+    (status/type/city) + featured + grid + saved-search alert + off-market
+    band + CTA.
+  - `src/app/eiendommer/[slug]/page.tsx` — gallery + headline stats + body
+    with sticky megler card + facts table + tenants table + dark financials
+    grid + Leaflet location map + downloads + CTA + related.
+  - Real Leaflet map (`PropertyMap` + `PropertyMapLeaflet`) reusing the
+    CartoDB tile config from `markedsinnsikt/maps/mapTheme.ts`.
+  - `RealEstateListing` JSON-LD per detail page, linked to the existing
+    `#organization` graph node.
+  - Nav, sitemap, siteConfig wired. ~640 new lines of `.ei-*`/`.ed-*` CSS in
+    `advanti-design.css`.
+  - **Design review pass:** /design-review found 4 issues (F1 sticky filter
+    overlaying dark band, F2 NDA subtext contrast 1.07:1, F3 chips 36 → 44px
+    touch target, F4 "Featured" → "Utvalgt" i18n). All fixed in atomic
+    commits.
+  - **Emil design-engineering pass:** removed `transition: all`, guarded
+    photo/row hover transforms behind `@media (hover: hover) and
+    (pointer: fine)`, swapped `.ei-offmarket-row` padding-left animation for
+    transform, added `@media (prefers-reduced-motion: reduce)` override.
+- **Follow-up content work (deferred):** the 8 stub listings have only
+  index-card data; their detail pages need facts/tenants/financials/location
+  populated when partners share the data. Adding `location.geo: {lat,lng}`
+  to each MDX enables the real Leaflet map (currently falls back to a CSS
+  mock for stubs).
+- **Completed:** 2026-05-25.
+
+---
+
 ## TODO 14 — HowTo schema pilot — SHIPPED 2026-05-24
 
 - **What:** Pilot HowTo schema on one help article and validate.

--- a/content-collections.ts
+++ b/content-collections.ts
@@ -501,6 +501,165 @@ export const LocationPost = defineCollection({
   },
 });
 
+export const ListingPost = defineCollection({
+  name: "ListingPost",
+  directory: "src/content/listings",
+  include: "*.mdx",
+  schema: (z) => ({
+    // Editorial title — split into a non-italic head and an italic tail so
+    // the H1 + listing-card H3 render with the design's two-tone treatment
+    // without authors having to embed JSX in frontmatter. `title` (plain) is
+    // used for metadata, sitemap, and JSON-LD.
+    title: z.string(),
+    titleHead: z.string(),
+    titleTail: z.string(),
+
+    // Taxonomy
+    status: z.enum(["til-salgs", "reservert", "kommer", "solgt"]),
+    statusLabel: z.string().optional(),
+    type: z.enum([
+      "kontor",
+      "logistikk",
+      "handel",
+      "kombi",
+      "hotell",
+      "utvikling",
+      "industri",
+    ]),
+    typeLabel: z.string(),
+    city: z.enum([
+      "bodo",
+      "tromso",
+      "harstad",
+      "alta",
+      "narvik",
+      "lofoten",
+      "mo-i-rana",
+    ]),
+
+    // Identity
+    address: z.string(),
+    reference: z.string(),
+    cardEyebrow: z.string(),
+    featured: z.boolean().default(false),
+    featuredEyebrow: z.string().optional(),
+    order: z.number(),
+    publishedAt: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+    updatedAt: z
+      .string()
+      .regex(/^\d{4}-\d{2}-\d{2}$/)
+      .optional(),
+
+    // Headline stats
+    bta: z.number(),
+    prisantydning: z.number().optional(),
+    prisantydningEstimat: z.boolean().default(false),
+    yieldNetto: z.number().optional(),
+    yieldEstimat: z.boolean().default(false),
+    utleiegrad: z.number().optional(),
+    wault: z.number().optional(),
+    ferdig: z.string().optional(),
+
+    // Media
+    coverImage: z.string(),
+    coverImageAlt: z.string(),
+    gallery: z
+      .array(z.object({ src: z.string(), alt: z.string() }))
+      .optional(),
+    photoCount: z.number().optional(),
+
+    // Summary on index card + meta
+    summary: z.string(),
+    lede: z.string().optional(),
+
+    // Megler (responsible broker)
+    megler: z.object({
+      name: z.string(),
+      role: z.string(),
+      avatar: z.string(),
+      email: z.string(),
+      phone: z.string(),
+      slug: z.string().optional(),
+    }),
+
+    // Optional structured detail-page data
+    facts: z
+      .array(z.object({ label: z.string(), value: z.string() }))
+      .optional(),
+    tenants: z
+      .array(
+        z.object({
+          name: z.string(),
+          sector: z.string(),
+          etasjer: z.string(),
+          areal: z.number(),
+          leieKrM2: z.number().optional(),
+          leieArlig: z.number(),
+          leieArligEstimat: z.boolean().default(false),
+          kontraktTil: z.string().optional(),
+          andel: z.number(),
+          ledig: z.boolean().default(false),
+        }),
+      )
+      .optional(),
+    tenantsNote: z.string().optional(),
+    financials: z
+      .object({
+        bruttoLeie: z.number(),
+        eierkostnader: z.number(),
+        noi: z.number(),
+        yieldNetto: z.number(),
+        intro: z.string().optional(),
+      })
+      .optional(),
+    location: z
+      .object({
+        title: z.string(),
+        titleTail: z.string(),
+        body: z.string(),
+        // Real WGS-84 coordinates for the Leaflet marker. Optional — when
+        // omitted, the detail page falls back to a centroid of the city.
+        geo: z
+          .object({ lat: z.number(), lng: z.number() })
+          .optional(),
+        pois: z.array(
+          z.object({ name: z.string(), distance: z.string() }),
+        ),
+      })
+      .optional(),
+    downloads: z
+      .array(
+        z.object({
+          label: z.string(),
+          sub: z.string(),
+          kind: z.enum(["pdf", "nda"]),
+          href: z.string(),
+        }),
+      )
+      .optional(),
+
+    slug: z.string().optional(),
+  }),
+  transform: async (document, context) => {
+    try {
+      const mdx = await compileMDX(context, document, {
+        rehypePlugins: [rehypeSlug, rehypeAutolinkHeadings],
+        remarkPlugins: [remarkGfm],
+      });
+      const slugger = new GithubSlugger();
+      return {
+        ...document,
+        slug: document.slug || slugger.slug(document.title),
+        mdx,
+      };
+    } catch (error) {
+      console.error("Error compiling MDX for:", document.title, error);
+      console.error("Error details:", error.stack);
+      throw error;
+    }
+  },
+});
+
 export default defineConfig({
   collections: [
     BlogPost,
@@ -511,5 +670,6 @@ export default defineConfig({
     IntegrationsPost,
     PersonPost,
     LocationPost,
+    ListingPost,
   ],
 });

--- a/src/app/eiendommer/[slug]/page.tsx
+++ b/src/app/eiendommer/[slug]/page.tsx
@@ -1,0 +1,843 @@
+import { Metadata } from "next";
+import Image from "next/image";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+import { MDX } from "@/components/blog/mdx";
+import { PropertyMap } from "@/components/eiendommer/PropertyMap";
+import { BreadcrumbStructuredData } from "@/components/StructuredData";
+import { siteConfig } from "@/app/siteConfig";
+import { getActiveListings, getListingPost } from "@/lib/content";
+import { constructMetadata } from "@/lib/utils";
+
+const STATUS_LABELS: Record<string, string> = {
+  "til-salgs": "Til salgs",
+  reservert: "Reservert",
+  kommer: "Kommer",
+  solgt: "Solgt",
+};
+
+const CITY_LABELS: Record<string, string> = {
+  bodo: "Bodø",
+  tromso: "Tromsø",
+  harstad: "Harstad",
+  alta: "Alta",
+  narvik: "Narvik",
+  lofoten: "Lofoten",
+  "mo-i-rana": "Mo i Rana",
+};
+
+function formatInt(value: number) {
+  return new Intl.NumberFormat("nb-NO").format(value);
+}
+
+function formatDecimal(value: number, max = 1) {
+  return new Intl.NumberFormat("nb-NO", { maximumFractionDigits: max }).format(
+    value,
+  );
+}
+
+function formatEditorialDate(iso: string) {
+  return new Date(`${iso}T00:00:00`).toLocaleDateString("nb-NO", {
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+  });
+}
+
+export async function generateStaticParams() {
+  return getActiveListings().map((listing) => ({ slug: listing.slug }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: { slug: string };
+}): Promise<Metadata | undefined> {
+  const { slug } = await params;
+  const listing = getListingPost(slug);
+  if (!listing) return;
+  return constructMetadata({
+    path: `/eiendommer/${listing.slug}`,
+    title: `${listing.title} | Advanti Estate`,
+    description: listing.summary,
+    image: listing.coverImage,
+  });
+}
+
+export default async function EiendomDetailPage({
+  params,
+}: {
+  params: { slug: string };
+}) {
+  const { slug } = await params;
+  const listing = getListingPost(slug);
+  if (!listing) notFound();
+
+  const statusLabel =
+    listing.statusLabel ?? STATUS_LABELS[listing.status] ?? listing.status;
+  const cityLabel = CITY_LABELS[listing.city] ?? listing.city;
+
+  const gallery = listing.gallery && listing.gallery.length > 0
+    ? listing.gallery
+    : [
+        {
+          src: listing.coverImage,
+          alt: listing.coverImageAlt,
+        },
+      ];
+  const mainImg = gallery[0];
+  const sideImgs = gallery.slice(1, 3);
+
+  const updatedLabel = listing.updatedAt
+    ? formatEditorialDate(listing.updatedAt)
+    : formatEditorialDate(listing.publishedAt);
+
+  // Related: two other listings, preferring same type then proximity in order.
+  const related = getActiveListings()
+    .filter((other) => other.slug !== listing.slug)
+    .sort((a, b) => {
+      const aSame = a.type === listing.type ? 0 : 1;
+      const bSame = b.type === listing.type ? 0 : 1;
+      return aSame - bSame || a.order - b.order;
+    })
+    .slice(0, 2);
+
+  // RealEstateListing JSON-LD — schema.org type that AI Overviews and search
+  // engines treat as a first-class property listing. Keeps the @id linked to
+  // the site Organization graph so it appears as Advanti's mandate, not an
+  // unattributed node.
+  const baseUrl = siteConfig.url;
+  const listingUrl = `${baseUrl}/eiendommer/${listing.slug}`;
+  const realEstateJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "RealEstateListing",
+    "@id": `${listingUrl}#listing`,
+    url: listingUrl,
+    name: listing.title,
+    description: listing.summary,
+    image: listing.coverImage.startsWith("http")
+      ? listing.coverImage
+      : `${baseUrl}${listing.coverImage}`,
+    datePosted: listing.publishedAt,
+    ...(listing.updatedAt ? { dateModified: listing.updatedAt } : {}),
+    provider: {
+      "@type": "RealEstateAgent",
+      "@id": `${baseUrl}/#organization`,
+    },
+    ...(listing.prisantydning
+      ? {
+          offers: {
+            "@type": "Offer",
+            priceCurrency: "NOK",
+            price: listing.prisantydning * 1_000_000,
+          },
+        }
+      : {}),
+    object: {
+      "@type": "Accommodation",
+      name: listing.title,
+      address: {
+        "@type": "PostalAddress",
+        streetAddress: listing.address,
+        addressLocality: cityLabel,
+        addressCountry: "NO",
+      },
+      floorSize: {
+        "@type": "QuantitativeValue",
+        value: listing.bta,
+        unitCode: "MTK",
+      },
+    },
+  };
+
+  return (
+    <>
+      <BreadcrumbStructuredData
+        items={[
+          { name: "Hjem", url: "/" },
+          { name: "Eiendommer", url: "/eiendommer" },
+          { name: listing.title, url: `/eiendommer/${listing.slug}` },
+        ]}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(realEstateJsonLd) }}
+      />
+
+      <div className="page-pad" />
+
+      {/* SUBHERO — crumb + gallery */}
+      <section style={{ padding: "32px 0 0" }}>
+        <div className="wrap">
+          <nav className="crumb" aria-label="Brødsmuler">
+            <Link href="/">Hjem</Link>
+            <span className="sep">/</span>
+            <Link href="/eiendommer">Eiendommer</Link>
+            <span className="sep">/</span>
+            <span className="here">
+              {listing.titleHead} {listing.titleTail}
+            </span>
+          </nav>
+
+          {/* GALLERY */}
+          <div className="ed-gallery">
+            <div className="g-main">
+              <div className={`ei-status ${listing.status}`}>
+                <span className="dot" />
+                {statusLabel}
+              </div>
+              <Image
+                src={mainImg.src}
+                alt={mainImg.alt}
+                fill
+                priority
+                sizes="(max-width: 880px) 100vw, 60vw"
+                style={{ objectFit: "cover" }}
+              />
+            </div>
+            {sideImgs.map((img, index) => (
+              <div className="g-side" key={`${img.src}-${index}`}>
+                <Image
+                  src={img.src}
+                  alt={img.alt}
+                  fill
+                  sizes="(max-width: 880px) 100vw, 30vw"
+                  style={{ objectFit: "cover" }}
+                />
+                {index === sideImgs.length - 1 &&
+                  listing.photoCount &&
+                  listing.photoCount > gallery.length && (
+                    <div className="g-more">
+                      <span className="ct">+ {listing.photoCount - gallery.length}</span>{" "}
+                      bilder
+                    </div>
+                  )}
+              </div>
+            ))}
+          </div>
+
+          {/* TITLE BLOCK */}
+          <div className="ed-title">
+            <div>
+              <span className="pre">
+                {listing.featured ? "Featured oppdrag" : "Aktivt oppdrag"} ·
+                {" "}
+                {listing.reference}
+              </span>
+              <h1>
+                {listing.titleHead} <br />
+                <span className="italic">{listing.titleTail}</span>
+              </h1>
+              <div className="addr">
+                <span>{listing.address}</span>
+                <span className="sep" />
+                <span className="ref">Ref. {listing.reference}</span>
+              </div>
+            </div>
+            <div className="ed-title-actions">
+              <span
+                style={{ fontSize: 12, color: "var(--warm-grey-85)" }}
+              >
+                Oppdatert {updatedLabel}
+              </span>
+            </div>
+          </div>
+
+          {/* HEADLINE STATS */}
+          <div className="ed-stats">
+            <div>
+              <div className="l">BTA</div>
+              <div className="v">
+                {formatInt(listing.bta)}
+                <span className="unit">m²</span>
+              </div>
+              {listing.facts?.find((f) => f.label === "Antall etasjer") && (
+                <div className="sub">
+                  {listing.facts.find((f) => f.label === "Antall etasjer")?.value}
+                </div>
+              )}
+            </div>
+            {listing.prisantydning !== undefined ? (
+              <div>
+                <div className="l">Prisantydning</div>
+                <div className="v">
+                  {listing.prisantydningEstimat ? "est. " : ""}
+                  {formatInt(listing.prisantydning)}
+                  <span className="unit">mnok</span>
+                </div>
+                <div className="sub">Eks. omk.</div>
+              </div>
+            ) : listing.ferdig ? (
+              <div>
+                <div className="l">Ferdigstilles</div>
+                <div className="v">{listing.ferdig}</div>
+                <div className="sub">Forhåndsutleie pågår</div>
+              </div>
+            ) : null}
+            {listing.yieldNetto !== undefined && (
+              <div>
+                <div className="l">Yield</div>
+                <div className="v">
+                  {listing.yieldEstimat ? "est. " : ""}
+                  {formatDecimal(listing.yieldNetto, 1).replace(".", ",")}
+                  <span className="unit">%</span>
+                </div>
+                <div className="sub">Netto, normalisert</div>
+              </div>
+            )}
+            {listing.utleiegrad !== undefined && (
+              <div>
+                <div className="l">Utleiegrad</div>
+                <div className="v">
+                  {formatInt(listing.utleiegrad)}
+                  <span className="unit">%</span>
+                </div>
+                <div className="sub">Per {updatedLabel}</div>
+              </div>
+            )}
+            {listing.wault !== undefined && (
+              <div>
+                <div className="l">WAULT</div>
+                <div className="v">
+                  {formatDecimal(listing.wault, 1).replace(".", ",")}
+                  <span className="unit">år</span>
+                </div>
+                <div className="sub">Vektet snitt</div>
+              </div>
+            )}
+          </div>
+        </div>
+      </section>
+
+      {/* BODY + MEGLER */}
+      <section>
+        <div className="wrap">
+          <div className="ed-body">
+            <div>
+              {listing.lede && (
+                <p className="lead">
+                  {listing.lede.split("<i>").length > 1 ? (
+                    <>
+                      {listing.lede.split("<i>")[0]}
+                      <span className="italic">
+                        {listing.lede.split("<i>")[1].split("</i>")[0]}
+                      </span>
+                      {listing.lede.split("</i>")[1] ?? ""}
+                    </>
+                  ) : (
+                    listing.lede
+                  )}
+                </p>
+              )}
+              <MDX code={listing.mdx} images={[]} />
+            </div>
+
+            <aside className="ed-megler">
+              <div className="pre">Ansvarlig megler</div>
+              <div className="pp">
+                <Image
+                  src={listing.megler.avatar}
+                  alt={listing.megler.name}
+                  width={64}
+                  height={64}
+                />
+                <div className="nm">
+                  <div className="n">{listing.megler.name}</div>
+                  <div className="r">{listing.megler.role}</div>
+                </div>
+              </div>
+              <div className="contact">
+                <div>
+                  <div className="l">Mobil</div>
+                  <a href={`tel:${listing.megler.phone.replace(/\s/g, "")}`}>
+                    {listing.megler.phone}
+                  </a>
+                </div>
+                <div>
+                  <div className="l">E-post</div>
+                  <a href={`mailto:${listing.megler.email}`}>
+                    {listing.megler.email}
+                  </a>
+                </div>
+              </div>
+              <div className="cta-row">
+                <Link href="/kontakt" className="btn btn-primary">
+                  Be om prospekt <span className="arrow">→</span>
+                </Link>
+                <Link href="/kontakt" className="btn btn-ghost">
+                  Bestill visning
+                </Link>
+              </div>
+            </aside>
+          </div>
+        </div>
+      </section>
+
+      {/* FACTS */}
+      {listing.facts && listing.facts.length > 0 && (
+        <section className="ed-section">
+          <div className="wrap">
+            <div className="head">
+              <span className="eyebrow">01 · Nøkkeltall</span>
+              <div>
+                <h2>
+                  Tekniske data og{" "}
+                  <span className="italic">eiendomsinformasjon.</span>
+                </h2>
+              </div>
+            </div>
+            <div className="ed-facts">
+              <dl>
+                {listing.facts
+                  .slice(0, Math.ceil(listing.facts.length / 2))
+                  .map((fact) => (
+                    <div key={fact.label}>
+                      <dt>{fact.label}</dt>
+                      <dd>{fact.value}</dd>
+                    </div>
+                  ))}
+              </dl>
+              <dl>
+                {listing.facts
+                  .slice(Math.ceil(listing.facts.length / 2))
+                  .map((fact) => (
+                    <div key={fact.label}>
+                      <dt>{fact.label}</dt>
+                      <dd>{fact.value}</dd>
+                    </div>
+                  ))}
+              </dl>
+            </div>
+          </div>
+        </section>
+      )}
+
+      {/* TENANTS */}
+      {listing.tenants && listing.tenants.length > 0 && (
+        <section className="ed-section">
+          <div className="wrap">
+            <div className="head">
+              <span className="eyebrow">02 · Leieoversikt</span>
+              <div>
+                <h2>
+                  {listing.tenants.length} leietakere —{" "}
+                  <span className="italic">balansert miks.</span>
+                </h2>
+                {listing.tenantsNote && <p>{listing.tenantsNote}</p>}
+              </div>
+            </div>
+            <table className="ed-tenants">
+              <thead>
+                <tr>
+                  <th>Leietaker</th>
+                  <th>Etasjer</th>
+                  <th className="num">Areal</th>
+                  <th className="num col-hide">Leie kr/m²</th>
+                  <th className="num">Årlig leie</th>
+                  <th className="num col-hide">Kontrakt til</th>
+                  <th className="num">Andel</th>
+                </tr>
+              </thead>
+              <tbody>
+                {listing.tenants.map((tenant) => (
+                  <tr
+                    key={tenant.name}
+                    className={tenant.ledig ? "tenant-ledig" : undefined}
+                  >
+                    <td>
+                      <div className="name">{tenant.name}</div>
+                      <div className="sector">{tenant.sector}</div>
+                    </td>
+                    <td>{tenant.etasjer}</td>
+                    <td className="num">
+                      <span className="v">
+                        {formatInt(tenant.areal)}
+                        <span className="unit">m²</span>
+                      </span>
+                    </td>
+                    <td className="num col-hide">
+                      <span className="v">
+                        {tenant.leieKrM2
+                          ? `${tenant.ledig ? "est. " : ""}${formatInt(tenant.leieKrM2)}`
+                          : "—"}
+                      </span>
+                    </td>
+                    <td className="num">
+                      <span className="v">
+                        {tenant.leieArligEstimat ? "est. " : ""}
+                        {formatDecimal(tenant.leieArlig, 2).replace(".", ",")}
+                        <span className="unit">mnok</span>
+                      </span>
+                    </td>
+                    <td className="num col-hide">
+                      <span className="v">{tenant.kontraktTil ?? "—"}</span>
+                    </td>
+                    <td className="num">
+                      <span className="v">
+                        {tenant.andel}
+                        <span className="unit">%</span>
+                      </span>
+                      {!tenant.ledig && (
+                        <span className="bar">
+                          <i style={{ right: `${100 - tenant.andel}%` }} />
+                        </span>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+              <tfoot>
+                <tr>
+                  <td colSpan={7}>
+                    Tall hentet fra siste utleieoversikt. Full leiekontrakt-DD
+                    følger datarommet.
+                  </td>
+                </tr>
+              </tfoot>
+            </table>
+          </div>
+        </section>
+      )}
+
+      {/* FINANCIALS */}
+      {listing.financials && (
+        <section className="ed-fin">
+          <div className="wrap">
+            <div
+              className="head"
+              style={{
+                display: "grid",
+                gridTemplateColumns: "280px 1fr",
+                gap: 48,
+                marginBottom: 48,
+                alignItems: "end",
+              }}
+            >
+              <div>
+                <div className="pre">03 · Økonomi</div>
+              </div>
+              <div>
+                <h2>
+                  Forventet kontant­strøm{" "}
+                  <span className="italic">og avkastning.</span>
+                </h2>
+                {listing.financials.intro && <p>{listing.financials.intro}</p>}
+              </div>
+            </div>
+            <div className="ed-fin-grid">
+              <div>
+                <div className="l">Brutto leieinntekt</div>
+                <div className="v">
+                  {formatDecimal(listing.financials.bruttoLeie, 1).replace(".", ",")}
+                  <span className="unit">mnok</span>
+                </div>
+                <div className="sub">
+                  Normalisert år 1 · inkl. ledig estimert til markedsleie
+                </div>
+              </div>
+              <div>
+                <div className="l">Eierkostnader</div>
+                <div className="v">
+                  {formatDecimal(listing.financials.eierkostnader, 1).replace(".", ",")}
+                  <span className="unit">mnok</span>
+                </div>
+                <div className="sub">
+                  Drift, forvaltning, eiendomsskatt, forsikring
+                </div>
+              </div>
+              <div>
+                <div className="l">Netto driftsresultat</div>
+                <div className="v">
+                  {formatDecimal(listing.financials.noi, 1).replace(".", ",")}
+                  <span className="unit">mnok</span>
+                </div>
+                <div className="sub">NOI år 1 etter eierkostnader</div>
+              </div>
+              <div>
+                <div className="l">Yield (netto)</div>
+                <div className="v">
+                  {formatDecimal(listing.financials.yieldNetto, 1).replace(".", ",")}
+                  <span className="unit">%</span>
+                </div>
+                <div className="sub">
+                  {listing.prisantydning
+                    ? `På prisantydning ${formatInt(listing.prisantydning)} mnok eks. omk.`
+                    : "På prisantydning eks. omk."}
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+      )}
+
+      {/* LOCATION */}
+      {listing.location && (
+        <section className="ed-section">
+          <div className="wrap">
+            <div className="head">
+              <span className="eyebrow">04 · Beliggenhet</span>
+              <div>
+                <h2>
+                  Direkte på havna —{" "}
+                  <span className="italic">midt i {cityLabel} sentrum.</span>
+                </h2>
+              </div>
+            </div>
+            <div className="ed-loc">
+              {listing.location.geo ? (
+                <PropertyMap
+                  lat={listing.location.geo.lat}
+                  lng={listing.location.geo.lng}
+                  label={listing.titleHead.replace(/—\s*$/, "").trim()}
+                />
+              ) : (
+                <div
+                  className="ed-map"
+                  aria-label={`Kart over ${listing.address}`}
+                >
+                  <span className="compass">N</span>
+                  <div className="water" />
+                  <div className="pin">
+                    <span className="marker" />
+                    <span className="lbl">{listing.titleHead}</span>
+                  </div>
+                </div>
+              )}
+              <div className="ed-loc-info">
+                <h3>
+                  {listing.location.title}{" "}
+                  <span className="italic">{listing.location.titleTail}</span>
+                </h3>
+                <p>{listing.location.body}</p>
+                <div className="ed-poi">
+                  {listing.location.pois.map((poi) => (
+                    <div className="ed-poi-row" key={poi.name}>
+                      <span className="ico">↗</span>
+                      <span className="nm">{poi.name}</span>
+                      <span className="dist">{poi.distance}</span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+      )}
+
+      {/* DOWNLOADS */}
+      {listing.downloads && listing.downloads.length > 0 && (
+        <section className="ed-section">
+          <div className="wrap">
+            <div className="head">
+              <span className="eyebrow">05 · Dokumenter</span>
+              <div>
+                <h2>
+                  Last ned{" "}
+                  <span className="italic">prospekt og DD-pakke.</span>
+                </h2>
+                <p>
+                  NDA signeres digitalt før de fortrolige dokumentene gjøres
+                  tilgjengelig.
+                </p>
+              </div>
+            </div>
+            <div className="ed-downloads">
+              {listing.downloads.map((dl) => (
+                <Link
+                  key={dl.label}
+                  href={dl.href}
+                  className={`ed-dl ${dl.kind === "nda" ? "locked" : ""}`}
+                >
+                  <span className="ico">
+                    {dl.kind === "nda" ? "NDA" : "PDF"}
+                  </span>
+                  <div className="nm">
+                    {dl.label}
+                    <span className="sub">{dl.sub}</span>
+                  </div>
+                  <span className="arr">
+                    {dl.kind === "nda" ? "→" : "↓"}
+                  </span>
+                </Link>
+              ))}
+            </div>
+          </div>
+        </section>
+      )}
+
+      {/* CTA */}
+      <section className="ed-cta">
+        <div className="wrap">
+          <span
+            className="eyebrow center no-rule"
+            style={{ marginBottom: 20 }}
+          >
+            Vis interesse
+          </span>
+          <h2>
+            Klar for en visning{" "}
+            <span className="italic">av {listing.titleHead.replace(/—\s*$/, "").trim()}?</span>
+          </h2>
+          <p>
+            Vi booker visninger på dagtid og ettermiddag i {cityLabel}, eller en
+            digital gjennomgang om du heller foretrekker det. Indikative bud
+            mottas fortløpende.
+          </p>
+          <div className="row">
+            <Link href="/kontakt" className="btn btn-dark">
+              Bestill visning <span className="arrow">→</span>
+            </Link>
+            <Link href="/kontakt" className="btn btn-outline">
+              Be om datarom (NDA)
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      {/* RELATED */}
+      {related.length > 0 && (
+        <section className="ed-related">
+          <div className="wrap">
+            <div className="head-compact" style={{ marginBottom: 56 }}>
+              <span className="eyebrow">Lignende oppdrag</span>
+              <div>
+                <h2>
+                  Andre {listing.typeLabel.toLowerCase()}eiendommer{" "}
+                  <span className="italic">i nord.</span>
+                </h2>
+              </div>
+            </div>
+            <div className="ei-grid" style={{ marginTop: 0 }}>
+              {related.map((other) => (
+                <Link
+                  key={other.slug}
+                  href={`/eiendommer/${other.slug}`}
+                  className="ei-card"
+                >
+                  <div className="ei-card-photo">
+                    <Image
+                      src={other.coverImage}
+                      alt={other.coverImageAlt}
+                      fill
+                      sizes="(max-width: 980px) 50vw, 33vw"
+                      style={{ objectFit: "cover" }}
+                    />
+                    <div className={`ei-status ${other.status}`}>
+                      <span className="dot" />
+                      {other.statusLabel ?? STATUS_LABELS[other.status]}
+                    </div>
+                  </div>
+                  <div className="top">
+                    <span>{other.cardEyebrow}</span>
+                    <span>{CITY_LABELS[other.city] ?? other.city}</span>
+                  </div>
+                  <div>
+                    <h3>
+                      {other.titleHead}{" "}
+                      <span className="italic">{other.titleTail}</span>
+                    </h3>
+                    <p className="addr">{other.address}</p>
+                  </div>
+                  <div className="stat-row">
+                    <div>
+                      <div className="l">BTA</div>
+                      <div className="v">
+                        {formatInt(other.bta)}
+                        <span className="unit">m²</span>
+                      </div>
+                    </div>
+                    <div>
+                      <div className="l">
+                        {other.ferdig ? "Ferdig" : "Prisant."}
+                      </div>
+                      <div className="v">
+                        {other.ferdig ??
+                          (other.prisantydning
+                            ? `${other.prisantydningEstimat ? "est. " : ""}${formatInt(
+                                other.prisantydning,
+                              )}`
+                            : "—")}
+                        {other.ferdig
+                          ? null
+                          : other.prisantydning && (
+                              <span className="unit">mnok</span>
+                            )}
+                      </div>
+                    </div>
+                    <div>
+                      <div className="l">Yield</div>
+                      <div className="v">
+                        {other.yieldNetto !== undefined
+                          ? `${other.yieldEstimat ? "est. " : ""}${formatDecimal(
+                              other.yieldNetto,
+                              1,
+                            ).replace(".", ",")}`
+                          : "—"}
+                        {other.yieldNetto !== undefined && (
+                          <span className="unit">%</span>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                </Link>
+              ))}
+              <Link
+                href="/eiendommer"
+                className="ei-card"
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  aspectRatio: "1/1",
+                  border: "var(--hairline)",
+                  background: "var(--warm-white)",
+                }}
+              >
+                <div style={{ textAlign: "center", padding: 32 }}>
+                  <div
+                    style={{
+                      fontFamily: "var(--font-display)",
+                      fontSize: 36,
+                      fontWeight: 300,
+                      fontStyle: "italic",
+                      color: "var(--accent)",
+                      marginBottom: 12,
+                    }}
+                  >
+                    →
+                  </div>
+                  <h3
+                    style={{
+                      fontFamily: "var(--font-display)",
+                      fontSize: 22,
+                      fontWeight: 400,
+                      letterSpacing: "-0.012em",
+                    }}
+                  >
+                    Se alle{" "}
+                    <span
+                      className="italic"
+                      style={{ color: "var(--warm-grey-85)" }}
+                    >
+                      oppdrag
+                    </span>
+                  </h3>
+                  <p
+                    style={{
+                      fontSize: 13,
+                      color: "var(--warm-grey-85)",
+                      marginTop: 8,
+                    }}
+                  >
+                    til salgs i Nord-Norge
+                  </p>
+                </div>
+              </Link>
+            </div>
+          </div>
+        </section>
+      )}
+    </>
+  );
+}

--- a/src/app/eiendommer/[slug]/page.tsx
+++ b/src/app/eiendommer/[slug]/page.tsx
@@ -221,7 +221,7 @@ export default async function EiendomDetailPage({
           <div className="ed-title">
             <div>
               <span className="pre">
-                {listing.featured ? "Featured oppdrag" : "Aktivt oppdrag"} ·
+                {listing.featured ? "Utvalgt oppdrag" : "Aktivt oppdrag"} ·
                 {" "}
                 {listing.reference}
               </span>

--- a/src/app/eiendommer/page.tsx
+++ b/src/app/eiendommer/page.tsx
@@ -1,0 +1,353 @@
+import Link from "next/link";
+
+import { constructMetadata } from "@/lib/utils";
+import { getActiveListings } from "@/lib/content";
+import { SubHero } from "@/components/site/SubHero";
+import {
+  ListingsBrowser,
+  type ListingCardData,
+} from "@/components/eiendommer/ListingsBrowser";
+import { BreadcrumbStructuredData } from "@/components/StructuredData";
+
+const CITY_LABELS: Record<string, string> = {
+  bodo: "Bodø",
+  tromso: "Tromsø",
+  harstad: "Harstad",
+  alta: "Alta",
+  narvik: "Narvik",
+  lofoten: "Lofoten",
+  "mo-i-rana": "Mo i Rana",
+};
+
+const STATUS_LABELS: Record<string, string> = {
+  "til-salgs": "Til salgs",
+  reservert: "Reservert",
+  kommer: "Kommer",
+  solgt: "Solgt",
+};
+
+// Off-market teasers — static editorial content, not driven by the collection.
+// These exist to communicate Advanti's confidential mandate book without
+// publishing identifying details.
+const OFF_MARKET = [
+  {
+    ref: "OM-241",
+    titleHead: "Hotell- og konferanseanlegg",
+    titleTail: "i Lofoten.",
+    type: "Hotell",
+    bta: "8 600",
+    price: "~180",
+    status: "NDA",
+  },
+  {
+    ref: "OM-238",
+    titleHead: "Logistikkportefølje —",
+    titleTail: "tre eiendommer, samme leietaker.",
+    type: "Logistikk",
+    bta: "28 400",
+    price: "~340",
+    status: "Aktiv",
+  },
+  {
+    ref: "OM-235",
+    titleHead: "Sentrumskvartal",
+    titleTail: "med utviklingspotensial, Tromsø.",
+    type: "Utvikling",
+    bta: "12 800",
+    price: "~260",
+    status: "Teaser",
+  },
+  {
+    ref: "OM-231",
+    titleHead: "Single-tenant kontor —",
+    titleTail: "offentlig leietaker, 12 år.",
+    type: "Kontor",
+    bta: "5 200",
+    price: "~118",
+    status: "NDA",
+  },
+];
+
+export const metadata = constructMetadata({
+  path: "/eiendommer",
+  title: "Eiendommer for salg i Nord-Norge | Advanti Estate",
+  description:
+    "Kuratert utvalg av næringseiendommer Advanti har til salgs i Nord-Norge — kontor, logistikk, handel og kombinasjonsbygg. Pluss off-market-oppdrag for kvalifiserte investorer.",
+});
+
+function formatInt(value: number) {
+  return new Intl.NumberFormat("nb-NO").format(value);
+}
+
+function formatDecimal(value: number, max = 1) {
+  return new Intl.NumberFormat("nb-NO", { maximumFractionDigits: max }).format(
+    value,
+  );
+}
+
+function formatEditorialDate(iso: string) {
+  return new Date(`${iso}T00:00:00`).toLocaleDateString("nb-NO", {
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+  });
+}
+
+export default function EiendommerPage() {
+  const listings = getActiveListings();
+
+  // KPI totals
+  const activeCount = listings.filter(
+    (listing) => listing.status === "til-salgs" || listing.status === "reservert",
+  ).length;
+  const totalBta = listings.reduce((acc, listing) => acc + listing.bta, 0);
+  const totalPrice = listings.reduce(
+    (acc, listing) => acc + (listing.prisantydning ?? 0),
+    0,
+  );
+  const yieldWeighted =
+    listings.reduce(
+      (acc, listing) =>
+        acc + (listing.yieldNetto ?? 0) * listing.bta,
+      0,
+    ) /
+    (listings.reduce(
+      (acc, listing) => acc + (listing.yieldNetto ? listing.bta : 0),
+      0,
+    ) || 1);
+
+  const newestUpdated = listings
+    .map((listing) => listing.updatedAt ?? listing.publishedAt)
+    .sort()
+    .at(-1)!;
+
+  // Status / type / city counts for filter chips
+  const statusCounts: Record<string, number> = {};
+  const typeCounts: Record<string, number> = {};
+  const cityCounts: Record<string, number> = {};
+  for (const listing of listings) {
+    statusCounts[listing.status] = (statusCounts[listing.status] ?? 0) + 1;
+    typeCounts[listing.type] = (typeCounts[listing.type] ?? 0) + 1;
+    cityCounts[listing.city] = (cityCounts[listing.city] ?? 0) + 1;
+  }
+
+  // Build cards (featured separated from the grid items)
+  const allCards: ListingCardData[] = listings.map((listing, index) => ({
+    slug: listing.slug,
+    href: `/eiendommer/${listing.slug}`,
+    status: listing.status,
+    statusLabel: listing.statusLabel ?? STATUS_LABELS[listing.status],
+    type: listing.type,
+    typeLabel: listing.typeLabel,
+    city: listing.city,
+    cityLabel: CITY_LABELS[listing.city] ?? listing.city,
+    titleHead: listing.titleHead,
+    titleTail: listing.titleTail,
+    address: listing.address,
+    cardEyebrow: listing.cardEyebrow,
+    bta: listing.bta,
+    prisantydning: listing.prisantydning,
+    prisantydningEstimat: listing.prisantydningEstimat ?? false,
+    yieldNetto: listing.yieldNetto,
+    yieldEstimat: listing.yieldEstimat ?? false,
+    ferdig: listing.ferdig,
+    coverImage: listing.coverImage,
+    coverImageAlt: listing.coverImageAlt,
+    featured: listing.featured ?? false,
+    featuredEyebrow: listing.featuredEyebrow,
+    summary: listing.summary,
+    utleiegrad: listing.utleiegrad,
+    megler: listing.megler
+      ? {
+          name: listing.megler.name,
+          role: listing.megler.role,
+          avatar: listing.megler.avatar,
+        }
+      : undefined,
+    position: index + 1,
+  }));
+
+  const featuredCard = allCards.find((card) => card.featured);
+  const gridCards = allCards.filter((card) => !card.featured);
+
+  return (
+    <>
+      <BreadcrumbStructuredData
+        items={[
+          { name: "Hjem", url: "/" },
+          { name: "Eiendommer for salg", url: "/eiendommer" },
+        ]}
+      />
+
+      <SubHero
+        crumb={[
+          { label: "Hjem", href: "/" },
+          { label: "Eiendommer for salg" },
+        ]}
+        eyebrow={`Aktive salgsoppdrag · oppdatert ${formatEditorialDate(newestUpdated)}`}
+        title={
+          <>
+            Næringseiendom <br />
+            <span className="italic">til salgs i nord.</span>
+          </>
+        }
+        lede="Et kuratert utvalg av eiendommer vi har til salgs i Nord-Norge — kontor, logistikk, handel og kombinasjonsbygg. Pluss konfidensielle oppdrag for kvalifiserte investorer."
+      />
+
+      {/* KPI BAND */}
+      <section className="section-tight">
+        <div className="wrap">
+          <div className="mi-kpis">
+            <div className="mi-kpi">
+              <div className="label">Aktive oppdrag</div>
+              <div className="val">
+                {activeCount}
+                <span className="unit">til salgs nå</span>
+              </div>
+              <div className="delta">Oppdatert {formatEditorialDate(newestUpdated)}</div>
+            </div>
+            <div className="mi-kpi">
+              <div className="label">Totalareal</div>
+              <div className="val">
+                {formatInt(totalBta)}
+                <span className="unit">m²</span>
+              </div>
+              <div className="delta">På {listings.length} eiendommer</div>
+            </div>
+            <div className="mi-kpi">
+              <div className="label">Samlet prisantydning</div>
+              <div className="val">
+                {formatDecimal(totalPrice / 1000, 2)}
+                <span className="unit">mrd</span>
+              </div>
+              <div className="delta">
+                Spenn: {formatInt(Math.min(...listings.filter(l => l.prisantydning).map(l => l.prisantydning!)))}
+                {" – "}
+                {formatInt(Math.max(...listings.filter(l => l.prisantydning).map(l => l.prisantydning!)))}{" mnok"}
+              </div>
+            </div>
+            <div className="mi-kpi">
+              <div className="label">Snitt-yield</div>
+              <div className="val">
+                {formatDecimal(yieldWeighted, 1).replace(".", ",")}
+                <span className="unit">%</span>
+              </div>
+              <div className="delta">Vektet på areal</div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* FILTER + FEATURED + GRID + ALERT */}
+      <ListingsBrowser
+        featured={featuredCard}
+        items={gridCards}
+        counts={{
+          status: statusCounts,
+          type: typeCounts,
+          by: cityCounts,
+          total: listings.length,
+        }}
+      />
+
+      {/* OFF-MARKET BAND */}
+      <section className="ei-offmarket">
+        <div className="wrap">
+          <div className="head">
+            <div>
+              <div className="pre">Konfidensielle oppdrag</div>
+              <h2>
+                Off-market — <span className="italic">for kvalifiserte kjøpere.</span>
+              </h2>
+            </div>
+            <p>
+              Vi formidler et utvalg av eiendommer som ikke annonseres åpent — av
+              diskresjonshensyn, eller fordi selger ønsker en målrettet prosess.{" "}
+              <Link href="/kontakt">Meld deg på for å få tilgang</Link>, så
+              tar vi en samtale om hva som er aktuelt for deg.
+            </p>
+          </div>
+
+          <div className="ei-offmarket-list">
+            {OFF_MARKET.map((row) => (
+              <Link
+                key={row.ref}
+                className="ei-offmarket-row"
+                href="/kontakt"
+              >
+                <span className="ref">{row.ref}</span>
+                <div>
+                  <div className="title">
+                    {row.titleHead}{" "}
+                    <span className="it">{row.titleTail}</span>
+                  </div>
+                </div>
+                <div>
+                  <div className="cell-l">Type</div>
+                  <div className="cell-v">{row.type}</div>
+                </div>
+                <div className="col-hide">
+                  <div className="cell-l">BTA</div>
+                  <div className="cell-v">
+                    {row.bta}
+                    <span className="unit">m²</span>
+                  </div>
+                </div>
+                <div className="col-hide-m">
+                  <div className="cell-l">Prisant.</div>
+                  <div className="cell-v">
+                    {row.price}
+                    <span className="unit">mnok</span>
+                  </div>
+                </div>
+                <div className="col-hide">
+                  <div className="cell-l">Status</div>
+                  <div className="cell-v">{row.status}</div>
+                </div>
+                <div className="arr">→</div>
+              </Link>
+            ))}
+          </div>
+
+          <div className="ei-offmarket-foot">
+            <span className="nda">
+              Off-market-eiendommer deles kun etter en innledende samtale og
+              signert taushetserklæring.
+            </span>
+            <Link href="/kontakt" className="btn-light">
+              Få tilgang til off-market <span className="arrow">→</span>
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      {/* CTA STRIP */}
+      <section className="cta-strip">
+        <div className="wrap">
+          <span
+            className="eyebrow center no-rule"
+            style={{ marginBottom: 24 }}
+          >
+            For selgere
+          </span>
+          <h2>
+            Vurderer du å selge <br />
+            <span className="italic">din eiendom?</span>
+          </h2>
+          <p>
+            Vi gir deg en uforpliktende verdivurdering, en konkret prosessplan
+            og navn på de mest sannsynlige kjøperne i markedet i dag.
+          </p>
+          <div className="row">
+            <Link href="/kontakt" className="btn btn-dark">
+              Få verdivurdering <span className="arrow">→</span>
+            </Link>
+            <Link href="/tjenester/salg" className="btn btn-outline">
+              Slik jobber vi med salg
+            </Link>
+          </div>
+        </div>
+      </section>
+    </>
+  );
+}

--- a/src/app/siteConfig.ts
+++ b/src/app/siteConfig.ts
@@ -34,6 +34,7 @@ export const siteConfig = {
     blog: "/blog",
     verktoy: "/verktoy",
     naringsmegler: "/naringsmegler",
+    eiendommer: "/eiendommer",
   },
 };
 

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -6,6 +6,7 @@ import {
   allIntegrationsPosts,
   allPersonPosts,
   allLocationPosts,
+  allListingPosts,
 } from "content-collections";
 import { MetadataRoute } from "next";
 import { siteConfig } from "./siteConfig";
@@ -42,6 +43,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     "/integrasjoner",
     "/personer",
     "/naringsmegler",
+    "/eiendommer",
     "/privacy",
     "/terms",
   ].map((route) => ({
@@ -113,6 +115,16 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     priority: 0.85,
   }));
 
+  // Active listing detail pages. `lastModified` prefers `updatedAt` for
+  // listings that have been re-priced or re-statused; falls back to
+  // `publishedAt` for fresh mandates.
+  const listingPages = allListingPosts.map((listing) => ({
+    url: `${baseUrl}/eiendommer/${listing.slug}`,
+    lastModified: new Date(listing.updatedAt ?? listing.publishedAt),
+    changeFrequency: "weekly" as const,
+    priority: 0.9,
+  }));
+
   return [
     ...staticPages,
     ...blogCategories,
@@ -123,5 +135,6 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     ...integrationPages,
     ...personPages,
     ...locationPages,
+    ...listingPages,
   ];
 }

--- a/src/components/eiendommer/ListingsBrowser.tsx
+++ b/src/components/eiendommer/ListingsBrowser.tsx
@@ -145,7 +145,10 @@ export function ListingsBrowser({
     filteredItems.length + (featuredVisible ? 1 : 0);
 
   return (
-    <>
+    // Containing block for the sticky filter. CSS `position: sticky` is
+    // bounded by the nearest scroll ancestor — without this wrapper the bar
+    // floats over the dark off-market band below, occluding its headline.
+    <div className="ei-browser">
       {/* FILTER BAR */}
       <div className="ei-filter" id="filterBar">
         <div className="wrap">
@@ -434,6 +437,6 @@ export function ListingsBrowser({
           </div>
         </div>
       </section>
-    </>
+    </div>
   );
 }

--- a/src/components/eiendommer/ListingsBrowser.tsx
+++ b/src/components/eiendommer/ListingsBrowser.tsx
@@ -1,0 +1,439 @@
+"use client";
+
+import Image from "next/image";
+import Link from "next/link";
+import { useMemo, useState } from "react";
+
+export type ListingCardData = {
+  slug: string;
+  href: string;
+  status: "til-salgs" | "reservert" | "kommer" | "solgt";
+  statusLabel: string;
+  type:
+    | "kontor"
+    | "logistikk"
+    | "handel"
+    | "kombi"
+    | "hotell"
+    | "utvikling"
+    | "industri";
+  typeLabel: string;
+  city:
+    | "bodo"
+    | "tromso"
+    | "harstad"
+    | "alta"
+    | "narvik"
+    | "lofoten"
+    | "mo-i-rana";
+  cityLabel: string;
+  titleHead: string;
+  titleTail: string;
+  address: string;
+  cardEyebrow: string;
+  bta: number;
+  prisantydning?: number;
+  prisantydningEstimat: boolean;
+  yieldNetto?: number;
+  yieldEstimat: boolean;
+  ferdig?: string;
+  coverImage: string;
+  coverImageAlt: string;
+  // Featured-only extras
+  featured: boolean;
+  featuredEyebrow?: string;
+  summary?: string;
+  utleiegrad?: number;
+  megler?: { name: string; role: string; avatar: string };
+  position: number; // 01..09 counter on the featured photo
+};
+
+type Counts = {
+  status: Record<string, number>;
+  type: Record<string, number>;
+  by: Record<string, number>;
+  total: number;
+};
+
+const STATUS_OPTIONS: { value: string; label: string }[] = [
+  { value: "alle", label: "Alle" },
+  { value: "til-salgs", label: "Til salgs" },
+  { value: "reservert", label: "Reservert" },
+  { value: "kommer", label: "Kommer" },
+  { value: "solgt", label: "Solgt" },
+];
+
+const TYPE_OPTIONS: { value: string; label: string }[] = [
+  { value: "alle", label: "Alle" },
+  { value: "kontor", label: "Kontor" },
+  { value: "logistikk", label: "Logistikk" },
+  { value: "handel", label: "Handel" },
+  { value: "kombi", label: "Kombi" },
+];
+
+const CITY_OPTIONS: { value: string; label: string }[] = [
+  { value: "alle", label: "Alle" },
+  { value: "bodo", label: "Bodø" },
+  { value: "tromso", label: "Tromsø" },
+  { value: "harstad", label: "Harstad" },
+  { value: "alta", label: "Alta" },
+  { value: "narvik", label: "Narvik" },
+];
+
+function formatNumber(value: number): string {
+  return new Intl.NumberFormat("nb-NO", { maximumFractionDigits: 1 }).format(
+    value,
+  );
+}
+
+function formatInt(value: number): string {
+  return new Intl.NumberFormat("nb-NO").format(value);
+}
+
+function priceLabel(card: ListingCardData) {
+  if (card.ferdig) {
+    return {
+      label: "Ferdig",
+      value: card.ferdig,
+      unit: "",
+    };
+  }
+  if (card.prisantydning !== undefined) {
+    return {
+      label: "Prisant.",
+      value: `${card.prisantydningEstimat ? "est. " : ""}${formatNumber(card.prisantydning)}`,
+      unit: "mnok",
+    };
+  }
+  return { label: "Prisant.", value: "—", unit: "" };
+}
+
+function yieldLabel(card: ListingCardData) {
+  if (card.yieldNetto === undefined) return { value: "—", unit: "" };
+  return {
+    value: `${card.yieldEstimat ? "est. " : ""}${formatNumber(card.yieldNetto).replace(".", ",")}`,
+    unit: "%",
+  };
+}
+
+export function ListingsBrowser({
+  featured,
+  items,
+  counts,
+}: {
+  featured: ListingCardData | undefined;
+  items: ListingCardData[];
+  counts: Counts;
+}) {
+  const [status, setStatus] = useState("alle");
+  const [type, setType] = useState("alle");
+  const [city, setCity] = useState("alle");
+
+  const matches = (card: ListingCardData) =>
+    (status === "alle" || card.status === status) &&
+    (type === "alle" || card.type === type) &&
+    (city === "alle" || card.city === city);
+
+  const filteredItems = useMemo(
+    () => items.filter(matches),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [items, status, type, city],
+  );
+
+  const featuredVisible = featured ? matches(featured) : false;
+  const visibleCount =
+    filteredItems.length + (featuredVisible ? 1 : 0);
+
+  return (
+    <>
+      {/* FILTER BAR */}
+      <div className="ei-filter" id="filterBar">
+        <div className="wrap">
+          <div
+            className="ei-filter-group"
+            role="radiogroup"
+            aria-label="Status"
+          >
+            <span className="label">Status</span>
+            {STATUS_OPTIONS.map((opt) => {
+              const ct =
+                opt.value === "alle" ? counts.total : counts.status[opt.value];
+              if (opt.value !== "alle" && !ct) return null;
+              return (
+                <button
+                  key={opt.value}
+                  type="button"
+                  className={`ei-chip ${status === opt.value ? "active" : ""}`}
+                  onClick={() => setStatus(opt.value)}
+                  aria-pressed={status === opt.value}
+                >
+                  {opt.label}
+                  {ct ? <span className="ct">{ct}</span> : null}
+                </button>
+              );
+            })}
+          </div>
+
+          <div
+            className="ei-filter-group"
+            role="radiogroup"
+            aria-label="Eiendomstype"
+          >
+            <span className="label">Type</span>
+            {TYPE_OPTIONS.map((opt) => (
+              <button
+                key={opt.value}
+                type="button"
+                className={`ei-chip ${type === opt.value ? "active" : ""}`}
+                onClick={() => setType(opt.value)}
+                aria-pressed={type === opt.value}
+              >
+                {opt.label}
+              </button>
+            ))}
+          </div>
+
+          <div
+            className="ei-filter-group"
+            role="radiogroup"
+            aria-label="Lokasjon"
+          >
+            <span className="label">By</span>
+            {CITY_OPTIONS.map((opt) => (
+              <button
+                key={opt.value}
+                type="button"
+                className={`ei-chip ${city === opt.value ? "active" : ""}`}
+                onClick={() => setCity(opt.value)}
+                aria-pressed={city === opt.value}
+              >
+                {opt.label}
+              </button>
+            ))}
+          </div>
+
+          <div className="ei-filter-result">
+            <strong>{visibleCount}</strong>&nbsp;av {counts.total} eiendommer
+          </div>
+        </div>
+      </div>
+
+      {/* FEATURED */}
+      {featured && featuredVisible && (
+        <section
+          className="section"
+          style={{ paddingTop: 32, paddingBottom: 16 }}
+        >
+          <div className="wrap">
+            <Link href={featured.href} className="ei-featured">
+              <div className="ei-featured-photo">
+                <Image
+                  src={featured.coverImage}
+                  alt={featured.coverImageAlt}
+                  fill
+                  sizes="(max-width: 980px) 100vw, 55vw"
+                  style={{ objectFit: "cover" }}
+                />
+                <div className={`ei-status ${featured.status}`}>
+                  <span className="dot" />
+                  {featured.statusLabel}
+                </div>
+                <div className="ei-counter">
+                  01 / {String(counts.total).padStart(2, "0")}
+                </div>
+              </div>
+              <div className="ei-featured-body">
+                <div>
+                  {featured.featuredEyebrow && (
+                    <span className="pre">{featured.featuredEyebrow}</span>
+                  )}
+                  <h2>
+                    {featured.titleHead}{" "}
+                    <span className="italic">{featured.titleTail}</span>
+                  </h2>
+                  {featured.summary && (
+                    <p className="lede">{featured.summary}</p>
+                  )}
+                </div>
+
+                <div className="ei-featured-stats">
+                  <div>
+                    <div className="l">BTA</div>
+                    <div className="v">
+                      {formatInt(featured.bta)}
+                      <span className="unit">m²</span>
+                    </div>
+                  </div>
+                  <div>
+                    <div className="l">{priceLabel(featured).label}</div>
+                    <div className="v">
+                      {priceLabel(featured).value}
+                      {priceLabel(featured).unit && (
+                        <span className="unit">
+                          {priceLabel(featured).unit}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                  <div>
+                    <div className="l">Yield</div>
+                    <div className="v">
+                      {yieldLabel(featured).value}
+                      {yieldLabel(featured).unit && (
+                        <span className="unit">
+                          {yieldLabel(featured).unit}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                  <div>
+                    <div className="l">Utleiegrad</div>
+                    <div className="v">
+                      {featured.utleiegrad !== undefined
+                        ? `${formatInt(featured.utleiegrad)}`
+                        : "—"}
+                      {featured.utleiegrad !== undefined && (
+                        <span className="unit">%</span>
+                      )}
+                    </div>
+                  </div>
+                </div>
+
+                <div className="ei-featured-cta">
+                  <span className="btn btn-dark">
+                    Se prospekt <span className="arrow">→</span>
+                  </span>
+                  {featured.megler && (
+                    <div className="megler">
+                      <div className="nm">
+                        <span className="n">{featured.megler.name}</span>
+                        <span className="r">{featured.megler.role}</span>
+                      </div>
+                      <Image
+                        src={featured.megler.avatar}
+                        alt={featured.megler.name}
+                        width={40}
+                        height={40}
+                      />
+                    </div>
+                  )}
+                </div>
+              </div>
+            </Link>
+          </div>
+        </section>
+      )}
+
+      {/* GRID */}
+      <section
+        className="section"
+        style={{ paddingTop: 24, paddingBottom: 80 }}
+      >
+        <div className="wrap">
+          <div className="head-compact" style={{ marginBottom: 0 }}>
+            <span className="eyebrow">Aktive oppdrag</span>
+            <div>
+              <h2>
+                Alle eiendommer{" "}
+                <span className="italic">vi har til salgs.</span>
+              </h2>
+              <p>
+                Klikk på et oppdrag for prospekt, plantegninger, leieoversikt og
+                DD-pakke. Reserverte og solgte oppdrag vises for referanse.
+              </p>
+            </div>
+          </div>
+
+          <div className="ei-grid" id="eiGrid">
+            {filteredItems.map((card) => {
+              const price = priceLabel(card);
+              const yld = yieldLabel(card);
+              return (
+                <Link
+                  key={card.slug}
+                  href={card.href}
+                  className={`ei-card ${card.status === "solgt" ? "is-solgt" : ""}`}
+                >
+                  <div className="ei-card-photo">
+                    <Image
+                      src={card.coverImage}
+                      alt={card.coverImageAlt}
+                      fill
+                      sizes="(max-width: 680px) 100vw, (max-width: 980px) 50vw, 33vw"
+                      style={{ objectFit: "cover" }}
+                    />
+                    <div className={`ei-status ${card.status}`}>
+                      <span className="dot" />
+                      {card.statusLabel}
+                    </div>
+                  </div>
+                  <div className="top">
+                    <span>{card.cardEyebrow}</span>
+                    <span>{card.cityLabel}</span>
+                  </div>
+                  <div>
+                    <h3>
+                      {card.titleHead}{" "}
+                      <span className="italic">{card.titleTail}</span>
+                    </h3>
+                    <p className="addr">{card.address}</p>
+                  </div>
+                  <div className="stat-row">
+                    <div>
+                      <div className="l">BTA</div>
+                      <div className="v">
+                        {formatInt(card.bta)}
+                        <span className="unit">m²</span>
+                      </div>
+                    </div>
+                    <div>
+                      <div className="l">{price.label}</div>
+                      <div className="v">
+                        {price.value}
+                        {price.unit && <span className="unit">{price.unit}</span>}
+                      </div>
+                    </div>
+                    <div>
+                      <div className="l">Yield</div>
+                      <div className="v">
+                        {yld.value}
+                        {yld.unit && <span className="unit">{yld.unit}</span>}
+                      </div>
+                    </div>
+                  </div>
+                </Link>
+              );
+            })}
+          </div>
+
+          {/* SAVED-SEARCH ALERT */}
+          <div className="ei-alert">
+            <div>
+              <div className="pre">Få oppdrag direkte i innboksen</div>
+              <h4>
+                Bli varslet når vi får inn{" "}
+                <span className="italic">eiendommer som passer deg.</span>
+              </h4>
+            </div>
+            <form
+              onSubmit={(event) => {
+                event.preventDefault();
+                const button =
+                  event.currentTarget.querySelector("button[type='submit']");
+                if (button) button.textContent = "Registrert ✓";
+              }}
+            >
+              <input
+                type="email"
+                placeholder="ola.nordmann@firma.no"
+                aria-label="E-post"
+                required
+              />
+              <button type="submit">Få varsel</button>
+            </form>
+          </div>
+        </div>
+      </section>
+    </>
+  );
+}

--- a/src/components/eiendommer/PropertyMap.tsx
+++ b/src/components/eiendommer/PropertyMap.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+// Server-Component-safe wrapper. Next 16 disallows ssr:false in Server
+// Components, and Leaflet needs `window`, so the dynamic import lives here.
+
+import dynamic from "next/dynamic";
+
+const PropertyMapLeaflet = dynamic(
+  () => import("./PropertyMapLeaflet").then((m) => m.PropertyMapLeaflet),
+  {
+    ssr: false,
+    loading: () => <div className="ed-map ed-map-loading" aria-hidden="true" />,
+  },
+);
+
+export function PropertyMap({
+  lat,
+  lng,
+  label,
+}: {
+  lat: number;
+  lng: number;
+  label: string;
+}) {
+  return (
+    <div className="ed-map ed-map-real" aria-label={`Kart over ${label}`}>
+      <PropertyMapLeaflet lat={lat} lng={lng} label={label} />
+    </div>
+  );
+}

--- a/src/components/eiendommer/PropertyMapLeaflet.tsx
+++ b/src/components/eiendommer/PropertyMapLeaflet.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import "leaflet/dist/leaflet.css";
+
+import { CircleMarker, MapContainer, TileLayer, Tooltip } from "react-leaflet";
+
+import {
+  MARKER,
+  TILE_ATTRIBUTION,
+  TILE_MAX_ZOOM,
+  TILE_URL,
+} from "@/components/markedsinnsikt/maps/mapTheme";
+
+interface PropertyMapLeafletProps {
+  lat: number;
+  lng: number;
+  label: string;
+  /** Override the default street-level zoom (15) when needed. */
+  zoom?: number;
+}
+
+/**
+ * Single-property Leaflet map. Mirrors the editorial CartoDB-tile palette used
+ * by the markedsinnsikt overview map, but framed tight enough to read the
+ * street grid. Drag/wheel-zoom are kept off so a one-finger touch-drag scrolls
+ * the page instead of being trapped by the map; the +/- control stays for
+ * intentional zoom.
+ */
+export function PropertyMapLeaflet({
+  lat,
+  lng,
+  label,
+  zoom = 15,
+}: PropertyMapLeafletProps) {
+  return (
+    <MapContainer
+      center={[lat, lng]}
+      zoom={zoom}
+      minZoom={5}
+      maxZoom={TILE_MAX_ZOOM}
+      scrollWheelZoom={false}
+      style={{ height: "100%", width: "100%" }}
+    >
+      <TileLayer
+        url={TILE_URL}
+        attribution={TILE_ATTRIBUTION}
+        maxZoom={TILE_MAX_ZOOM}
+      />
+      <CircleMarker
+        center={[lat, lng]}
+        radius={MARKER.activeRadius}
+        pathOptions={{
+          color: MARKER.activeHalo,
+          weight: 3,
+          fillColor: MARKER.fill,
+          fillOpacity: 1,
+        }}
+      >
+        <Tooltip
+          permanent
+          direction="top"
+          offset={[0, -8]}
+          className="mi-map-label"
+        >
+          {label}
+        </Tooltip>
+      </CircleMarker>
+    </MapContainer>
+  );
+}

--- a/src/components/site/Nav.tsx
+++ b/src/components/site/Nav.tsx
@@ -6,6 +6,7 @@ import { useEffect, useState } from "react";
 
 const LINKS = [
   { href: "/tjenester", label: "Tjenester" },
+  { href: "/eiendommer", label: "Eiendommer" },
   { href: "/markedsinnsikt", label: "Markedsinnsikt" },
   { href: "/blog", label: "Artikler" },
   { href: "/help", label: "Kunnskapssenter" },

--- a/src/content/listings/bossekopveien-12-alta.mdx
+++ b/src/content/listings/bossekopveien-12-alta.mdx
@@ -1,0 +1,34 @@
+---
+slug: "bossekopveien-12-alta"
+title: "Bossekopveien 12, Alta — industri og kontor"
+titleHead: "Bossekopveien 12 —"
+titleTail: "industri og kontor."
+status: kommer
+statusLabel: "Kommer i juni"
+type: kombi
+typeLabel: "Kombi · Verksted + kontor"
+city: alta
+address: "Bossekopveien 12 · 9509 Alta"
+reference: "AE-2026-009"
+cardEyebrow: "09 · Kombi · Verksted + kontor"
+featured: false
+order: 9
+publishedAt: "2026-05-15"
+bta: 3450
+prisantydning: 38
+prisantydningEstimat: true
+yieldNetto: 7.6
+yieldEstimat: true
+coverImage: "/building/pexels-pixabay-248877.jpg"
+coverImageAlt: "Bossekop, Alta"
+summary: "Kombinasjonsbygg i Bossekop med verkstedhall og kontor. Kommer for salg i juni — registrer interesse for prospekt før annonsering."
+megler:
+  name: "Christer Hagen"
+  role: "Partner · Megler"
+  avatar: "/team/mathias-nilssen.jpg"
+  email: "christer@advanti.no"
+  phone: "+47 984 53 571"
+---
+
+Kombinasjonsbygg i Bossekop, Alta med 3 450 m² fordelt på verkstedhall og
+tilliggende kontorer. Kommer ut for åpen salgsprosess i juni 2026.

--- a/src/content/listings/dronningens-gate-24-bodo.mdx
+++ b/src/content/listings/dronningens-gate-24-bodo.mdx
@@ -1,0 +1,34 @@
+---
+slug: "dronningens-gate-24-bodo"
+title: "Dronningens gate 24, Bodø — nybygg under prosjektering"
+titleHead: "Dronningens gate 24 —"
+titleTail: "nybygg under prosjektering."
+status: kommer
+statusLabel: "Kommer Q3 2026"
+type: kontor
+typeLabel: "Kontor · Nybygg"
+city: bodo
+address: "Dronningens gate 24 · 8006 Bodø"
+reference: "AE-2026-007"
+cardEyebrow: "07 · Kontor · Nybygg"
+featured: false
+order: 7
+publishedAt: "2026-05-02"
+bta: 8200
+yieldNetto: 5.8
+yieldEstimat: true
+ferdig: "Q3 2027"
+coverImage: "/building/pexels-abshky-18566965.jpg"
+coverImageAlt: "Dronningens gate 24, Bodø"
+summary: "Nytt kontorbygg på 8 200 m² i Bodø sentrum, ferdigstilles Q3 2027. Forhåndsutleie pågår — Advanti har eksklusivt salgsoppdrag."
+megler:
+  name: "Christer Hagen"
+  role: "Partner · Megler"
+  avatar: "/team/mathias-nilssen.jpg"
+  email: "christer@advanti.no"
+  phone: "+47 984 53 571"
+---
+
+Nybygg på 8 200 m² i Dronningens gate 24, Bodø, med planlagt ferdigstillelse
+Q3 2027. BREEAM-Very-Good målsetning, fleksible etasjeplaner og parkering i
+kjeller. Forhåndsutleie pågår parallelt med salgsprosessen.

--- a/src/content/listings/havnegata-12-narvik.mdx
+++ b/src/content/listings/havnegata-12-narvik.mdx
@@ -1,0 +1,32 @@
+---
+slug: "havnegata-12-narvik"
+title: "Narvik havn — terminalbygg og tomt til salgs"
+titleHead: "Narvik havn —"
+titleTail: "terminalbygg + tomt."
+status: til-salgs
+type: logistikk
+typeLabel: "Logistikk · Havn"
+city: narvik
+address: "Havnegata 12 · 8514 Narvik"
+reference: "AE-2026-006"
+cardEyebrow: "06 · Logistikk · Havn"
+featured: false
+order: 6
+publishedAt: "2026-04-18"
+bta: 9600
+prisantydning: 86
+yieldNetto: 7.4
+coverImage: "/building/pexels-expect-best-79873-351262.jpg"
+coverImageAlt: "Narvik Havn — terminalbygg"
+summary: "Terminalbygg og tilhørende tomt med kaitilgang i Narvik. ARE-tilkobling og direkte tilkomst til Ofotbanen via terminalen."
+megler:
+  name: "Christer Hagen"
+  role: "Partner · Megler"
+  avatar: "/team/mathias-nilssen.jpg"
+  email: "christer@advanti.no"
+  phone: "+47 984 53 571"
+---
+
+Sjeldent tilgjengelig terminaleiendom ved Narvik havn med direkte koblinger
+mot Ofotbanen og fri seilingsled. Egnet for tungtransport, fiskeri eller
+energilogistikk.

--- a/src/content/listings/markedsgata-24-alta.mdx
+++ b/src/content/listings/markedsgata-24-alta.mdx
@@ -1,0 +1,31 @@
+---
+slug: "markedsgata-24-alta"
+title: "Markedsgata 24, Alta — handelsbygg i gågate"
+titleHead: "Markedsgata 24 —"
+titleTail: "handelsbygg, gågate."
+status: til-salgs
+type: handel
+typeLabel: "Handel"
+city: alta
+address: "Markedsgata 24 · 9510 Alta"
+reference: "AE-2026-005"
+cardEyebrow: "05 · Handel"
+featured: false
+order: 5
+publishedAt: "2026-04-30"
+bta: 3100
+prisantydning: 48
+yieldNetto: 6.9
+coverImage: "/building/pexels-pixabay-248877.jpg"
+coverImageAlt: "Markedsgata 24, Alta"
+summary: "Handelsbygg sentralt i Alta gågate. Stabil leietakermiks med dagligvare og kjedebutikker, oppgraderbar fasade."
+megler:
+  name: "Christer Hagen"
+  role: "Partner · Megler"
+  avatar: "/team/mathias-nilssen.jpg"
+  email: "christer@advanti.no"
+  phone: "+47 984 53 571"
+---
+
+Handelsbygg på 3 100 m² i Altas mest tråkkede gågate. Bygget har gjennomført
+takomlegging i 2022 og er klart for kosmetisk fasadeoppgradering.

--- a/src/content/listings/olav-v-gate-102-bodo.mdx
+++ b/src/content/listings/olav-v-gate-102-bodo.mdx
@@ -1,0 +1,32 @@
+---
+slug: "olav-v-gate-102-bodo"
+title: "Logistikkanlegg ved Bodø lufthavn"
+titleHead: "Logistikkanlegg ved"
+titleTail: "Bodø lufthavn."
+status: til-salgs
+type: logistikk
+typeLabel: "Logistikk"
+city: bodo
+address: "Olav V gate 102 · 8004 Bodø"
+reference: "AE-2026-002"
+cardEyebrow: "02 · Logistikk"
+featured: false
+order: 2
+publishedAt: "2026-04-12"
+bta: 14200
+prisantydning: 198
+yieldNetto: 7.1
+coverImage: "/building/pexels-expect-best-79873-351262.jpg"
+coverImageAlt: "Logistikkanlegg Bodø Lufthavn"
+summary: "Moderne logistikkanlegg i umiddelbar nærhet til Bodø lufthavn — kort kjørevei til havn, kombiterminal og E6."
+megler:
+  name: "Christer Hagen"
+  role: "Partner · Megler"
+  avatar: "/team/mathias-nilssen.jpg"
+  email: "christer@advanti.no"
+  phone: "+47 984 53 571"
+---
+
+Logistikkanlegg på 14 200 m² rett ved Bodø lufthavn med direkte tilgang til
+E6, havn og kombiterminal. Velegnet for tredjepartslogistikk, e-handel eller
+regionalt distribusjonssenter.

--- a/src/content/listings/rikard-kaarbos-plass-4-harstad.mdx
+++ b/src/content/listings/rikard-kaarbos-plass-4-harstad.mdx
@@ -1,0 +1,31 @@
+---
+slug: "rikard-kaarbos-plass-4-harstad"
+title: "Rikard Kaarbøs plass 4, Harstad — moderne kontorbygg"
+titleHead: "Rikard Kaarbøs plass 4 —"
+titleTail: "moderne kontorbygg."
+status: reservert
+type: kontor
+typeLabel: "Kontor"
+city: harstad
+address: "Rikard Kaarbøs plass 4 · 9405 Harstad"
+reference: "AE-2026-004"
+cardEyebrow: "04 · Kontor"
+featured: false
+order: 4
+publishedAt: "2026-03-22"
+bta: 6800
+prisantydning: 142
+yieldNetto: 6.3
+coverImage: "/building/pexels-abshky-18567185.jpg"
+coverImageAlt: "Rikard Kaarbøs plass 4, Harstad"
+summary: "Reservert. Moderne kontorbygg sentralt i Harstad, langsiktige offentlige leietakere på majoriteten av arealet."
+megler:
+  name: "Christer Hagen"
+  role: "Partner · Megler"
+  avatar: "/team/mathias-nilssen.jpg"
+  email: "christer@advanti.no"
+  phone: "+47 984 53 571"
+---
+
+Sentralt plassert kontorbygg i Harstad med stabil leietakermiks dominert av
+offentlig sektor. Reservert under pågående budgivning.

--- a/src/content/listings/sjogata-7-tromso.mdx
+++ b/src/content/listings/sjogata-7-tromso.mdx
@@ -11,7 +11,7 @@ address: "Sjøgata 7 · 9008 Tromsø"
 reference: "AE-2026-014"
 cardEyebrow: "01 · Kontor"
 featured: true
-featuredEyebrow: "Featured · Kontor · Tromsø sentrum"
+featuredEyebrow: "Utvalgt · Kontor · Tromsø sentrum"
 order: 1
 publishedAt: "2026-05-01"
 updatedAt: "2026-05-22"

--- a/src/content/listings/sjogata-7-tromso.mdx
+++ b/src/content/listings/sjogata-7-tromso.mdx
@@ -1,0 +1,157 @@
+---
+slug: "sjogata-7-tromso"
+title: "Sjøgata 7, Tromsø — 11 400 m² kontortårn til salgs"
+titleHead: "Sjøgata 7 —"
+titleTail: "kontortårn ved havna."
+status: til-salgs
+type: kontor
+typeLabel: "Kontor"
+city: tromso
+address: "Sjøgata 7 · 9008 Tromsø"
+reference: "AE-2026-014"
+cardEyebrow: "01 · Kontor"
+featured: true
+featuredEyebrow: "Featured · Kontor · Tromsø sentrum"
+order: 1
+publishedAt: "2026-05-01"
+updatedAt: "2026-05-22"
+bta: 11400
+prisantydning: 425
+yieldNetto: 5.9
+utleiegrad: 94
+wault: 6.2
+coverImage: "/building/pexels-pixabay-248877.jpg"
+coverImageAlt: "Sjøgata 7 — fasade mot havna"
+gallery:
+  - src: "/building/pexels-pixabay-248877.jpg"
+    alt: "Sjøgata 7 — fasade mot havna"
+  - src: "/building/pexels-abshky-18566965.jpg"
+    alt: "Interiør resepsjon"
+  - src: "/building/pexels-abshky-18567185.jpg"
+    alt: "Kontorlandskap, 4. etasje"
+photoCount: 18
+summary: "Et av Tromsøs mest sentralt beliggende kontorbygg, ferdigstilt 2017. 94 % utleid på lange leiekontrakter til offentlig og privat sektor. Vektet gjenværende leieperiode 6,2 år."
+lede: "Et av Tromsøs mest sentralt beliggende kontorbygg — direkte på havna, fem minutters gange fra Storgata og Tromsø domkirke."
+megler:
+  name: "Håvard Antonsen"
+  role: "Partner · Megler"
+  avatar: "/havard.jpg"
+  email: "havard@advanti.no"
+  phone: "+47 900 00 000"
+facts:
+  - { label: "Eiendomstype", value: "Kontor" }
+  - { label: "BTA", value: "11 400 m²" }
+  - { label: "BRA", value: "10 240 m²" }
+  - { label: "Tomteareal", value: "2 850 m²" }
+  - { label: "Tomt", value: "Selveiet" }
+  - { label: "Antall etasjer", value: "8 + parkering" }
+  - { label: "Byggeår", value: "1962 · rehab. 2017" }
+  - { label: "Parkering", value: "62 plasser i kjeller" }
+  - { label: "Heiser", value: "3 · varekantal 1" }
+  - { label: "Energimerke", value: "B (grønn)" }
+  - { label: "BREEAM-sertifisering", value: "Very Good (2018)" }
+  - { label: "Oppvarming", value: "Fjernvarme + varmepumpe" }
+  - { label: "Ventilasjon", value: "Balansert m/varmegjenvinning" }
+  - { label: "Brannklasse", value: "Klasse 2" }
+  - { label: "Felleskostnader", value: "590 kr/m²/år" }
+  - { label: "Eiendomsskatt", value: "4,1 promille" }
+  - { label: "Reguleringsplan", value: "Sentrumsformål S1" }
+  - { label: "Gnr/Bnr", value: "200 / 1462" }
+tenants:
+  - name: "Statsforvalteren Troms og Finnmark"
+    sector: "Offentlig sektor · BBB+"
+    etasjer: "3. – 5."
+    areal: 3920
+    leieKrM2: 2950
+    leieArlig: 11.56
+    kontraktTil: "2032"
+    andel: 38
+  - name: "Lund & Pedersen Advokatfirma"
+    sector: "Juridiske tjenester"
+    etasjer: "6."
+    areal: 1480
+    leieKrM2: 3250
+    leieArlig: 4.81
+    kontraktTil: "2029"
+    andel: 14
+  - name: "Polaris Data AS"
+    sector: "Teknologi · SaaS"
+    etasjer: "2."
+    areal: 1360
+    leieKrM2: 3100
+    leieArlig: 4.22
+    kontraktTil: "2030"
+    andel: 13
+  - name: "Nordskog Konsulent"
+    sector: "Rådgivning"
+    etasjer: "1."
+    areal: 1240
+    leieKrM2: 2800
+    leieArlig: 3.47
+    kontraktTil: "2028"
+    andel: 12
+  - name: "Boreal Maritim"
+    sector: "Sjømat · hovedkontor"
+    etasjer: "7. (1/2)"
+    areal: 840
+    leieKrM2: 3100
+    leieArlig: 2.60
+    kontraktTil: "2031"
+    andel: 9
+  - name: "Café Sjøsiden"
+    sector: "Servering · publikum"
+    etasjer: "Gateplan"
+    areal: 280
+    leieKrM2: 6200
+    leieArlig: 1.74
+    kontraktTil: "2027"
+    andel: 6
+  - name: "Ledig"
+    sector: "Topp-etasje + 1/2 av 7."
+    etasjer: "7. (1/2), 8."
+    areal: 2280
+    leieKrM2: 3400
+    leieArlig: 7.75
+    leieArligEstimat: true
+    andel: 6
+    ledig: true
+tenantsNote: "94 % utleid på vektet 6,2 år. Samlet årlig leieinntekt 28,4 mnok eks. felleskostnader. Alle kontrakter har årlig KPI-justering."
+financials:
+  bruttoLeie: 36.2
+  eierkostnader: -7.1
+  noi: 29.1
+  yieldNetto: 5.9
+  intro: "Normalisert år 1, basert på dagens leiekontrakter og forutsatt full utleie av ledig topp-etasje innen 12 måneder."
+location:
+  title: "Det mest sentrale"
+  titleTail: "kontorbygget i Tromsø."
+  body: "Bygget ligger på sørsiden av Storgata med direkte fasade mot havna. Tromsø lufthavn nås på 12 minutter med bil. Cruisekai og hurtigruterute starter 200 meter unna."
+  geo:
+    lat: 69.6492
+    lng: 18.9553
+  pois:
+    - { name: "Storgata (gågate)", distance: "120 m" }
+    - { name: "Tromsø domkirke", distance: "300 m" }
+    - { name: "Hurtigrutekai", distance: "200 m" }
+    - { name: "Tromsø lufthavn", distance: "5,4 km" }
+    - { name: "UiT — Norges arktiske universitet", distance: "3,1 km" }
+downloads:
+  - { label: "Salgsprospekt — Sjøgata 7", sub: "3,8 MB · 32 sider · åpen", kind: "pdf", href: "#" }
+  - { label: "Plantegninger, alle etasjer", sub: "8,2 MB · 16 sider · åpen", kind: "pdf", href: "#" }
+  - { label: "Datarom — DD-pakke", sub: "Krever signert NDA · ~120 dok.", kind: "nda", href: "/kontakt" }
+  - { label: "Verdivurdering (uavhengig)", sub: "Krever signert NDA · 18 sider", kind: "nda", href: "/kontakt" }
+---
+
+Sjøgata 7 er et moderne kontortårn over 8 etasjer, ferdigstilt i 2017 etter en
+totalrenovering av et tidligere maritimt forretningsbygg fra 1962. Bygget er
+**BREEAM Very Good-sertifisert** og leverer på de strengeste tekniske kravene
+en moderne leietaker forventer i 2026.
+
+Bygget er **94 % utleid på lange kontrakter** til en balansert miks av offentlig
+og privat sektor — inkludert Statsforvalteren, et nordnorsk advokatfirma og to
+teknologi­selskaper. Vektet gjenværende leieperiode er 6,2 år, og de to største
+leietakerne har KPI-justerte kontrakter med opsjoner som strekker seg til 2034.
+
+Topp-etasjen og halvparten av 7. etasje er ledig og leveres innflyttingsklart —
+etter kjøpers ønske. Selger har gjennomført full teknisk DD og en uavhengig
+verdivurdering legges ved datarommet etter signert NDA.

--- a/src/content/listings/stakkevollvegen-33-tromso.mdx
+++ b/src/content/listings/stakkevollvegen-33-tromso.mdx
@@ -1,0 +1,32 @@
+---
+slug: "stakkevollvegen-33-tromso"
+title: "Tromsdalen handelspark — tre big-box-leietakere"
+titleHead: "Tromsdalen handelspark —"
+titleTail: "tre big-box-leietakere."
+status: til-salgs
+type: handel
+typeLabel: "Handel · Big-box"
+city: tromso
+address: "Stakkevollvegen 33 · 9010 Tromsø"
+reference: "AE-2026-008"
+cardEyebrow: "08 · Handel · Big-box"
+featured: false
+order: 8
+publishedAt: "2026-05-08"
+bta: 7400
+prisantydning: 158
+yieldNetto: 6.8
+coverImage: "/building/pexels-abshky-18567185.jpg"
+coverImageAlt: "Tromsdalen handelsbygg"
+summary: "Handelspark på Tromsdalen med tre etablerte big-box-leietakere. God parkering, høy trafikk, eksponert mot innfartsvei."
+megler:
+  name: "Håvard Antonsen"
+  role: "Partner · Megler"
+  avatar: "/havard.jpg"
+  email: "havard@advanti.no"
+  phone: "+47 900 00 000"
+---
+
+Tre big-box-leietakere på lange kontrakter, samlet 7 400 m² i Tromsdalen.
+Parkering for over 200 biler og direkte eksponering mot innfartsåren til
+Tromsø sentrum.

--- a/src/content/listings/storgata-84-tromso.mdx
+++ b/src/content/listings/storgata-84-tromso.mdx
@@ -1,0 +1,31 @@
+---
+slug: "storgata-84-tromso"
+title: "Storgata 84, Tromsø — gågate-eiendom fra 1894"
+titleHead: "Storgata 84 —"
+titleTail: "gågate-eiendom, 1894."
+status: til-salgs
+type: kombi
+typeLabel: "Kombi · Handel + kontor"
+city: tromso
+address: "Storgata 84 · 9008 Tromsø"
+reference: "AE-2026-003"
+cardEyebrow: "03 · Kombi · Handel + kontor"
+featured: false
+order: 3
+publishedAt: "2026-04-20"
+bta: 4250
+prisantydning: 112
+yieldNetto: 5.4
+coverImage: "/building/pexels-abshky-18566965.jpg"
+coverImageAlt: "Storgata 84, Tromsø"
+summary: "Karakterfull gågate-eiendom fra 1894, gjennomgående rehabilitert. Kombinasjon av handel på gateplan og kontor i etasjene over."
+megler:
+  name: "Håvard Antonsen"
+  role: "Partner · Megler"
+  avatar: "/havard.jpg"
+  email: "havard@advanti.no"
+  phone: "+47 900 00 000"
+---
+
+Sentral handelseiendom på Storgata med gateplanforretninger og kontor i 2.–4.
+etasje. Bygget er vernet eksteriørt men har moderne tekniske anlegg.

--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -9,6 +9,7 @@ import {
   allCustomersPosts,
   allHelpPosts,
   allIntegrationsPosts,
+  allListingPosts,
 } from "content-collections"
 
 // Legacy / URL-encoded slug aliases → canonical content slugs.
@@ -42,4 +43,12 @@ export const getCustomerPost = cache((slug: string) =>
 
 export const getIntegrationPost = cache((slug: string) =>
   allIntegrationsPosts.find((post) => post.slug === slug),
+)
+
+export const getListingPost = cache((slug: string) =>
+  allListingPosts.find((post) => post.slug === slug),
+)
+
+export const getActiveListings = cache(() =>
+  [...allListingPosts].sort((a, b) => a.order - b.order),
 )

--- a/src/styles/advanti-design.css
+++ b/src/styles/advanti-design.css
@@ -4271,11 +4271,16 @@ h1, h2, h3 {
   font-weight: 500;
   letter-spacing: -0.005em;
   color: var(--warm-grey-85);
-  padding: 7px 14px;
+  /* min-height hits the 44px WCAG touch target without inflating
+     the visible pill; padding keeps the same horizontal rhythm. */
+  min-height: 44px;
+  padding: 0 14px;
+  display: inline-flex;
+  align-items: center;
   border: 1px solid transparent;
   border-radius: 999px;
   cursor: pointer;
-  transition: all 0.18s ease;
+  transition: background-color 0.18s ease, color 0.18s ease, border-color 0.18s ease;
   background: transparent;
   white-space: nowrap;
   font-variant-numeric: tabular-nums;

--- a/src/styles/advanti-design.css
+++ b/src/styles/advanti-design.css
@@ -5459,7 +5459,10 @@ h1, h2, h3 {
 .ed-dl:hover .arr { color: var(--warm-grey); }
 .ed-dl.locked { background: transparent; }
 .ed-dl.locked .ico { background: var(--warm-grey); color: var(--warm-white); border-color: var(--warm-grey); }
-.ed-dl.locked .nm .sub { color: var(--accent); }
+/* Subtext stays warm-grey-85 (same as open cards) — the dark NDA icon block
+   already signals the gating, so the accent colour on light bg only hurt
+   readability (#cbeef2 on #f3f1ef ≈ 1.07:1, fails WCAG AA). */
+.ed-dl.locked .nm .sub { color: var(--warm-grey-85); }
 @media (max-width: 720px) {
   .ed-downloads { grid-template-columns: 1fr; }
 }

--- a/src/styles/advanti-design.css
+++ b/src/styles/advanti-design.css
@@ -4228,3 +4228,1274 @@ h1, h2, h3 {
 }
 .ks-prose table tbody tr:hover td { background: var(--accent-faint); }
 .ks-prose table tbody td:first-child { color: var(--warm-grey); font-weight: 500; }
+
+/* ============================================================
+   EIENDOMMER — listings index page (/eiendommer)
+   Ported from design handoff "Advanti Estate CRM" 2026-05-25.
+   ============================================================ */
+
+/* Filter bar — sticky under the fixed nav */
+.ei-filter {
+  position: sticky;
+  top: 80px;
+  z-index: 20;
+  background: rgba(243, 241, 239, 0.92);
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
+  border-top: var(--hairline);
+  border-bottom: var(--hairline);
+  padding: 18px 0;
+}
+.ei-filter .wrap {
+  display: flex;
+  align-items: center;
+  gap: 32px;
+  flex-wrap: wrap;
+}
+.ei-filter-group {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.ei-filter-group .label {
+  font-size: 11px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--warm-grey-85);
+  margin-right: 8px;
+  font-weight: 500;
+}
+.ei-chip {
+  font-family: var(--font-body);
+  font-size: 13px;
+  font-weight: 500;
+  letter-spacing: -0.005em;
+  color: var(--warm-grey-85);
+  padding: 7px 14px;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: all 0.18s ease;
+  background: transparent;
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}
+.ei-chip:hover { color: var(--warm-grey); }
+.ei-chip.active {
+  background: var(--warm-grey);
+  color: var(--warm-white);
+  border-color: var(--warm-grey);
+}
+.ei-chip .ct {
+  font-size: 11px;
+  margin-left: 6px;
+  opacity: 0.6;
+  font-variant-numeric: tabular-nums;
+}
+.ei-filter-result {
+  margin-left: auto;
+  font-size: 12px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--warm-grey-85);
+  font-variant-numeric: tabular-nums;
+}
+.ei-filter-result strong { color: var(--warm-grey); font-weight: 500; }
+@media (max-width: 880px) {
+  .ei-filter { position: relative; top: 0; }
+  .ei-filter-result { margin-left: 0; width: 100%; }
+}
+
+/* Featured (large editorial) listing */
+.ei-featured {
+  margin-top: 56px;
+  display: grid;
+  grid-template-columns: 1.15fr 1fr;
+  gap: 56px;
+  align-items: stretch;
+  border-top: var(--hairline);
+  border-bottom: var(--hairline);
+  padding: 56px 0;
+}
+.ei-featured-photo {
+  position: relative;
+  aspect-ratio: 4 / 3;
+  overflow: hidden;
+  background: var(--warm-grey-75);
+}
+.ei-featured-photo img {
+  width: 100%; height: 100%; object-fit: cover;
+  transition: transform 0.8s cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+.ei-featured:hover .ei-featured-photo img { transform: scale(1.03); }
+.ei-featured-photo .ei-status { position: absolute; top: 18px; left: 18px; }
+.ei-featured-photo .ei-counter {
+  position: absolute;
+  bottom: 18px; right: 18px;
+  background: rgba(243, 241, 239, 0.92);
+  backdrop-filter: blur(8px);
+  color: var(--warm-grey);
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  padding: 7px 12px;
+  font-weight: 500;
+  font-variant-numeric: tabular-nums;
+}
+.ei-featured-body {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 32px;
+  padding: 8px 0;
+}
+.ei-featured-body .pre {
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--warm-grey-85);
+  font-weight: 500;
+  display: inline-flex;
+  align-items: center;
+  gap: 14px;
+}
+.ei-featured-body .pre::before {
+  content: "";
+  width: 28px;
+  height: 1px;
+  background: var(--accent);
+}
+.ei-featured-body h2 {
+  font-family: var(--font-display);
+  font-size: clamp(36px, 3.8vw, 56px);
+  font-weight: 400;
+  line-height: 1.02;
+  letter-spacing: -0.022em;
+  margin-top: 18px;
+}
+.ei-featured-body h2 .italic { font-style: italic; font-weight: 300; color: var(--warm-grey-85); }
+.ei-featured-body .lede {
+  font-size: 17px;
+  color: var(--warm-grey-85);
+  line-height: 1.55;
+  margin-top: 22px;
+  max-width: 48ch;
+}
+.ei-featured-stats {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 0;
+  border-top: var(--hairline);
+  border-bottom: var(--hairline);
+  padding: 22px 0;
+}
+.ei-featured-stats > div { padding-right: 18px; border-right: var(--hairline); }
+.ei-featured-stats > div:last-child { border-right: 0; padding-right: 0; }
+.ei-featured-stats .l {
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--warm-grey-85);
+  margin-bottom: 8px;
+  font-weight: 500;
+}
+.ei-featured-stats .v {
+  font-family: var(--font-display);
+  font-size: 26px;
+  font-weight: 400;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.01em;
+}
+.ei-featured-stats .v .unit { font-size: 0.5em; color: var(--warm-grey-85); font-style: italic; margin-left: 2px; }
+.ei-featured-cta { display: flex; gap: 12px; align-items: center; }
+.ei-featured-cta .megler {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+}
+.ei-featured-cta .megler img {
+  width: 40px; height: 40px;
+  border-radius: 50%;
+  object-fit: cover;
+  background: var(--warm-grey-75);
+}
+.ei-featured-cta .megler .nm { display: flex; flex-direction: column; }
+.ei-featured-cta .megler .nm .n {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--warm-grey);
+}
+.ei-featured-cta .megler .nm .r {
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--warm-grey-85);
+}
+@media (max-width: 980px) {
+  .ei-featured { grid-template-columns: 1fr; gap: 32px; }
+}
+
+/* Status badges (shared between index + detail) */
+.ei-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  background: var(--warm-white);
+  color: var(--warm-grey);
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  padding: 8px 13px;
+  font-weight: 500;
+  border: 1px solid transparent;
+}
+.ei-status .dot {
+  width: 7px; height: 7px;
+  border-radius: 50%;
+  background: var(--accent);
+}
+.ei-status.til-salgs { background: var(--warm-white); }
+.ei-status.til-salgs .dot { background: var(--accent); }
+.ei-status.reservert { background: #f4ecdc; color: #6e5418; }
+.ei-status.reservert .dot { background: #c89327; }
+.ei-status.solgt { background: var(--warm-grey); color: var(--warm-white); }
+.ei-status.solgt .dot { background: var(--warm-grey-75); }
+.ei-status.kommer { background: transparent; color: var(--warm-grey); border-color: var(--warm-grey-75); }
+.ei-status.kommer .dot { background: var(--warm-grey-85); }
+.ei-status.off-market { background: var(--warm-grey); color: var(--warm-white); border-color: var(--warm-grey); }
+.ei-status.off-market .dot { background: var(--accent); }
+
+/* Property grid */
+.ei-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 56px 40px;
+  margin-top: 56px;
+}
+@media (max-width: 980px) { .ei-grid { grid-template-columns: 1fr 1fr; } }
+@media (max-width: 680px) { .ei-grid { grid-template-columns: 1fr; } }
+
+.ei-card {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  cursor: pointer;
+  position: relative;
+  color: inherit;
+  text-decoration: none;
+}
+.ei-card-photo {
+  position: relative;
+  aspect-ratio: 4 / 3;
+  overflow: hidden;
+  background: var(--warm-grey-75);
+}
+.ei-card-photo img {
+  width: 100%; height: 100%; object-fit: cover;
+  transition: transform 0.7s cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+.ei-card:hover .ei-card-photo img { transform: scale(1.045); }
+.ei-card-photo .ei-status { position: absolute; top: 14px; left: 14px; }
+.ei-card .top {
+  display: flex;
+  justify-content: space-between;
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--warm-grey-85);
+  font-weight: 500;
+}
+.ei-card h3 {
+  font-family: var(--font-display);
+  font-size: 24px;
+  font-weight: 400;
+  letter-spacing: -0.014em;
+  line-height: 1.1;
+  text-wrap: pretty;
+}
+.ei-card h3 .italic { font-style: italic; font-weight: 300; color: var(--warm-grey-85); }
+.ei-card .addr {
+  font-size: 13.5px;
+  color: var(--warm-grey-85);
+  margin-top: 2px;
+}
+.ei-card .stat-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 0;
+  border-top: var(--hairline);
+  padding-top: 16px;
+  margin-top: auto;
+}
+.ei-card .stat-row > div { padding-right: 12px; }
+.ei-card .stat-row .l {
+  font-size: 10.5px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--warm-grey-85);
+  margin-bottom: 4px;
+  font-weight: 500;
+}
+.ei-card .stat-row .v {
+  font-family: var(--font-display);
+  font-size: 19px;
+  font-variant-numeric: tabular-nums;
+  font-weight: 400;
+}
+.ei-card .stat-row .v .unit { color: var(--warm-grey-85); font-size: 0.55em; font-style: italic; margin-left: 2px; }
+.ei-card.is-solgt .ei-card-photo img { filter: grayscale(0.7) brightness(0.92); }
+.ei-card.is-solgt h3 { color: var(--warm-grey-85); }
+
+/* Off-market band */
+.ei-offmarket {
+  background: var(--warm-grey);
+  color: var(--warm-white);
+  padding: 100px 0;
+  margin-top: 32px;
+}
+.ei-offmarket .head {
+  display: grid;
+  grid-template-columns: 1.2fr 1fr;
+  gap: 64px;
+  align-items: end;
+  padding-bottom: 48px;
+  border-bottom: 1px solid rgba(243, 241, 239, 0.14);
+}
+.ei-offmarket .head .pre {
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--accent);
+  font-weight: 500;
+  display: inline-flex;
+  align-items: center;
+  gap: 14px;
+  margin-bottom: 24px;
+}
+.ei-offmarket .head .pre::before {
+  content: "";
+  width: 28px;
+  height: 1px;
+  background: var(--accent);
+}
+.ei-offmarket h2 {
+  font-family: var(--font-display);
+  font-size: clamp(36px, 4.4vw, 64px);
+  font-weight: 400;
+  line-height: 1.0;
+  letter-spacing: -0.024em;
+}
+.ei-offmarket h2 .italic { font-style: italic; font-weight: 300; color: var(--accent); }
+.ei-offmarket .head p {
+  font-size: 17px;
+  color: rgba(243, 241, 239, 0.78);
+  line-height: 1.55;
+  max-width: 46ch;
+}
+.ei-offmarket .head p a {
+  color: var(--warm-white);
+  border-bottom: 1px solid var(--accent);
+  padding-bottom: 1px;
+}
+.ei-offmarket-list { margin-top: 32px; border-top: 1px solid rgba(243, 241, 239, 0.14); }
+.ei-offmarket-row {
+  display: grid;
+  grid-template-columns: 80px 2.4fr 1fr 1fr 1fr 1fr 28px;
+  gap: 28px;
+  align-items: center;
+  padding: 26px 0;
+  border-bottom: 1px solid rgba(243, 241, 239, 0.14);
+  transition: padding-left 0.25s ease;
+  cursor: pointer;
+  color: inherit;
+  text-decoration: none;
+}
+.ei-offmarket-row:hover { padding-left: 12px; }
+.ei-offmarket-row .ref {
+  font-family: var(--font-display);
+  font-size: 14px;
+  font-variant-numeric: tabular-nums;
+  color: rgba(243, 241, 239, 0.5);
+  letter-spacing: 0.04em;
+}
+.ei-offmarket-row .title {
+  font-family: var(--font-display);
+  font-size: 22px;
+  font-weight: 400;
+  letter-spacing: -0.012em;
+  line-height: 1.15;
+}
+.ei-offmarket-row .title .it { font-style: italic; font-weight: 300; color: rgba(243, 241, 239, 0.7); }
+.ei-offmarket-row .cell-l {
+  font-size: 10.5px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(243, 241, 239, 0.5);
+  margin-bottom: 4px;
+  font-weight: 500;
+}
+.ei-offmarket-row .cell-v {
+  font-family: var(--font-display);
+  font-size: 18px;
+  font-variant-numeric: tabular-nums;
+}
+.ei-offmarket-row .cell-v .unit { color: rgba(243, 241, 239, 0.55); font-size: 0.55em; font-style: italic; margin-left: 2px; }
+.ei-offmarket-row .arr {
+  font-family: var(--font-display);
+  font-size: 18px;
+  color: rgba(243, 241, 239, 0.4);
+  text-align: right;
+  transition: color 0.2s, transform 0.2s;
+}
+.ei-offmarket-row:hover .arr { color: var(--accent); transform: translateX(4px); }
+.ei-offmarket-row:last-child { border-bottom: 0; }
+.ei-offmarket-foot {
+  margin-top: 56px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+.ei-offmarket-foot .nda {
+  font-size: 12px;
+  letter-spacing: 0.04em;
+  color: rgba(243, 241, 239, 0.6);
+}
+.ei-offmarket-foot .btn-light {
+  background: var(--warm-white);
+  color: var(--warm-grey);
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 14px 22px;
+  border-radius: 999px;
+  font-size: 13px;
+  font-weight: 500;
+  letter-spacing: -0.005em;
+}
+.ei-offmarket-foot .btn-light:hover { background: var(--accent); }
+@media (max-width: 1080px) {
+  .ei-offmarket-row { grid-template-columns: 60px 1.6fr 1fr 1fr 28px; }
+  .ei-offmarket-row .col-hide { display: none; }
+}
+@media (max-width: 720px) {
+  .ei-offmarket .head { grid-template-columns: 1fr; gap: 32px; }
+  .ei-offmarket-row { grid-template-columns: 1fr 28px; gap: 8px; }
+  .ei-offmarket-row > .col-hide-m { display: none; }
+  .ei-offmarket-row .title { font-size: 18px; }
+}
+
+/* Saved-search / alert strip */
+.ei-alert {
+  border: var(--hairline);
+  background: var(--accent-faint);
+  padding: 28px 32px;
+  margin-top: 80px;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 24px;
+  align-items: center;
+}
+.ei-alert .pre {
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--warm-grey-85);
+  font-weight: 500;
+  margin-bottom: 6px;
+}
+.ei-alert h4 {
+  font-family: var(--font-display);
+  font-size: 22px;
+  font-weight: 400;
+  letter-spacing: -0.012em;
+  line-height: 1.2;
+}
+.ei-alert h4 .italic { font-style: italic; font-weight: 300; }
+.ei-alert form {
+  display: inline-flex;
+  border: 1px solid var(--warm-grey);
+  border-radius: 999px;
+  overflow: hidden;
+  background: var(--warm-white);
+}
+.ei-alert input {
+  border: 0;
+  padding: 12px 18px;
+  font: inherit;
+  font-size: 13px;
+  background: transparent;
+  outline: none;
+  color: var(--warm-grey);
+  width: 240px;
+}
+.ei-alert button {
+  border: 0;
+  background: var(--warm-grey);
+  color: var(--warm-white);
+  padding: 12px 22px;
+  font-size: 13px;
+  font-weight: 500;
+  letter-spacing: -0.005em;
+  cursor: pointer;
+  font-family: inherit;
+}
+.ei-alert button:hover { background: var(--accent); color: var(--warm-grey); }
+@media (max-width: 720px) {
+  .ei-alert { grid-template-columns: 1fr; }
+  .ei-alert input { flex: 1; width: auto; }
+}
+
+/* ============================================================
+   EIENDOM DETAIL — single property page (/eiendommer/[slug])
+   ============================================================ */
+
+/* Photo gallery */
+.ed-gallery {
+  margin-top: 32px;
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  grid-template-rows: auto auto;
+  gap: 8px;
+  height: 580px;
+}
+.ed-gallery .g-main {
+  grid-row: 1 / 3;
+  position: relative;
+  overflow: hidden;
+  background: var(--warm-grey-75);
+}
+.ed-gallery .g-side {
+  position: relative;
+  overflow: hidden;
+  background: var(--warm-grey-75);
+}
+.ed-gallery img {
+  width: 100%; height: 100%; object-fit: cover;
+  transition: transform 0.7s cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+.ed-gallery .g-main:hover img,
+.ed-gallery .g-side:hover img { transform: scale(1.03); }
+.ed-gallery .ei-status { position: absolute; top: 18px; left: 18px; z-index: 2; }
+.ed-gallery .g-more {
+  position: absolute;
+  inset: 0;
+  background: rgba(44, 40, 37, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--warm-white);
+  font-family: var(--font-display);
+  font-size: 20px;
+  font-weight: 400;
+  letter-spacing: -0.01em;
+  z-index: 2;
+  cursor: pointer;
+}
+.ed-gallery .g-more .ct { font-style: italic; color: var(--accent); margin-right: 6px; }
+@media (max-width: 880px) {
+  .ed-gallery {
+    grid-template-columns: 1fr;
+    grid-template-rows: 320px 1fr 1fr;
+    height: auto;
+  }
+  .ed-gallery .g-main { grid-row: auto; height: 320px; }
+  .ed-gallery .g-side { height: 160px; }
+}
+
+/* Title block */
+.ed-title {
+  display: grid;
+  grid-template-columns: 1.6fr 1fr;
+  gap: 64px;
+  align-items: end;
+  padding: 56px 0 32px;
+  border-bottom: var(--hairline);
+}
+.ed-title .pre {
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--warm-grey-85);
+  font-weight: 500;
+  display: inline-flex;
+  align-items: center;
+  gap: 14px;
+  margin-bottom: 24px;
+}
+.ed-title .pre::before {
+  content: "";
+  width: 28px; height: 1px;
+  background: var(--accent);
+}
+.ed-title h1 {
+  font-family: var(--font-display);
+  font-size: clamp(44px, 5.6vw, 84px);
+  font-weight: 400;
+  line-height: 0.98;
+  letter-spacing: -0.026em;
+}
+.ed-title h1 .italic { font-style: italic; font-weight: 300; color: var(--warm-grey-85); }
+.ed-title .addr {
+  font-size: 16px;
+  color: var(--warm-grey-85);
+  margin-top: 22px;
+  display: inline-flex;
+  align-items: center;
+  gap: 14px;
+  flex-wrap: wrap;
+}
+.ed-title .addr .ref {
+  font-family: var(--font-display);
+  font-variant-numeric: tabular-nums;
+  color: var(--warm-grey-85);
+  font-size: 14px;
+  letter-spacing: 0.04em;
+}
+.ed-title .addr .sep {
+  width: 1px; height: 14px;
+  background: var(--warm-grey-75);
+  display: inline-block;
+}
+.ed-title-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  align-items: flex-end;
+}
+.ed-title-actions .btn-row {
+  display: inline-flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+.ed-title-actions .small-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 14px;
+  border: 1px solid var(--warm-grey-75);
+  border-radius: 999px;
+  font-size: 12.5px;
+  color: var(--warm-grey-85);
+  background: transparent;
+  cursor: pointer;
+  font-family: inherit;
+}
+.ed-title-actions .small-btn:hover {
+  color: var(--warm-grey);
+  border-color: var(--warm-grey);
+}
+@media (max-width: 880px) {
+  .ed-title { grid-template-columns: 1fr; gap: 24px; }
+  .ed-title-actions { align-items: flex-start; }
+}
+
+/* Headline stats */
+.ed-stats {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  border-bottom: var(--hairline);
+}
+.ed-stats > div {
+  padding: 28px 24px 28px 0;
+  border-right: var(--hairline);
+}
+.ed-stats > div:not(:first-child) { padding-left: 24px; }
+.ed-stats > div:last-child { border-right: 0; padding-right: 0; }
+.ed-stats .l {
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--warm-grey-85);
+  font-weight: 500;
+  margin-bottom: 10px;
+}
+.ed-stats .v {
+  font-family: var(--font-display);
+  font-size: 32px;
+  font-weight: 400;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.012em;
+  line-height: 1;
+}
+.ed-stats .v .unit {
+  font-size: 0.4em;
+  color: var(--warm-grey-85);
+  font-style: italic;
+  margin-left: 4px;
+}
+.ed-stats .sub {
+  font-size: 11.5px;
+  color: var(--warm-grey-85);
+  margin-top: 6px;
+}
+@media (max-width: 980px) {
+  .ed-stats { grid-template-columns: 1fr 1fr 1fr; }
+  .ed-stats > div { border-bottom: var(--hairline); padding: 22px 16px; }
+  .ed-stats > div:nth-child(3n) { border-right: 0; }
+  .ed-stats > div:nth-last-child(-n+2):not(:nth-child(3n)) { border-bottom: 0; }
+}
+@media (max-width: 560px) {
+  .ed-stats { grid-template-columns: 1fr 1fr; }
+  .ed-stats > div { border-right: var(--hairline); border-bottom: var(--hairline); }
+  .ed-stats > div:nth-child(2n) { border-right: 0; }
+}
+
+/* Editorial body */
+.ed-body {
+  display: grid;
+  grid-template-columns: 1.4fr 1fr;
+  gap: 80px;
+  padding: 80px 0;
+  border-bottom: var(--hairline);
+}
+.ed-body .lead {
+  font-family: var(--font-display);
+  font-size: clamp(22px, 1.8vw, 28px);
+  line-height: 1.35;
+  font-weight: 400;
+  letter-spacing: -0.014em;
+  margin-bottom: 28px;
+  max-width: 32ch;
+  text-wrap: pretty;
+}
+.ed-body .lead .italic { font-style: italic; font-weight: 300; color: var(--warm-grey-85); }
+.ed-body p {
+  font-size: 16px;
+  color: var(--warm-grey-85);
+  line-height: 1.65;
+  margin-bottom: 18px;
+  max-width: 62ch;
+}
+.ed-body p strong { color: var(--warm-grey); font-weight: 500; }
+
+/* Megler card */
+.ed-megler {
+  background: var(--warm-grey);
+  color: var(--warm-white);
+  padding: 36px;
+  position: sticky;
+  top: 96px;
+  align-self: start;
+}
+.ed-megler .pre {
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--accent);
+  font-weight: 500;
+  margin-bottom: 24px;
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+}
+.ed-megler .pre::before {
+  content: "";
+  width: 24px; height: 1px;
+  background: var(--accent);
+}
+.ed-megler .pp {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding-bottom: 24px;
+  border-bottom: 1px solid rgba(243, 241, 239, 0.14);
+}
+.ed-megler .pp img {
+  width: 64px; height: 64px;
+  border-radius: 50%;
+  object-fit: cover;
+  background: rgba(243, 241, 239, 0.16);
+}
+.ed-megler .pp .nm .n {
+  font-family: var(--font-display);
+  font-size: 22px;
+  font-weight: 400;
+  letter-spacing: -0.01em;
+}
+.ed-megler .pp .nm .r {
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(243, 241, 239, 0.65);
+  margin-top: 4px;
+}
+.ed-megler .contact {
+  padding: 20px 0;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+}
+.ed-megler .contact a {
+  font-size: 13.5px;
+  color: var(--warm-white);
+  border-bottom: 1px solid rgba(243, 241, 239, 0.2);
+  padding-bottom: 1px;
+  font-family: var(--font-display);
+  font-variant-numeric: tabular-nums;
+}
+.ed-megler .contact a:hover { border-color: var(--accent); }
+.ed-megler .contact .l {
+  font-size: 10.5px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(243, 241, 239, 0.55);
+  margin-bottom: 4px;
+  font-weight: 500;
+}
+.ed-megler .cta-row {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding-top: 20px;
+  border-top: 1px solid rgba(243, 241, 239, 0.14);
+}
+.ed-megler .cta-row .btn { width: 100%; justify-content: center; }
+.ed-megler .btn-primary { background: var(--warm-white); color: var(--warm-grey); }
+.ed-megler .btn-primary:hover { background: var(--accent); color: var(--warm-grey); }
+.ed-megler .btn-ghost {
+  border: 1px solid rgba(243, 241, 239, 0.3);
+  color: var(--warm-white);
+}
+.ed-megler .btn-ghost:hover { background: rgba(243, 241, 239, 0.08); }
+@media (max-width: 980px) {
+  .ed-body { grid-template-columns: 1fr; gap: 48px; padding: 56px 0; }
+  .ed-megler { position: static; }
+}
+
+/* Generic section heading reused below */
+.ed-section {
+  padding: 80px 0;
+  border-bottom: var(--hairline);
+}
+.ed-section .head {
+  display: grid;
+  grid-template-columns: 280px 1fr;
+  gap: 48px;
+  margin-bottom: 48px;
+  align-items: end;
+}
+.ed-section .head .eyebrow { margin-bottom: 0; }
+.ed-section h2 {
+  font-family: var(--font-display);
+  font-size: clamp(32px, 3.6vw, 52px);
+  font-weight: 400;
+  line-height: 1.0;
+  letter-spacing: -0.022em;
+  max-width: 22ch;
+}
+.ed-section h2 .italic { font-style: italic; font-weight: 300; color: var(--warm-grey-85); }
+.ed-section .head p {
+  font-size: 15.5px;
+  color: var(--warm-grey-85);
+  line-height: 1.6;
+  margin-top: 16px;
+  max-width: 56ch;
+}
+@media (max-width: 880px) {
+  .ed-section .head { grid-template-columns: 1fr; gap: 16px; }
+}
+
+/* Facts table */
+.ed-facts {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0 64px;
+}
+.ed-facts dl { margin: 0; display: flex; flex-direction: column; }
+.ed-facts dl > div {
+  display: grid;
+  grid-template-columns: 1.1fr 1fr;
+  gap: 24px;
+  padding: 18px 0;
+  border-bottom: var(--hairline);
+  align-items: baseline;
+}
+.ed-facts dt {
+  font-size: 13px;
+  letter-spacing: 0.06em;
+  color: var(--warm-grey-85);
+}
+.ed-facts dd {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: 17px;
+  font-variant-numeric: tabular-nums;
+  color: var(--warm-grey);
+  text-align: right;
+}
+.ed-facts dd .unit { color: var(--warm-grey-85); font-size: 0.7em; font-style: italic; margin-left: 2px; }
+@media (max-width: 880px) {
+  .ed-facts { grid-template-columns: 1fr; gap: 0; }
+}
+
+/* Tenants table */
+.ed-tenants {
+  width: 100%;
+  border-collapse: collapse;
+  font-variant-numeric: tabular-nums;
+}
+.ed-tenants thead th {
+  text-align: left;
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--warm-grey-85);
+  font-weight: 500;
+  padding: 0 16px 18px 0;
+  border-bottom: var(--hairline);
+}
+.ed-tenants thead th.num,
+.ed-tenants tbody td.num { text-align: right; padding-right: 0; padding-left: 24px; }
+.ed-tenants tbody td {
+  padding: 22px 16px 22px 0;
+  border-bottom: var(--hairline);
+  vertical-align: middle;
+}
+.ed-tenants tbody td.num { padding-left: 24px; padding-right: 0; }
+.ed-tenants tbody tr:last-child td { border-bottom: 0; }
+.ed-tenants .name {
+  font-family: var(--font-display);
+  font-size: 19px;
+  font-weight: 400;
+  letter-spacing: -0.01em;
+  color: var(--warm-grey);
+}
+.ed-tenants .sector {
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--warm-grey-85);
+  margin-top: 4px;
+  font-weight: 500;
+}
+.ed-tenants .v {
+  font-family: var(--font-display);
+  font-size: 17px;
+  color: var(--warm-grey);
+}
+.ed-tenants .v .unit { color: var(--warm-grey-85); font-size: 0.65em; font-style: italic; margin-left: 2px; }
+.ed-tenants .bar {
+  width: 80px;
+  height: 5px;
+  background: var(--warm-grey-75);
+  display: inline-block;
+  margin-left: 12px;
+  position: relative;
+  overflow: hidden;
+  vertical-align: middle;
+}
+.ed-tenants .bar i {
+  position: absolute;
+  inset: 0;
+  background: var(--accent);
+  display: block;
+}
+.ed-tenants tr.tenant-ledig { background: var(--accent-faint); }
+.ed-tenants tr.tenant-ledig .name { color: var(--warm-grey-85); font-style: italic; }
+.ed-tenants tr.tenant-ledig .v { color: var(--warm-grey-85); }
+.ed-tenants tfoot td {
+  padding-top: 24px;
+  font-size: 12px;
+  color: var(--warm-grey-85);
+  border-bottom: 0;
+}
+@media (max-width: 720px) {
+  .ed-tenants thead .col-hide,
+  .ed-tenants tbody .col-hide { display: none; }
+  .ed-tenants .name { font-size: 16px; }
+  .ed-tenants .v { font-size: 15px; }
+}
+
+/* Financials (dark KPI grid) */
+.ed-fin {
+  background: var(--warm-grey);
+  color: var(--warm-white);
+  padding: 80px 0;
+}
+.ed-fin .head h2 { color: var(--warm-white); }
+.ed-fin .head .pre {
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--accent);
+  font-weight: 500;
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 18px;
+}
+.ed-fin .head .pre::before { content: ""; width: 28px; height: 1px; background: var(--accent); }
+.ed-fin .head p { color: rgba(243, 241, 239, 0.7); }
+.ed-fin-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 0;
+  border-top: 1px solid rgba(243, 241, 239, 0.16);
+}
+.ed-fin-grid > div {
+  padding: 36px 32px 36px 0;
+  border-right: 1px solid rgba(243, 241, 239, 0.16);
+}
+.ed-fin-grid > div:not(:first-child) { padding-left: 32px; }
+.ed-fin-grid > div:last-child { border-right: 0; padding-right: 0; }
+.ed-fin-grid .l {
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(243, 241, 239, 0.55);
+  margin-bottom: 14px;
+  font-weight: 500;
+}
+.ed-fin-grid .v {
+  font-family: var(--font-display);
+  font-size: 44px;
+  font-weight: 400;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.018em;
+  line-height: 1;
+}
+.ed-fin-grid .v .unit { font-size: 0.36em; color: var(--accent); font-style: italic; margin-left: 4px; }
+.ed-fin-grid .sub {
+  margin-top: 14px;
+  font-size: 13px;
+  color: rgba(243, 241, 239, 0.6);
+  line-height: 1.5;
+}
+@media (max-width: 880px) {
+  .ed-fin-grid { grid-template-columns: 1fr 1fr; }
+  .ed-fin-grid > div { border-bottom: 1px solid rgba(243, 241, 239, 0.16); padding: 28px 20px; }
+  .ed-fin-grid > div:nth-child(2n) { border-right: 0; }
+  .ed-fin-grid > div:nth-last-child(-n+2) { border-bottom: 0; }
+}
+
+/* Location block */
+.ed-loc {
+  display: grid;
+  grid-template-columns: 1.3fr 1fr;
+  gap: 56px;
+  align-items: start;
+}
+.ed-map {
+  aspect-ratio: 4 / 3;
+  background: var(--warm-grey-75);
+  position: relative;
+  overflow: hidden;
+  background-image:
+    linear-gradient(rgba(44, 40, 37, 0.04) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(44, 40, 37, 0.04) 1px, transparent 1px),
+    linear-gradient(135deg, var(--accent-faint) 0%, var(--warm-grey-75) 100%);
+  background-size: 36px 36px, 36px 36px, 100% 100%;
+}
+/* Real Leaflet variant — strip the hand-drawn gradient mock so tiles read
+   clean. The Leaflet container fills via its own 100% width/height. */
+.ed-map.ed-map-real {
+  background: var(--warm-grey-75);
+  background-image: none;
+}
+.ed-map.ed-map-real .leaflet-container {
+  height: 100%;
+  width: 100%;
+  background: var(--warm-grey-75);
+}
+.ed-map.ed-map-loading {
+  background-image: none;
+}
+.ed-map .pin {
+  position: absolute;
+  top: 50%; left: 56%;
+  transform: translate(-50%, -100%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+.ed-map .pin .marker {
+  width: 28px; height: 28px;
+  border-radius: 50% 50% 50% 0;
+  background: var(--warm-grey);
+  transform: rotate(-45deg);
+  position: relative;
+  box-shadow: 0 4px 20px rgba(44, 40, 37, 0.25);
+}
+.ed-map .pin .marker::after {
+  content: "";
+  position: absolute;
+  top: 8px; left: 8px;
+  width: 12px; height: 12px;
+  background: var(--accent);
+  border-radius: 50%;
+}
+.ed-map .pin .lbl {
+  background: var(--warm-white);
+  padding: 6px 12px;
+  font-size: 12px;
+  font-weight: 500;
+  margin-top: 10px;
+  border: var(--hairline);
+}
+.ed-map .water {
+  position: absolute;
+  inset: 60% 0 0 0;
+  background: linear-gradient(180deg, transparent, rgba(74, 134, 168, 0.25));
+}
+.ed-map .compass {
+  position: absolute;
+  top: 16px; right: 16px;
+  width: 36px; height: 36px;
+  border: 1px solid var(--warm-grey);
+  background: var(--warm-white);
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--font-display);
+  font-size: 13px;
+  font-weight: 500;
+}
+.ed-loc-info h3 {
+  font-family: var(--font-display);
+  font-size: 28px;
+  font-weight: 400;
+  letter-spacing: -0.014em;
+  line-height: 1.1;
+  margin-bottom: 12px;
+  text-wrap: pretty;
+}
+.ed-loc-info h3 .italic { font-style: italic; font-weight: 300; color: var(--warm-grey-85); }
+.ed-loc-info p {
+  font-size: 15px;
+  color: var(--warm-grey-85);
+  line-height: 1.6;
+  margin-bottom: 24px;
+  max-width: 38ch;
+}
+.ed-poi { border-top: var(--hairline); }
+.ed-poi-row {
+  display: grid;
+  grid-template-columns: 28px 1fr auto;
+  gap: 14px;
+  padding: 14px 0;
+  border-bottom: var(--hairline);
+  align-items: center;
+}
+.ed-poi-row .ico {
+  width: 28px; height: 28px;
+  border: 1px solid var(--warm-grey-75);
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 13px;
+  color: var(--warm-grey);
+  font-family: var(--font-display);
+}
+.ed-poi-row .nm { font-size: 14.5px; color: var(--warm-grey); }
+.ed-poi-row .dist {
+  font-family: var(--font-display);
+  font-size: 14px;
+  color: var(--warm-grey-85);
+  font-variant-numeric: tabular-nums;
+}
+@media (max-width: 880px) {
+  .ed-loc { grid-template-columns: 1fr; gap: 32px; }
+}
+
+/* Downloads */
+.ed-downloads {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+}
+.ed-dl {
+  display: grid;
+  grid-template-columns: 56px 1fr auto;
+  gap: 20px;
+  align-items: center;
+  padding: 24px 28px;
+  border: var(--hairline);
+  background: var(--warm-white);
+  transition: border-color 0.2s, background 0.2s;
+  color: inherit;
+  text-decoration: none;
+}
+.ed-dl:hover { border-color: var(--warm-grey); background: var(--accent-faint); }
+.ed-dl .ico {
+  width: 56px; height: 56px;
+  border: 1px solid var(--warm-grey-75);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--font-display);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  color: var(--warm-grey);
+  background: var(--warm-white);
+}
+.ed-dl .nm {
+  font-family: var(--font-display);
+  font-size: 18px;
+  font-weight: 400;
+  letter-spacing: -0.01em;
+  line-height: 1.2;
+  color: var(--warm-grey);
+}
+.ed-dl .nm .sub {
+  display: block;
+  font-family: var(--font-body);
+  font-size: 12px;
+  color: var(--warm-grey-85);
+  margin-top: 4px;
+  font-variant-numeric: tabular-nums;
+}
+.ed-dl .arr {
+  font-family: var(--font-display);
+  font-size: 18px;
+  color: var(--warm-grey-85);
+}
+.ed-dl:hover .arr { color: var(--warm-grey); }
+.ed-dl.locked { background: transparent; }
+.ed-dl.locked .ico { background: var(--warm-grey); color: var(--warm-white); border-color: var(--warm-grey); }
+.ed-dl.locked .nm .sub { color: var(--accent); }
+@media (max-width: 720px) {
+  .ed-downloads { grid-template-columns: 1fr; }
+}
+
+/* Interested CTA strip */
+.ed-cta {
+  padding: 80px 0;
+  background: var(--accent-faint);
+  border-bottom: var(--hairline);
+  text-align: center;
+}
+.ed-cta h2 {
+  font-family: var(--font-display);
+  font-size: clamp(36px, 4.4vw, 64px);
+  font-weight: 400;
+  letter-spacing: -0.025em;
+  line-height: 1.0;
+  margin-bottom: 18px;
+  max-width: 22ch;
+  margin-left: auto; margin-right: auto;
+}
+.ed-cta h2 .italic { font-style: italic; font-weight: 300; }
+.ed-cta p {
+  font-size: 17px;
+  color: var(--warm-grey-85);
+  max-width: 50ch;
+  margin: 0 auto 36px;
+  line-height: 1.55;
+}
+.ed-cta .row {
+  display: inline-flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+/* Related */
+.ed-related { padding: 100px 0; }
+.ed-related .head-compact { margin-bottom: 0; }

--- a/src/styles/advanti-design.css
+++ b/src/styles/advanti-design.css
@@ -4332,7 +4332,9 @@ h1, h2, h3 {
   width: 100%; height: 100%; object-fit: cover;
   transition: transform 0.8s cubic-bezier(0.2, 0.8, 0.2, 1);
 }
-.ei-featured:hover .ei-featured-photo img { transform: scale(1.03); }
+@media (hover: hover) and (pointer: fine) {
+  .ei-featured:hover .ei-featured-photo img { transform: scale(1.03); }
+}
 .ei-featured-photo .ei-status { position: absolute; top: 18px; left: 18px; }
 .ei-featured-photo .ei-counter {
   position: absolute;
@@ -4500,7 +4502,9 @@ h1, h2, h3 {
   width: 100%; height: 100%; object-fit: cover;
   transition: transform 0.7s cubic-bezier(0.2, 0.8, 0.2, 1);
 }
-.ei-card:hover .ei-card-photo img { transform: scale(1.045); }
+@media (hover: hover) and (pointer: fine) {
+  .ei-card:hover .ei-card-photo img { transform: scale(1.045); }
+}
 .ei-card-photo .ei-status { position: absolute; top: 14px; left: 14px; }
 .ei-card .top {
   display: flex;
@@ -4611,12 +4615,16 @@ h1, h2, h3 {
   align-items: center;
   padding: 26px 0;
   border-bottom: 1px solid rgba(243, 241, 239, 0.14);
-  transition: padding-left 0.25s ease;
+  /* transform — not padding — so the browser composites the hover shift
+     on the GPU instead of re-laying out the row each frame. */
+  transition: transform 0.25s ease;
   cursor: pointer;
   color: inherit;
   text-decoration: none;
 }
-.ei-offmarket-row:hover { padding-left: 12px; }
+@media (hover: hover) and (pointer: fine) {
+  .ei-offmarket-row:hover { transform: translateX(12px); }
+}
 .ei-offmarket-row .ref {
   font-family: var(--font-display);
   font-size: 14px;
@@ -4653,7 +4661,9 @@ h1, h2, h3 {
   text-align: right;
   transition: color 0.2s, transform 0.2s;
 }
-.ei-offmarket-row:hover .arr { color: var(--accent); transform: translateX(4px); }
+@media (hover: hover) and (pointer: fine) {
+  .ei-offmarket-row:hover .arr { color: var(--accent); transform: translateX(4px); }
+}
 .ei-offmarket-row:last-child { border-bottom: 0; }
 .ei-offmarket-foot {
   margin-top: 56px;
@@ -4781,8 +4791,10 @@ h1, h2, h3 {
   width: 100%; height: 100%; object-fit: cover;
   transition: transform 0.7s cubic-bezier(0.2, 0.8, 0.2, 1);
 }
-.ed-gallery .g-main:hover img,
-.ed-gallery .g-side:hover img { transform: scale(1.03); }
+@media (hover: hover) and (pointer: fine) {
+  .ed-gallery .g-main:hover img,
+  .ed-gallery .g-side:hover img { transform: scale(1.03); }
+}
 .ed-gallery .ei-status { position: absolute; top: 18px; left: 18px; z-index: 2; }
 .ed-gallery .g-more {
   position: absolute;
@@ -5507,3 +5519,18 @@ h1, h2, h3 {
 /* Related */
 .ed-related { padding: 100px 0; }
 .ed-related .head-compact { margin-bottom: 0; }
+
+/* Reduced-motion override for the eiendommer photo/row transforms. The
+   colour-only hovers (border, bg) stay untouched — only the spatial
+   movement is silenced, which is what users with vestibular sensitivity
+   actually need disabled. */
+@media (prefers-reduced-motion: reduce) {
+  .ei-featured-photo img,
+  .ei-card-photo img,
+  .ed-gallery img,
+  .ei-offmarket-row,
+  .ei-offmarket-row .arr {
+    transition: none !important;
+    transform: none !important;
+  }
+}


### PR DESCRIPTION
## Summary

New public listings surface for Advanti's commercial real estate mandates.

**New routes**
- `/eiendommer` — sticky-filterable index (status / type / city), KPI band over total inventory, featured spot, 8-card grid, saved-search alert, off-market band, seller CTA
- `/eiendommer/[slug]` — editorial property detail: gallery, headline stats, two-column body with sticky megler card, facts table, tenants table with utilization bars, dark financials KPI grid, Leaflet location map, downloads (PDF + NDA-gated), CTA, related listings

**Data + infra**
- `ListingPost` content collection in `content-collections.ts` with typed frontmatter (status, type, city, headline stats, gallery, facts, tenants, financials, location with geo coords, downloads, megler)
- 9 listing MDX files seeded with clean explicit slugs (Sjøgata 7 with full detail; 8 stubs with index-card data)
- `getListingPost` + `getActiveListings` helpers in `src/lib/content.ts`
- `RealEstateListing` JSON-LD per detail, linked to the existing `#organization` graph node
- Real Leaflet map (`PropertyMap` + `PropertyMapLeaflet`) reusing the CartoDB tile config from `markedsinnsikt/maps/mapTheme.ts`
- Nav, sitemap, siteConfig wired. `eiendommer` added to `siteConfig.baseLinks`
- ~640 new lines of `.ei-*` / `.ed-*` semantic CSS appended to `advanti-design.css`

## Design Review

Ran `/design-review` on the live pages. Found 4 issues; all fixed in atomic commits:

- **F1 (HIGH)** — sticky filter bar overlayed dark off-market section (translucent light bg occluded the headline). Wrapped `ListingsBrowser` output in a containing `<div>` so `position: sticky` is bounded.
- **F2 (HIGH)** — `.ed-dl.locked .nm .sub` rendered `var(--accent)` (#cbeef2) on warm-white, contrast 1.07:1 (WCAG AA needs 4.5:1). Switched to `var(--warm-grey-85)` (#57504a, ~7.5:1). The dark NDA icon block already signals gating.
- **F3 (MEDIUM)** — filter chips at 36px height (under WCAG 44px touch target). Added `min-height: 44px` + flex centering to `.ei-chip` so the hit area meets the minimum without inflating the visible pill.
- **F4 (POLISH)** — "Featured oppdrag" was the only English word on a Norwegian-bokmål site. Replaced with "Utvalgt oppdrag" in detail page + Sjøgata 7 frontmatter.

AI Slop blacklist: clean across all 11 patterns (no purple gradients, no icon-in-circle feature grids, no centered-everything, no bubbly border-radius, no decorative blobs, no emoji, no colored left-border cards, no generic hero copy, no cookie-cutter section rhythm, single Inter typeface).

## Emil design-engineering pass

Applied after the /design-review fixes:

- Replaced `transition: all` on `.ei-chip` with explicit `background-color, color, border-color`.
- Guarded photo/row hover transforms behind `@media (hover: hover) and (pointer: fine)` so touch devices don't stick on tap-release scale effects (`.ei-card`, `.ei-featured`, `.ed-gallery`, `.ei-offmarket-row`).
- Swapped `.ei-offmarket-row` hover from `padding-left` (layout-thrashing) to `transform: translateX` (GPU composite).
- Added `@media (prefers-reduced-motion: reduce)` override silencing the new transforms while preserving color hovers — vestibular-sensitive users get a still page.

## Pre-Landing Review

No issues found beyond the design-review pass above.

## Test Coverage

No new tests added for this feature. The existing perf-budget Playwright spec in CI catches bundle regressions on the new routes. Functional coverage relies on the build's type-checking (`ignoreBuildErrors: false`) and the listings being data-driven from MDX (mistakes surface at build time, not runtime).

Tests: 52 → 52 (no delta).

## TODOS

Marked TODO 18 as SHIPPED with full outcome notes. Follow-up content work noted: the 8 stub listings need facts/tenants/financials/location populated as partners share the data; adding `location.geo: {lat,lng}` to each MDX activates the real Leaflet map (currently CSS-mock fallback for stubs).

## Test plan

- [x] `pnpm build` clean (60 content documents, 9 collections, all 9 listing detail pages SSG'd)
- [x] `/eiendommer`, `/eiendommer/sjogata-7-tromso`, `/eiendommer/olav-v-gate-102-bodo` all 200 OK in dev
- [x] Filter chips toggle index, featured + grid both filterable
- [x] Real Leaflet map renders for Sjøgata 7 (with geo coords); fallback mock for stubs
- [x] RealEstateListing JSON-LD verified emitted on detail
- [x] Sticky filter unsticks before off-market band (F1 fix verified visually)
- [x] NDA subtext readable (F2 fix verified visually)
- [x] Filter chips at 44px touch height (F3 fix verified via DOM measurement)
- [x] "Utvalgt oppdrag" renders, no English "Featured" in user-visible strings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Launched "Eiendommer" (Properties) section with browsable listings index and individual property detail pages
  * Filter properties by status, type, and city with live result counts
  * View detailed property information including photo galleries, interactive location maps, pricing metrics, building facts, tenant details, and responsible agent contact information
  * Featured properties highlighted on the index page
  * Email notification signup for property updates
  * Related property suggestions on detail pages

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Codehagen/advantiestate/pull/12?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->