### PR TITLE
feat(seo): OG cards, llms.txt, structured data, cross-links for /eiendommer

### DIFF
--- a/src/app/api/og/listing/[slug]/route.tsx
+++ b/src/app/api/og/listing/[slug]/route.tsx
@@ -1,0 +1,128 @@
+import { ImageResponse } from "next/og";
+
+import { ListingCard } from "@/components/og/ListingCard";
+import { getListingPost } from "@/lib/content";
+import { loadOgFonts } from "@/lib/og/fonts";
+
+export const runtime = "nodejs";
+
+const SIZE = { width: 1200, height: 630 };
+
+const STATUS_LABELS = {
+  "til-salgs": "Til salgs",
+  reservert: "Reservert",
+  kommer: "Kommer",
+  solgt: "Solgt",
+} as const;
+
+const CITY_LABELS: Record<string, string> = {
+  bodo: "Bodø",
+  tromso: "Tromsø",
+  harstad: "Harstad",
+  alta: "Alta",
+  narvik: "Narvik",
+  lofoten: "Lofoten",
+  "mo-i-rana": "Mo i Rana",
+};
+
+function formatInt(value: number) {
+  // Use a non-breaking space (U+00A0) as the thousands separator per Norwegian
+  // convention so numbers never wrap across lines (per DESIGN.md gotchas).
+  return new Intl.NumberFormat("nb-NO").format(value).replace(/\s/g, " ");
+}
+
+function formatDecimal(value: number, max = 1) {
+  return new Intl.NumberFormat("nb-NO", { maximumFractionDigits: max }).format(
+    value,
+  );
+}
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ slug: string }> },
+) {
+  try {
+    const { slug } = await params;
+    const listing = getListingPost(slug);
+    const fonts = (await loadOgFonts()).map((f) => ({
+      name: f.name,
+      data: f.data,
+      weight: f.weight,
+      style: f.style,
+    }));
+
+    // Fall back to a generic listing card if the slug doesn't resolve.
+    // notFound() at the page level usually catches this first, but a social
+    // crawler can hit the OG handler directly — better to return a valid
+    // 1200×630 than a 500.
+    if (!listing) {
+      return new ImageResponse(
+        (
+          <ListingCard
+            title="Næringseiendom i Nord-Norge"
+            address="Bodø · Tromsø · Alta · Narvik"
+            reference="—"
+            status="til-salgs"
+            statusLabel="Eiendommer"
+            typeLabel="Advanti Estate"
+            stats={{
+              bta: "—",
+              headline: "—",
+              headlineLabel: "Prisantydning",
+              yield: "—",
+            }}
+          />
+        ),
+        { ...SIZE, fonts },
+      );
+    }
+
+    const cityLabel = CITY_LABELS[listing.city] ?? listing.city;
+    const statusLabel =
+      listing.statusLabel ?? STATUS_LABELS[listing.status] ?? listing.status;
+
+    // Headline stat picks price for active mandates, ferdig-quarter for kommer.
+    const headlineStat =
+      listing.prisantydning !== undefined
+        ? {
+            headlineLabel: "Prisantydning",
+            headline: `${listing.prisantydningEstimat ? "est. " : ""}${formatInt(listing.prisantydning)} mnok`,
+          }
+        : listing.ferdig
+          ? {
+              headlineLabel: "Ferdigstilles",
+              headline: listing.ferdig,
+            }
+          : {
+              headlineLabel: "Prisantydning",
+              headline: "—",
+            };
+
+    return new ImageResponse(
+      (
+        <ListingCard
+          title={listing.title}
+          address={listing.address}
+          reference={listing.reference}
+          status={listing.status}
+          statusLabel={statusLabel}
+          typeLabel={`${listing.typeLabel} · ${cityLabel}`}
+          stats={{
+            bta: `${formatInt(listing.bta)} m²`,
+            headline: headlineStat.headline,
+            headlineLabel: headlineStat.headlineLabel,
+            yield:
+              listing.yieldNetto !== undefined
+                ? `${listing.yieldEstimat ? "est. " : ""}${formatDecimal(listing.yieldNetto, 1).replace(".", ",")} %`
+                : "—",
+          }}
+        />
+      ),
+      { ...SIZE, fonts },
+    );
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : "unknown";
+    console.error(`Failed to generate listing OG image: ${msg}`);
+    return new Response(`Failed to generate OG image: ${msg}`, { status: 500 });
+  }
+}

--- a/src/app/eiendommer/[slug]/page.tsx
+++ b/src/app/eiendommer/[slug]/page.tsx
@@ -57,11 +57,17 @@ export async function generateMetadata({
   const { slug } = await params;
   const listing = getListingPost(slug);
   if (!listing) return;
+  // Drop the " | Advanti Estate" brand suffix — listing titles already pack
+  // address + m² + headline into ~50 chars; appending the brand pushes most
+  // listings past Google's SERP truncation at ~60. og:site_name + canonical
+  // already carry the brand. Use the per-listing OG card route so social
+  // shares show price/yield/BTA over the cover photo.
   return constructMetadata({
     path: `/eiendommer/${listing.slug}`,
-    title: `${listing.title} | Advanti Estate`,
+    title: listing.title,
     description: listing.summary,
-    image: listing.coverImage,
+    image: `/api/og/listing/${listing.slug}`,
+    imageAlt: listing.coverImageAlt,
   });
 }
 

--- a/src/app/eiendommer/page.tsx
+++ b/src/app/eiendommer/page.tsx
@@ -1,13 +1,16 @@
 import Link from "next/link";
 
 import { constructMetadata } from "@/lib/utils";
+import { siteConfig } from "@/app/siteConfig";
 import { getActiveListings } from "@/lib/content";
 import { SubHero } from "@/components/site/SubHero";
 import {
   ListingsBrowser,
   type ListingCardData,
 } from "@/components/eiendommer/ListingsBrowser";
-import { BreadcrumbStructuredData } from "@/components/StructuredData";
+import StructuredData, {
+  BreadcrumbStructuredData,
+} from "@/components/StructuredData";
 
 const CITY_LABELS: Record<string, string> = {
   bodo: "Bodø",
@@ -170,6 +173,44 @@ export default function EiendommerPage() {
   const featuredCard = allCards.find((card) => card.featured);
   const gridCards = allCards.filter((card) => !card.featured);
 
+  // ItemList JSON-LD — surfaces the entire mandate inventory as a machine
+  // readable list of RealEstateListing items. Direct AI Overview / Google
+  // rich-result lever for "commercial properties in [region]" queries.
+  // Each item links back to the detail page via @id matching the inline
+  // RealEstateListing graph node emitted there.
+  const itemListJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "ItemList",
+    name: "Næringseiendom til salgs i Nord-Norge",
+    description:
+      "Aktive salgsoppdrag formidlet av Advanti Estate i Bodø, Tromsø, Alta, Narvik, Harstad og Lofoten.",
+    numberOfItems: listings.length,
+    itemListOrder: "https://schema.org/ItemListOrderAscending",
+    itemListElement: listings.map((listing, index) => ({
+      "@type": "ListItem",
+      position: index + 1,
+      item: {
+        "@type": "RealEstateListing",
+        "@id": `${siteConfig.url}/eiendommer/${listing.slug}#listing`,
+        url: `${siteConfig.url}/eiendommer/${listing.slug}`,
+        name: listing.title,
+        description: listing.summary,
+        image: listing.coverImage.startsWith("http")
+          ? listing.coverImage
+          : `${siteConfig.url}${listing.coverImage}`,
+        ...(listing.prisantydning
+          ? {
+              offers: {
+                "@type": "Offer",
+                priceCurrency: "NOK",
+                price: listing.prisantydning * 1_000_000,
+              },
+            }
+          : {}),
+      },
+    })),
+  };
+
   return (
     <>
       <BreadcrumbStructuredData
@@ -177,6 +218,18 @@ export default function EiendommerPage() {
           { name: "Hjem", url: "/" },
           { name: "Eiendommer for salg", url: "/eiendommer" },
         ]}
+      />
+      <StructuredData
+        type="service"
+        data={{
+          name: "Salg av næringseiendom i Nord-Norge",
+          description:
+            "Advanti Estate formidler salg av kontorbygg, logistikkanlegg, handelseiendom og kombinasjonsbygg i Nordland og Troms. Aktive mandater + off-market-portefølje for kvalifiserte investorer.",
+        }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(itemListJsonLd) }}
       />
 
       <SubHero

--- a/src/app/llms.txt/route.ts
+++ b/src/app/llms.txt/route.ts
@@ -3,6 +3,7 @@ import {
   allHelpPosts,
   allLocationPosts,
   allCustomersPosts,
+  allListingPosts,
 } from "content-collections";
 import { siteConfig } from "../siteConfig";
 
@@ -100,6 +101,28 @@ function buildBody(baseUrl: string): string {
       )
       .join("\n"),
   );
+
+  // Active mandates — surfaces the eiendommer inventory directly to AI engines
+  // (ChatGPT, Claude, Perplexity, Google AI Overviews). Listed by the same
+  // collection that drives the public /eiendommer index and sitemap, so the
+  // three sources cannot drift apart. Excludes sold listings.
+  const activeListings = [...allListingPosts]
+    .filter((listing) => listing.status !== "solgt")
+    .sort((a, b) => a.order - b.order);
+  if (activeListings.length > 0) {
+    sections.push(`## Eiendommer for salg`);
+    sections.push(
+      activeListings
+        .map((listing) =>
+          line(
+            `${listing.titleHead} ${listing.titleTail}`.replace(/\s+/g, " ").trim(),
+            `${baseUrl}/eiendommer/${listing.slug}`,
+            listing.summary,
+          ),
+        )
+        .join("\n"),
+    );
+  }
 
   sections.push(`## Hjelp og terminologi`);
   sections.push(

--- a/src/app/naringsmegler/[slug]/page.tsx
+++ b/src/app/naringsmegler/[slug]/page.tsx
@@ -9,6 +9,7 @@ import StructuredData, {
 import { CtaStrip } from "@/components/site/CtaStrip";
 import { ProseShell } from "@/components/site/ProseShell";
 import { LocationMdx } from "@/components/locations/LocationMdx";
+import { ActiveListingsStrip } from "@/components/eiendommer/ActiveListingsStrip";
 import { siteConfig } from "@/app/siteConfig";
 import { constructMetadata } from "@/lib/utils";
 
@@ -499,6 +500,19 @@ export default async function LocationPage({
           </div>
         </section>
       )}
+
+      <ActiveListingsStrip
+        eyebrow={`Aktuelle oppdrag · ${location.name}`}
+        title={
+          <>
+            Eiendommer vi formidler{" "}
+            <span className="italic">i {location.name}.</span>
+          </>
+        }
+        lede="Pluss off-market-portefølje for kvalifiserte investorer."
+        city={location.slug}
+        limit={3}
+      />
 
       <CtaStrip
         eyebrow={`Næringsmegler i ${location.name}`}

--- a/src/app/tjenester/salg/page.tsx
+++ b/src/app/tjenester/salg/page.tsx
@@ -3,6 +3,7 @@ import { SubHero } from "@/components/site/SubHero";
 import { CtaStrip } from "@/components/site/CtaStrip";
 import { PhotoBand } from "@/components/site/PhotoBand";
 import { Faq, type FaqItem } from "@/components/site/Faq";
+import { ActiveListingsStrip } from "@/components/eiendommer/ActiveListingsStrip";
 import StructuredData, {
   BreadcrumbStructuredData,
 } from "@/components/StructuredData";
@@ -348,8 +349,19 @@ export default function SalgPage() {
         </div>
       </section>
 
+      <ActiveListingsStrip
+        eyebrow="05 — Aktuelle salgsoppdrag"
+        title={
+          <>
+            Eiendommer vi har <span className="italic">til salgs nå.</span>
+          </>
+        }
+        lede="Et utvalg av aktive mandater. Se hele inventaret på /eiendommer."
+        limit={3}
+      />
+
       <Faq
-        eyebrow="05 — Ofte stilte spørsmål"
+        eyebrow="06 — Ofte stilte spørsmål"
         title={
           <>
             Spørsmål om{" "}

--- a/src/components/eiendommer/ActiveListingsStrip.tsx
+++ b/src/components/eiendommer/ActiveListingsStrip.tsx
@@ -1,0 +1,178 @@
+import Image from "next/image";
+import Link from "next/link";
+
+import { getActiveListings } from "@/lib/content";
+
+const STATUS_LABELS: Record<string, string> = {
+  "til-salgs": "Til salgs",
+  reservert: "Reservert",
+  kommer: "Kommer",
+  solgt: "Solgt",
+};
+
+const CITY_LABELS: Record<string, string> = {
+  bodo: "Bodø",
+  tromso: "Tromsø",
+  harstad: "Harstad",
+  alta: "Alta",
+  narvik: "Narvik",
+  lofoten: "Lofoten",
+  "mo-i-rana": "Mo i Rana",
+};
+
+function formatInt(value: number) {
+  return new Intl.NumberFormat("nb-NO").format(value);
+}
+
+function formatDecimal(value: number, max = 1) {
+  return new Intl.NumberFormat("nb-NO", { maximumFractionDigits: max }).format(
+    value,
+  );
+}
+
+interface ActiveListingsStripProps {
+  /** Editorial section eyebrow, e.g. "06 — Aktuelle salgsoppdrag". */
+  eyebrow: string;
+  /** Section heading. */
+  title: React.ReactNode;
+  /** Optional supporting paragraph below the heading. */
+  lede?: string;
+  /** Filter to a specific city slug (bodo|tromso|...). Omit for all cities. */
+  city?: string;
+  /** Filter to a specific listing type (kontor|logistikk|...). */
+  type?: string;
+  /** Max cards to render. Defaults to 3. */
+  limit?: number;
+  /** Bypass the "exclude reservert/solgt" filter — used for archive pages. */
+  includeInactive?: boolean;
+}
+
+/**
+ * Editorial cross-link strip surfacing active eiendommer mandates on
+ * /tjenester/* and /naringsmegler/* pages. Reuses the .ei-card chrome
+ * from advanti-design.css so it visually matches the public listings
+ * grid.
+ */
+export function ActiveListingsStrip({
+  eyebrow,
+  title,
+  lede,
+  city,
+  type,
+  limit = 3,
+  includeInactive = false,
+}: ActiveListingsStripProps) {
+  const all = getActiveListings();
+  const filtered = all.filter((listing) => {
+    if (!includeInactive && listing.status === "solgt") return false;
+    if (city && listing.city !== city) return false;
+    if (type && listing.type !== type) return false;
+    return true;
+  });
+  // Featured first, then the rest by order.
+  const sorted = filtered.sort((a, b) => {
+    if (a.featured && !b.featured) return -1;
+    if (!a.featured && b.featured) return 1;
+    return a.order - b.order;
+  });
+  const cards = sorted.slice(0, limit);
+
+  if (cards.length === 0) return null;
+
+  return (
+    <section className="section section-divider">
+      <div className="wrap">
+        <div className="head-compact">
+          <span className="eyebrow">{eyebrow}</span>
+          <div>
+            <h2>{title}</h2>
+            {lede && <p>{lede}</p>}
+          </div>
+        </div>
+
+        <div className="ei-grid" style={{ marginTop: 40 }}>
+          {cards.map((listing) => {
+            const cityLabel = CITY_LABELS[listing.city] ?? listing.city;
+            const statusLabel =
+              listing.statusLabel ??
+              STATUS_LABELS[listing.status] ??
+              listing.status;
+            return (
+              <Link
+                key={listing.slug}
+                href={`/eiendommer/${listing.slug}`}
+                className="ei-card"
+              >
+                <div className="ei-card-photo">
+                  <Image
+                    src={listing.coverImage}
+                    alt={listing.coverImageAlt}
+                    fill
+                    sizes="(max-width: 680px) 100vw, (max-width: 980px) 50vw, 33vw"
+                    style={{ objectFit: "cover" }}
+                  />
+                  <div className={`ei-status ${listing.status}`}>
+                    <span className="dot" />
+                    {statusLabel}
+                  </div>
+                </div>
+                <div className="top">
+                  <span>{listing.cardEyebrow}</span>
+                  <span>{cityLabel}</span>
+                </div>
+                <div>
+                  <h3>
+                    {listing.titleHead}{" "}
+                    <span className="italic">{listing.titleTail}</span>
+                  </h3>
+                  <p className="addr">{listing.address}</p>
+                </div>
+                <div className="stat-row">
+                  <div>
+                    <div className="l">BTA</div>
+                    <div className="v">
+                      {formatInt(listing.bta)}
+                      <span className="unit">m²</span>
+                    </div>
+                  </div>
+                  <div>
+                    <div className="l">
+                      {listing.ferdig ? "Ferdig" : "Prisant."}
+                    </div>
+                    <div className="v">
+                      {listing.ferdig ??
+                        (listing.prisantydning !== undefined
+                          ? `${listing.prisantydningEstimat ? "est. " : ""}${formatInt(listing.prisantydning)}`
+                          : "—")}
+                      {!listing.ferdig &&
+                        listing.prisantydning !== undefined && (
+                          <span className="unit">mnok</span>
+                        )}
+                    </div>
+                  </div>
+                  <div>
+                    <div className="l">Yield</div>
+                    <div className="v">
+                      {listing.yieldNetto !== undefined
+                        ? `${listing.yieldEstimat ? "est. " : ""}${formatDecimal(listing.yieldNetto, 1).replace(".", ",")}`
+                        : "—"}
+                      {listing.yieldNetto !== undefined && (
+                        <span className="unit">%</span>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              </Link>
+            );
+          })}
+        </div>
+
+        <div style={{ marginTop: 40, textAlign: "center" }}>
+          <Link href="/eiendommer" className="btn btn-outline">
+            Se alle aktive oppdrag <span className="arrow">→</span>
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/og/ListingCard.tsx
+++ b/src/components/og/ListingCard.tsx
@@ -1,0 +1,352 @@
+// Listing OG card (1200×630). Renders a commercial-RE listing for social
+// previews — price, yield, BTA and status badge over a dark editorial layout.
+// Mirrors the EditorialCard chrome (logo + hairline + author rail) but swaps
+// the bottom rail for the stat strip that makes a CRE listing click-worthy
+// when dropped in LinkedIn/WhatsApp/Slack.
+//
+// Satori-safe: flex only, inline styles, no CSS shorthand for background, all
+// colour values as full strings.
+
+const WARM_GREY = "#2c2825";
+const WARM_WHITE = "#f3f1ef";
+const LIGHT_BLUE = "#cbeef2";
+const FADE_72 = "rgba(243, 241, 239, 0.72)";
+const FADE_55 = "rgba(243, 241, 239, 0.55)";
+const FADE_40 = "rgba(243, 241, 239, 0.40)";
+const HAIRLINE = "rgba(243, 241, 239, 0.18)";
+
+export type ListingCardProps = {
+  title: string;
+  address: string;
+  reference: string;
+  status: "til-salgs" | "reservert" | "kommer" | "solgt";
+  statusLabel: string;
+  stats: {
+    bta: string;       // e.g. "11 400 m²"
+    headline: string;  // "425 mnok" | "Q3 2027" | "—"
+    headlineLabel: string; // "Prisantydning" | "Ferdigstilles"
+    yield: string;     // e.g. "5,9 %"
+  };
+  typeLabel: string;   // e.g. "Kontor · Tromsø"
+};
+
+// Title font-size selection — Satori can't measure text, so approximate by
+// character count. Listing titles are typically longer than blog ("Sjøgata 7
+// — kontortårn ved havna." vs "DCF-Analyse for Næringseiendom"), so the
+// curve starts smaller.
+function titleFontSize(title: string): number {
+  const len = title.length;
+  if (len <= 28) return 72;
+  if (len <= 44) return 60;
+  if (len <= 60) return 52;
+  if (len <= 80) return 44;
+  return 38;
+}
+
+function Logo() {
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "baseline",
+        color: WARM_WHITE,
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          width: 12,
+          height: 12,
+          backgroundColor: LIGHT_BLUE,
+          borderRadius: 9999,
+          marginRight: 10,
+          transform: "translateY(-2px)",
+        }}
+      />
+      <div
+        style={{
+          display: "flex",
+          fontFamily: "Newsreader",
+          fontWeight: 600,
+          fontSize: 28,
+          letterSpacing: "-0.01em",
+        }}
+      >
+        Advanti.
+      </div>
+      <div
+        style={{
+          display: "flex",
+          fontFamily: "Inter",
+          fontWeight: 400,
+          fontSize: 12,
+          letterSpacing: "0.22em",
+          color: FADE_55,
+          textTransform: "uppercase",
+          marginLeft: 10,
+        }}
+      >
+        Estate
+      </div>
+    </div>
+  );
+}
+
+function StatusBadge({
+  status,
+  label,
+}: {
+  status: ListingCardProps["status"];
+  label: string;
+}) {
+  // Brown for reservert (#f4ecdc/#6e5418), dark for solgt, accent for active.
+  const styles: Record<
+    ListingCardProps["status"],
+    { bg: string; color: string; dotBg: string; border: string }
+  > = {
+    "til-salgs": {
+      bg: WARM_WHITE,
+      color: WARM_GREY,
+      dotBg: LIGHT_BLUE,
+      border: "transparent",
+    },
+    reservert: {
+      bg: "#f4ecdc",
+      color: "#6e5418",
+      dotBg: "#c89327",
+      border: "transparent",
+    },
+    kommer: {
+      bg: "transparent",
+      color: WARM_WHITE,
+      dotBg: FADE_55,
+      border: HAIRLINE,
+    },
+    solgt: {
+      bg: WARM_GREY,
+      color: WARM_WHITE,
+      dotBg: FADE_55,
+      border: HAIRLINE,
+    },
+  };
+  const s = styles[status];
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        backgroundColor: s.bg,
+        color: s.color,
+        border: `1px solid ${s.border}`,
+        padding: "10px 16px",
+        fontFamily: "Inter",
+        fontSize: 13,
+        fontWeight: 500,
+        letterSpacing: "0.14em",
+        textTransform: "uppercase",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          width: 8,
+          height: 8,
+          borderRadius: 9999,
+          backgroundColor: s.dotBg,
+          marginRight: 10,
+        }}
+      />
+      {label}
+    </div>
+  );
+}
+
+function Eyebrow({ text }: { text: string }) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        color: LIGHT_BLUE,
+        fontFamily: "Inter",
+        fontSize: 14,
+        fontWeight: 500,
+        letterSpacing: "0.18em",
+        textTransform: "uppercase",
+      }}
+    >
+      <div
+        style={{
+          width: 28,
+          height: 1,
+          backgroundColor: LIGHT_BLUE,
+          marginRight: 14,
+        }}
+      />
+      {text}
+    </div>
+  );
+}
+
+function StatCell({
+  label,
+  value,
+  borderLeft,
+}: {
+  label: string;
+  value: string;
+  borderLeft?: boolean;
+}) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        flex: 1,
+        paddingLeft: borderLeft ? 32 : 0,
+        borderLeft: borderLeft ? `1px solid ${HAIRLINE}` : "none",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          fontFamily: "Inter",
+          fontWeight: 500,
+          fontSize: 12,
+          color: FADE_55,
+          letterSpacing: "0.14em",
+          textTransform: "uppercase",
+          marginBottom: 12,
+        }}
+      >
+        {label}
+      </div>
+      <div
+        style={{
+          display: "flex",
+          fontFamily: "Newsreader",
+          fontWeight: 400,
+          fontSize: 38,
+          color: WARM_WHITE,
+          letterSpacing: "-0.012em",
+          lineHeight: 1,
+        }}
+      >
+        {value}
+      </div>
+    </div>
+  );
+}
+
+export function ListingCard(props: ListingCardProps) {
+  const fontSize = titleFontSize(props.title);
+
+  return (
+    <div
+      style={{
+        width: "100%",
+        height: "100%",
+        backgroundColor: WARM_GREY,
+        color: WARM_WHITE,
+        padding: "56px 72px",
+        display: "flex",
+        flexDirection: "column",
+        justifyContent: "space-between",
+        fontFamily: "Inter",
+      }}
+    >
+      {/* TOP: logo (left) + status badge (right) */}
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+        }}
+      >
+        <Logo />
+        <StatusBadge status={props.status} label={props.statusLabel} />
+      </div>
+
+      {/* MIDDLE: eyebrow + title + address */}
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          maxWidth: 1056,
+        }}
+      >
+        <div style={{ display: "flex", marginBottom: 22 }}>
+          <Eyebrow text={`${props.typeLabel} · ${props.reference}`} />
+        </div>
+        <div
+          style={{
+            display: "flex",
+            fontFamily: "Newsreader",
+            fontWeight: 400,
+            fontSize,
+            lineHeight: 1.02,
+            letterSpacing: "-0.024em",
+            color: WARM_WHITE,
+          }}
+        >
+          {props.title}
+        </div>
+        <div
+          style={{
+            display: "flex",
+            marginTop: 18,
+            fontFamily: "Newsreader",
+            fontStyle: "italic",
+            fontWeight: 300,
+            fontSize: 22,
+            color: FADE_72,
+          }}
+        >
+          {props.address}
+        </div>
+      </div>
+
+      {/* BOTTOM: hairline + stat strip (BTA · price · yield) */}
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          borderTop: `1px solid ${HAIRLINE}`,
+          paddingTop: 28,
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "stretch",
+          }}
+        >
+          <StatCell label="BTA" value={props.stats.bta} />
+          <StatCell
+            label={props.stats.headlineLabel}
+            value={props.stats.headline}
+            borderLeft
+          />
+          <StatCell label="Yield" value={props.stats.yield} borderLeft />
+          <div
+            style={{
+              display: "flex",
+              alignItems: "flex-end",
+              fontFamily: "Newsreader",
+              fontStyle: "italic",
+              fontWeight: 300,
+              fontSize: 18,
+              color: FADE_40,
+              paddingLeft: 32,
+              borderLeft: `1px solid ${HAIRLINE}`,
+            }}
+          >
+            advantiestate.no
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/content/listings/sjogata-7-tromso.mdx
+++ b/src/content/listings/sjogata-7-tromso.mdx
@@ -30,7 +30,7 @@ gallery:
   - src: "/building/pexels-abshky-18567185.jpg"
     alt: "Kontorlandskap, 4. etasje"
 photoCount: 18
-summary: "Et av Tromsøs mest sentralt beliggende kontorbygg, ferdigstilt 2017. 94 % utleid på lange leiekontrakter til offentlig og privat sektor. Vektet gjenværende leieperiode 6,2 år."
+summary: "BREEAM-sertifisert kontortårn på 11 400 m² ved Tromsø havn. 94 % utleid på vektet 6,2 år til offentlig og privat sektor. Yield 5,9 %, prisantydning 425 mnok."
 lede: "Et av Tromsøs mest sentralt beliggende kontorbygg — direkte på havna, fem minutters gange fra Storgata og Tromsø domkirke."
 megler:
   name: "Håvard Antonsen"

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -134,6 +134,7 @@ export function constructMetadata({
   title = SITE_TITLE_FALLBACK,
   description = SITE_DESCRIPTION_FALLBACK,
   image = OG_IMAGE_DEFAULT,
+  imageAlt,
   noIndex = false,
   ogType = "website",
   publishedTime,
@@ -149,6 +150,10 @@ export function constructMetadata({
    *  route at /api/og/brand. Per-article routes (e.g. blog posts) pass
    *  their own URL like /api/og/blog/<slug> to override. */
   image?: string;
+  /** Optional alt text for the OG image. Falls back to OG_IMAGE_ALT (the
+   *  site-wide brand alt) when omitted. Pages with a per-asset OG card
+   *  (blog posts, listings) should pass their content-specific alt. */
+  imageAlt?: string;
   noIndex?: boolean;
   ogType?: "website" | "article";
   /** ISO date — only used when ogType is "article". */
@@ -163,7 +168,12 @@ export function constructMetadata({
   const metaDescription = normalizeMetaDescription(description);
   const canonicalUrl = `${siteConfig.url}${path}`;
   const ogImages = [
-    { url: image, width: 1200, height: 630, alt: OG_IMAGE_ALT },
+    {
+      url: image,
+      width: 1200,
+      height: 630,
+      alt: imageAlt ?? OG_IMAGE_ALT,
+    },
   ];
 
   // Build openGraph as one literal per type so TypeScript narrows it to the


### PR DESCRIPTION
## Summary

Follow-up to #12 (eiendommer listings feature). The SEO audit found 8 gaps; this PR ships all of them.

**OG / share previews (S1, S4, S7)**
- New `/api/og/listing/[slug]` route renders an editorial-dark 1200×630 card with logo, status badge, eyebrow (type · city · ref), title, address, and a BTA/price/yield stat strip — replaces the raw building photo when a listing URL is shared in LinkedIn, Slack or WhatsApp
- `constructMetadata` now accepts `imageAlt` so listings can pass their own `coverImageAlt` ("Sjøgata 7 — fasade mot havna") instead of the site-wide fallback
- Drop " | Advanti Estate" brand suffix from detail-page titles — listing titles already pack address + m² + headline into ~50 chars; appending the brand pushed most past Google's SERP truncation at 60. `og:site_name` + canonical already carry the brand.

**AI search visibility (S2)**
- `/llms.txt` gets a `## Eiendommer for salg` section listing all 9 non-sold mandates with summary lines. Same content-collection driver as `sitemap.ts`, so the inventory shown to AI engines cannot drift from the public site.

**Structured data (S3, S6)**
- `ItemList` JSON-LD on the index, each item a positioned `RealEstateListing` linked to the detail page's @id via fragment identifier — Google + AI Overviews can extract the property inventory as a structured list instead of parsing rendered HTML
- `Service` JSON-LD on the index matching the `/tjenester/*` pattern (listings index is a brokerage service surface)

**Content differentiation (S8)**
- Sjøgata 7's `summary` rewritten as a data-dense one-liner ("BREEAM-sertifisert kontortårn på 11 400 m² ved Tromsø havn. 94 % utleid på vektet 6,2 år til offentlig og privat sektor. Yield 5,9 %, prisantydning 425 mnok") so the SEO meta and the on-page lede serve different audiences

**Internal linking (S5)**
- New `<ActiveListingsStrip>` component renders 3 active mandates on `/tjenester/salg` and on every `/naringsmegler/[slug]` city page (filtered to that city). Funnel benefit: visitors on high-intent service / location pages no longer need to discover `/eiendommer` through nav.

## Validation

- `pnpm build` clean
- `/api/og/listing/sjogata-7-tromso` returns 200 PNG 1200×630 (verified visually)
- `og:image:alt` = "Sjøgata 7 — fasade mot havna" on detail page
- `<title>` = "Sjøgata 7, Tromsø — 11 400 m² kontortårn til salgs" (51 chars, fits SERP)
- `/llms.txt` `## Eiendommer for salg` section renders with 9 entries
- `/eiendommer` HTML contains `@type:ItemList` (numberOfItems: 9) + `@type:Service`
- `/naringsmegler/tromso` strip renders exactly the 3 Tromsø listings
- `/tjenester/salg` strip renders featured + 2 active mandates

## Test plan

- [x] Build green, all 9 listing detail pages SSG'd
- [x] OG image renders correctly for Sjøgata 7 (status badge, stats, address, eyebrow all populated)
- [x] llms.txt validates against llmstxt.org spec (still passes — only added a new H2)
- [x] ItemList JSON-LD parses + matches schema.org
- [x] Service JSON-LD parses + matches schema.org
- [x] Active listings strip city filter verified on /naringsmegler/tromso
- [x] No breaking changes to other pages using `constructMetadata` (imageAlt is optional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)