### PR TITLE
style(eiendommer): drop sticky filter bar

### DIFF
--- a/src/styles/advanti-design.css
+++ b/src/styles/advanti-design.css
@@ -4234,14 +4234,14 @@ h1, h2, h3 {
    Ported from design handoff "Advanti Estate CRM" 2026-05-25.
    ============================================================ */
 
-/* Filter bar — sticky under the fixed nav */
+/* Filter bar — static, sits once at the top of the listings grid.
+   The sticky variant was load-bearing only as long as we wanted the
+   filter to follow the user past the grid; in practice the grid is
+   short enough that scrolling back to filter is fine, and the
+   translucent-light bar floating over the dark off-market band was
+   never going to be fully solved. */
 .ei-filter {
-  position: sticky;
-  top: 80px;
-  z-index: 20;
-  background: rgba(243, 241, 239, 0.92);
-  backdrop-filter: blur(14px);
-  -webkit-backdrop-filter: blur(14px);
+  background: var(--warm-white);
   border-top: var(--hairline);
   border-bottom: var(--hairline);
   padding: 18px 0;
@@ -4307,7 +4307,6 @@ h1, h2, h3 {
 }
 .ei-filter-result strong { color: var(--warm-grey); font-weight: 500; }
 @media (max-width: 880px) {
-  .ei-filter { position: relative; top: 0; }
   /* Stack filter groups vertically so STATUS / TYPE / BY each get their
      own row at mobile, and allow chips inside each group to wrap when
      5+ chips exceed viewport width. Otherwise the chip row overflows


### PR DESCRIPTION
## Summary

Remove `position: sticky` from `.ei-filter` so the filter bar sits once at the top of the listings grid and scrolls away with the rest of the page.

The sticky variant was load-bearing only as long as we wanted the filter to follow the user past the grid. In practice the inventory is short (9 listings), scrolling back to filter is trivial, and the translucent-light bar floating over photo cards / the dark off-market band felt heavier than the editorial design wants.

## Change

One block in `advanti-design.css`:

- Drop `position: sticky; top: 80px; z-index: 20;`
- Drop the translucent `rgba(243, 241, 239, 0.92)` background + `backdrop-filter: blur(14px)`
- Background simplifies to solid `var(--warm-white)`
- Mobile override's redundant `position: relative; top: 0` removed (default is now static)

The hairline-bordered look + 18px padding stays.

## Validation

- `pnpm build` clean
- Computed `position` on `.ei-filter` = `static` (verified via DOM)
- Scrolling past the grid into the off-market band no longer shows the filter floating on top

## Test plan

- [x] `pnpm build` green
- [x] Filter bar renders once at the top of `/eiendommer`, scrolls away as expected
- [x] Off-market band no longer has anything floating over it
- [x] Mobile rendering unchanged (was already non-sticky)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the visual presentation of the listings filter bar by changing its appearance from a floating translucent bar to a static bar with a solid background, enhancing clarity across all devices.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Codehagen/advantiestate/pull/15?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->