### PR TITLE
fix(eiendommer): mobile responsive pass (M1-M4)

### DIFF
--- a/src/styles/advanti-design.css
+++ b/src/styles/advanti-design.css
@@ -4308,6 +4308,19 @@ h1, h2, h3 {
 .ei-filter-result strong { color: var(--warm-grey); font-weight: 500; }
 @media (max-width: 880px) {
   .ei-filter { position: relative; top: 0; }
+  /* Stack filter groups vertically so STATUS / TYPE / BY each get their
+     own row at mobile, and allow chips inside each group to wrap when
+     5+ chips exceed viewport width. Otherwise the chip row overflows
+     horizontally (status: 5 × ~90px = ~500px > 390px viewport). */
+  .ei-filter .wrap {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 14px;
+  }
+  .ei-filter-group {
+    flex-wrap: wrap;
+    width: 100%;
+  }
   .ei-filter-result { margin-left: 0; width: 100%; }
 }
 
@@ -4697,9 +4710,32 @@ h1, h2, h3 {
 }
 @media (max-width: 720px) {
   .ei-offmarket .head { grid-template-columns: 1fr; gap: 32px; }
-  .ei-offmarket-row { grid-template-columns: 1fr 28px; gap: 8px; }
-  .ei-offmarket-row > .col-hide-m { display: none; }
-  .ei-offmarket-row .title { font-size: 18px; }
+  /* Stack each row as a vertical card: ref + title + label-inline-value
+     meta rows. The 7-column desktop grid collapsing to 1fr 28px clipped the
+     title horizontally and pushed the type/BTA/status cells onto a chaotic
+     second row. flex-column lets the row breathe and keeps each
+     label-value pair inline for scan rhythm. */
+  .ei-offmarket-row {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding: 22px 0;
+  }
+  .ei-offmarket-row:hover { transform: none; padding-left: 0; }
+  .ei-offmarket-row > .col-hide,
+  .ei-offmarket-row > .col-hide-m { display: flex; }
+  .ei-offmarket-row > div {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+  }
+  .ei-offmarket-row .cell-l {
+    margin-bottom: 0;
+    min-width: 80px;
+  }
+  .ei-offmarket-row .cell-v { font-size: 15px; }
+  .ei-offmarket-row .title { font-size: 19px; }
+  .ei-offmarket-row .arr { display: none; }
 }
 
 /* Saved-search / alert strip */
@@ -4957,8 +4993,16 @@ h1, h2, h3 {
 }
 @media (max-width: 560px) {
   .ed-stats { grid-template-columns: 1fr 1fr; }
-  .ed-stats > div { border-right: var(--hairline); border-bottom: var(--hairline); }
+  .ed-stats > div {
+    border-right: var(--hairline);
+    border-bottom: var(--hairline);
+    padding: 18px 12px;
+  }
   .ed-stats > div:nth-child(2n) { border-right: 0; }
+  /* Cap value font so the 5-stat row doesn't overflow a 2-col grid at
+     390px — "11 400 m²" at 32px overran its cell on the narrow column. */
+  .ed-stats .v { font-size: 26px; }
+  .ed-stats .l { font-size: 10.5px; letter-spacing: 0.12em; }
 }
 
 /* Editorial body */
@@ -5225,6 +5269,21 @@ h1, h2, h3 {
   .ed-tenants tbody .col-hide { display: none; }
   .ed-tenants .name { font-size: 16px; }
   .ed-tenants .v { font-size: 15px; }
+}
+/* Phone (≤560px): 5 columns clip even after col-hide removes 2.
+   Drop Etasjer too — leaves Leietaker, Areal, Årlig leie, Andel.
+   Andel bar collapses to text so the percent number isn't crowded. */
+@media (max-width: 560px) {
+  .ed-tenants thead th:nth-child(2),
+  .ed-tenants tbody td:nth-child(2) { display: none; }
+  .ed-tenants thead th,
+  .ed-tenants tbody td { padding-right: 8px; padding-left: 12px; }
+  .ed-tenants thead th:first-child,
+  .ed-tenants tbody td:first-child { padding-left: 0; }
+  .ed-tenants .bar { display: none; }
+  .ed-tenants .v { font-size: 14px; }
+  .ed-tenants .name { font-size: 15px; }
+  .ed-tenants .sector { font-size: 10px; letter-spacing: 0.1em; }
 }
 
 /* Financials (dark KPI grid) */


### PR DESCRIPTION
## Summary

Mobile QA on the live /eiendommer pages turned up 4 responsive bugs. User-reported example: the off-market row collapsed to "OM-241 / Hotell- og konferanseanlegg i Lofoten. / Type / Hotell" with title clipping and labels stacked above values.

All 4 fixed in one commit (all CSS-only, all in `advanti-design.css`).

## Fixes

| ID | Issue | Fix |
|---|---|---|
| **M1** (HIGH, user-reported) | Off-market row chaotic at ≤720px — 7-col grid → 1fr+28px clipped title and stacked type/BTA/status onto a confusing second row | Flex-column card layout: REF top, title, then each meta cell as a label-inline-value row. Arrow hidden (whole card is the tap target) |
| **M2** (HIGH) | Filter chips overflowed horizontally at ≤880px — Status/Type/City groups each ~500px wide on a 390px viewport | Stack filter groups vertically, allow chips to wrap within each group |
| **M3** (MEDIUM) | Detail page stats grid "PRISANTYDNING" cell clipped at ≤560px — 32px value font overran 171px column | Cap value font to 26px, tighten cell padding 18×12 |
| **M4** (MEDIUM) | Tenants table clipped right columns at ≤560px — 5 visible columns too cramped | Hide Etasjer too, drop utilization bar (keep percentage), tighten padding |

## Validation

Verified locally at 390x844 (iPhone 14 Pro):
- Off-market row renders as a clean vertical card with each label-value pair inline
- Filter bar: STATUS / TYPE / BY each on their own row, chips wrap to 2 rows where needed
- Detail stats: 2×3 grid, no overflow on any cell
- Tenants table: 4 visible columns (Leietaker / Areal / Årlig leie / Andel), all readable

Before/after screenshots at `/tmp/advanti-mobile-20260525/` and `/tmp/advanti-mobile-after/`.

## Test plan

- [x] `pnpm build` clean (1 CSS file changed, no logic)
- [x] /eiendommer renders cleanly at 390px (off-market + filter both verified)
- [x] /eiendommer/sjogata-7-tromso renders cleanly at 390px (stats + tenants verified)
- [x] Desktop 1440px unchanged — all media queries are `max-width` so the new rules don't fire above the breakpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)