### PR TITLE
fix(eiendommer): detail-page mobile pass (M5-M6)

### DIFF
--- a/src/app/eiendommer/[slug]/page.tsx
+++ b/src/app/eiendommer/[slug]/page.tsx
@@ -510,16 +510,7 @@ export default async function EiendomDetailPage({
       {listing.financials && (
         <section className="ed-fin">
           <div className="wrap">
-            <div
-              className="head"
-              style={{
-                display: "grid",
-                gridTemplateColumns: "280px 1fr",
-                gap: 48,
-                marginBottom: 48,
-                alignItems: "end",
-              }}
-            >
+            <div className="head">
               <div>
                 <div className="pre">03 · Økonomi</div>
               </div>

--- a/src/styles/advanti-design.css
+++ b/src/styles/advanti-design.css
@@ -4943,6 +4943,16 @@ h1, h2, h3 {
 @media (max-width: 880px) {
   .ed-title { grid-template-columns: 1fr; gap: 24px; }
   .ed-title-actions { align-items: flex-start; }
+  /* Address row stacks vertically on mobile — the 1×14px separator pipe
+     between "Tromsø" and "Ref. AE-2026-014" wrapped to its own line under
+     flex-wrap, looking like a lost glyph. Hide the pipe, drop gap to 0,
+     let each line sit on its own row. */
+  .ed-title .addr {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 6px;
+  }
+  .ed-title .addr .sep { display: none; }
 }
 
 /* Headline stats */
@@ -5290,6 +5300,20 @@ h1, h2, h3 {
   background: var(--warm-grey);
   color: var(--warm-white);
   padding: 80px 0;
+}
+/* Match the .ed-section .head two-column grid + mobile collapse so the
+   financials head doesn't need a brittle inline style. The detail-page
+   page.tsx previously hardcoded `gridTemplateColumns: "280px 1fr"` which
+   gave the H2 a 62px column at 390px and clipped "Forventet kontantstrøm" */
+.ed-fin .head {
+  display: grid;
+  grid-template-columns: 280px 1fr;
+  gap: 48px;
+  margin-bottom: 48px;
+  align-items: end;
+}
+@media (max-width: 880px) {
+  .ed-fin .head { grid-template-columns: 1fr; gap: 16px; }
 }
 .ed-fin .head h2 { color: var(--warm-white); }
 .ed-fin .head .pre {


### PR DESCRIPTION
## Summary

Mobile QA of the eiendommer detail page (`/eiendommer/sjogata-7-tromso`) at 390×844 turned up 2 bugs after the M1-M4 pass cleaned up the index. Both fixed:

**M5 — Financials section head clipped horizontally at mobile**
`.ed-fin .head` had an inline `gridTemplateColumns: "280px 1fr"` style that didn't collapse on small viewports. At 390px the H2 column got 62px which truncated "Forventet kontantstrøm" mid-word and stretched the intro paragraph into a 9-row sliver. Moved the grid to a CSS rule on `.ed-fin .head` (mirroring `.ed-section .head` including the existing `≤880px → 1fr` collapse), removed the inline style.

**M6 — Title address row floating pipe at mobile**
`.ed-title .addr` used `flex-wrap: wrap` for desktop responsiveness. On mobile the small `<span class="sep">|</span>` divider wrapped to its own row before "Ref. AE-2026-014", looking like an orphaned glyph. Stack the address vertically (`flex-direction: column`) and hide the separator at ≤880px.

## Validation

Local screenshots at 390px confirm:
- Økonomi section header renders "Forventet kontantstrøm og avkastning." cleanly with the intro paragraph wrapping naturally
- Title address stacks: "Sjøgata 7 · 9008 Tromsø" / "Ref. AE-2026-014" / "Oppdatert 22. mai 2026" — three clean lines, no floating pipe

## Test plan

- [x] `pnpm build` green
- [x] Detail page at 390px: financials head no longer clips
- [x] Detail page at 390px: address row stacks vertically
- [x] Desktop 1440px unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)