### PR TITLE
feat: editorial MDX blog components (.ae-*)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,11 @@ SUPABASE_URL=
 # IMPORTANT: service_role key (server-side only, bypasses RLS). NEVER the
 # anon key. NEVER expose this in client code, public env vars, or git.
 SUPABASE_SERVICE_ROLE_KEY=
+# Public values — safe to expose client-side. Needed for Supabase Storage CDN
+# images (public `imagebank` bucket) and any client-side Supabase SDK use.
+NEXT_PUBLIC_SUPABASE_URL=
+# Modern publishable key (sb_publishable_...). Replaces the legacy anon key.
+NEXT_PUBLIC_SUPABASE_ANON_KEY=
 
 # ─── Discord (team-side lead notifications) ────────────────────────────────────
 # Webhook for the team's lead-flow channel. Already in use by /sjekkliste-

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,7 +119,7 @@ Path alias: `@/*` → `src/*`. Content collections alias: `content-collections`
 | Need to add… | Put it in |
 |---|---|
 | New service page | `src/app/tjenester/<slug>/page.tsx` (static, not dynamic route) |
-| New blog post | `src/content/blog/<slug>.mdx` with full frontmatter |
+| New blog post | `src/content/blog/<slug>.mdx` with full frontmatter; follow `src/content/blog/AUTHORING.md` (use the `.ae-*` editorial components) |
 | New help article | `src/content/help/<slug>.mdx` (incl. `updatedAt`) |
 | New location | `src/content/locations/<city>.mdx` (drives `/naringsmegler/<city>`) |
 | New chart | `src/components/markedsinnsikt/charts/` (Recharts) or `src/components/advanti/` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,7 +190,7 @@ Remote image patterns allowed:
 ## Development Workflow
 
 1. **Adding New Service Pages**: Create under `src/app/tjenester/[service-name]/page.tsx`
-2. **Creating Blog Content**: Add MDX files to `src/content/blog/` with required frontmatter (title, categories, publishedAt, image, author, summary)
+2. **Creating Blog Content**: Add MDX files to `src/content/blog/` with required frontmatter (title, categories, publishedAt, image, author, summary). Follow the editorial component patterns in [`src/content/blog/AUTHORING.md`](./src/content/blog/AUTHORING.md) — use the `.ae-*` components (`Summary`, `Fact`, `StatStrip`, `Compare`, `Note`, …) instead of bold-label lists.
 3. **Building Charts**: Extend chart components in `src/components/` using existing patterns (DcfChart, and the Recharts charts in `src/components/markedsinnsikt/charts/`)
 4. **Map Features**: Use the Leaflet map components in `src/components/markedsinnsikt/maps/` (client-only, CartoDB tiles)
 5. **Market Analysis**: Components in `src/components/markedsinnsikt/`

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -153,6 +153,41 @@ OPPDRAG archive · BLOG
 
 Find the matching banner before adding or changing styles.
 
+### BLOG editorial components — `.ae-*`
+
+The MDX article body (`src/components/blog/mdx.tsx`) renders a family of
+editorial components styled by `.ae-*` classes in the **BLOG** section of
+`advanti-design.css`. They follow the system: hairlines, restrained type,
+numbered labels, accent as a small detail, icon-free. The article wrapper
+carries **`.ks-prose`** (not Tailwind `prose`), so base typography is shared
+across blog, help, kunder, integrasjoner and eiendommer.
+
+| Component (MDX) | Class | Notes |
+|---|---|---|
+| `Note` | `.ae-note[.is-key/.is-caution/.is-positive]` | Variants `neutral·key·caution·positive`; legacy `info·warning·success` accepted. Max one `key` per article. |
+| `Aside` (`Info`) | `.ae-aside` | Margin note. |
+| `Fact` | `.ae-fact[.is-inline]` | Term + definition. |
+| `StatStrip` | `.ae-stat-strip` | Big numerals, hairline-divided. |
+| `Summary` | `.ae-summary` | Numbered I/II/III takeaways. |
+| `Stepper` | `.ae-stepper` | Numbered steps. |
+| `Example` | `.ae-example` | Calculation table; `isResult` row emphasized. |
+| `Prerequisites` | `.ae-prereq` | Accepts `items` or markdown `children`. |
+| `Quote` | `.ae-quote` | Editorial pull-quote (accepts legacy customer-quote props). |
+| `CTA` / `AnimatedCTA` | `.ae-cta[.is-light]` | `CTA` = editorial band; `AnimatedCTA` = legacy animated grid (opt-in). |
+| `Math`/`FormulaDisplay`/`Formula` | `.ae-formula[.is-light]` | Dark frame around `KatexMath`; `Formula` is children-based. |
+| `Figure` | `.ae-figure[.is-wide]` | Wraps `ZoomImage`/`BlurImage`. |
+| `Timeline` · `Compare` · `ReadMore` · `Changelog` | `.ae-timeline` · `.ae-compare` · `.ae-readmore` · `.ae-changelog` | |
+
+Two low-chroma support tokens are defined for these components:
+
+| Token | Value | Use |
+|---|---|---|
+| `--ae-caution` | `oklch(0.70 0.055 65)` (muted ochre) | caution **rules** only — never as label text (contrast) |
+| `--ae-positive` | `oklch(0.66 0.045 155)` (muted sage) | positive **rules** only — never as label text |
+
+Authoring patterns (when to use which component, the bold-list → `<Summary>`
+rule) live in [`src/content/blog/AUTHORING.md`](./src/content/blog/AUTHORING.md).
+
 ---
 
 ## 6. Gotchas / patterns

--- a/TODOS.md
+++ b/TODOS.md
@@ -346,3 +346,45 @@ the AI SEO closure review (/plan-eng-review, 2026-05-24), and the AI-SEO researc
   `content-collections.ts` build-config errors scoped out via `@ts-nocheck`),
   `ignoreBuildErrors` flipped to `false`. `next build` now type-checks for real.
 - **Completed:** 2026-05-21 (commit `f63d3b7`, branch `redesign-editorial-port`).
+
+---
+
+## TODO 19 — Migrate the 21 existing blog articles to editorial MDX components
+
+- **What:** Rewrite the existing `src/content/blog/*.mdx` articles to use the new
+  editorial component family (`<Summary>`, `<Fact>`, `<StatStrip>`, `<Compare>`,
+  `<Timeline>`, richer `<Note>` variants) instead of the current plain-markdown
+  `**bold:**` lists.
+- **Why:** The editorial-components PR (/plan-eng-review, 2026-06-03) lands the
+  CSS + wrappers backward-compatibly, but the existing articles still read as flat
+  markdown and barely exercise the new components. The visual upgrade only fully
+  shows once articles adopt the patterns.
+- **Pros:** Articles gain scannable summaries, stat strips, comparison blocks; the
+  `key` callout variant and the editorial rhythm from `AUTHORING.md` come through.
+- **Cons:** Editorial-judgment work (which callouts, which summaries) per article;
+  21 files; content/SEO regression risk if headings or copy shift. Not mechanical.
+- **Context:** Foundation shipped in the editorial-components PR — `.ae-*` classes
+  in `advanti-design.css`, wrappers in `src/components/blog/mdx.tsx`, authoring
+  rulebook at `src/content/blog/AUTHORING.md`. Do this article-by-article post-merge,
+  following the guide. Start with the highest-traffic articles.
+- **Depends on / blocked by:** Editorial-components PR merged first.
+
+---
+
+## TODO 20 — Add the 5 best-practice example articles as live exemplars
+
+- **What:** Publish the 5 handoff example articles (markedspuls-nord-norge-2026,
+  dcf-analyse, kjope-vs-leie, verdivurdering-guide, investere-kontorlokaler) into
+  `src/content/blog/` as on-site rendered references.
+- **Why:** `AUTHORING.md` documents the patterns in prose, but live articles give
+  editors (and Claude Code) a rendered reference to copy from.
+- **Pros:** Concrete, composed exemplars exercising every component cluster.
+- **Cons:** Real published content — needs editorial sign-off and valid
+  `BLOG_CATEGORIES` slugs (invalid category → `notFound()`).
+- **Context / GOTCHA:** Three of the handoff filenames collide with existing
+  article slugs already in `src/content/blog/` (`dcf-analyse-naringseiendom.mdx`,
+  `kjope-vs-leie-naringseiendom.mdx`, `investere-kontorlokaler-nord-norge.mdx`).
+  Dropping them in as-is would overwrite live articles. Rename or merge before
+  publishing. Source files live in the handoff bundle's `best-practice/`.
+- **Depends on / blocked by:** Editorial-components PR merged first; slug-collision
+  resolution.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -117,6 +117,14 @@ const nextConfig = {
         pathname: "/**",
       },
       {
+        // Supabase Storage CDN — public `imagebank` bucket + render/resize
+        // endpoint. Serves https://<ref>.supabase.co/storage/v1/...
+        protocol: "https",
+        hostname: "kukzjreikqbgbolxvqaj.supabase.co",
+        port: "",
+        pathname: "/storage/v1/**",
+      },
+      {
         protocol: "https",
         hostname: "avatar.vercel.sh",
         port: "",

--- a/src/app/(blog)/blog/(post)/[slug]/page.tsx
+++ b/src/app/(blog)/blog/(post)/[slug]/page.tsx
@@ -3,7 +3,6 @@ import { MDX } from "@/components/blog/mdx";
 import ScrollProgress from "@/components/blog/scroll-progress";
 import { CtaStrip } from "@/components/site/CtaStrip";
 import { NewsletterSection } from "@/components/site/NewsletterSection";
-import { ProseShell } from "@/components/site/ProseShell";
 import BlurImage from "@/lib/blog/blur-image";
 import { BLOG_CATEGORIES } from "@/lib/blog/content";
 import { getBlurDataURL } from "@/lib/blog/images";
@@ -258,15 +257,13 @@ export default async function BlogArticle({
 
           <div className="ks-article">
             <article className="ks-art-body">
-              <ProseShell>
-                <MDX
-                  code={data.mdx}
-                  images={images.map((image) => ({
-                    ...image,
-                    alt: data.title,
-                  }))}
-                />
-              </ProseShell>
+              <MDX
+                code={data.mdx}
+                images={images.map((image) => ({
+                  ...image,
+                  alt: data.title,
+                }))}
+              />
 
               {/* Author footer */}
               {authorMeta && (

--- a/src/app/(help)/help/article/[slug]/page.tsx
+++ b/src/app/(help)/help/article/[slug]/page.tsx
@@ -5,7 +5,6 @@ import { notFound } from "next/navigation"
 
 import { CtaStrip } from "@/components/site/CtaStrip"
 import { NewsletterSection } from "@/components/site/NewsletterSection"
-import { ProseShell } from "@/components/site/ProseShell"
 import { MDX } from "@/components/blog/mdx"
 import { HELP_CATEGORIES } from "@/lib/blog/content"
 import { getBlurDataURL } from "@/lib/blog/images"
@@ -227,9 +226,7 @@ export default async function HelpArticle({
                 </div>
               )}
 
-              <ProseShell>
-                <MDX code={data.mdx} images={images} />
-              </ProseShell>
+              <MDX code={data.mdx} images={images} />
 
               {/* Feedback */}
               <div className="ks-feedback">

--- a/src/app/kunder/[slug]/page.tsx
+++ b/src/app/kunder/[slug]/page.tsx
@@ -6,7 +6,6 @@ import { notFound } from "next/navigation";
 
 import { MDX } from "@/components/blog/mdx";
 import { CtaStrip } from "@/components/site/CtaStrip";
-import { ProseShell } from "@/components/site/ProseShell";
 import { getBlurDataURL } from "@/lib/blog/images";
 import { constructMetadata } from "@/lib/utils";
 import { getCustomerPost } from "@/lib/content";
@@ -301,9 +300,7 @@ export default async function CustomerStory({
         <div className="wrap">
           <div className="ks-article">
             <article className="ks-art-body" style={{ maxWidth: 760 }}>
-              <ProseShell>
-                <MDX code={data.mdx} images={images} />
-              </ProseShell>
+              <MDX code={data.mdx} images={images} />
             </article>
 
             {/* SIDEBAR */}

--- a/src/components/blog/mdx.tsx
+++ b/src/components/blog/mdx.tsx
@@ -1,22 +1,16 @@
 "use client"
 
 import { MDXContent } from "@content-collections/mdx/react"
-import {
-  allBlogPosts,
-  allChangelogPosts,
-  allHelpPosts,
-} from "content-collections"
+import { allHelpPosts } from "content-collections"
 import dynamic from "next/dynamic"
 import Link from "next/link"
 
-import BlurImage from "@/lib/blog/blur-image"
 import { HELP_CATEGORIES, POPULAR_ARTICLES } from "@/lib/blog/content"
-import { cx, formatDate } from "@/lib/utils"
+import { cx } from "@/lib/utils"
 
 import CategoryCard from "./category-card"
 import CopyBox from "./copy-box"
 import HelpArticleLink from "./help-article-link"
-import ExpandingArrow from "./icons/expanding-arrow"
 import ZoomImage from "./zoom-image"
 
 // Heavy MDX widgets — loaded on demand via next/dynamic so the ~47 articles
@@ -62,18 +56,289 @@ const CustomLink = (props: any) => {
   return <a target="_blank" rel="noopener noreferrer" {...props} />
 }
 
+/* ============================================================
+   Editorial MDX components (.ae-*) — see DESIGN.md §5 BLOG.
+   Structure comes from the semantic .ae-* classes in
+   advanti-design.css; these wrappers only render the markup.
+   ============================================================ */
+
+/* -- NOTE / CALLOUT ----------------------------------------
+   Backward-compatible variants: the editorial vocabulary is
+   neutral | key | caution | positive, but existing articles
+   use the older info | warning | success — both are accepted
+   and normalized here so nothing breaks. */
+const NOTE_CLASS: Record<string, string> = {
+  neutral: "ae-note",
+  key: "ae-note is-key",
+  caution: "ae-note is-caution",
+  positive: "ae-note is-positive",
+  // legacy aliases
+  info: "ae-note",
+  warning: "ae-note is-caution",
+  success: "ae-note is-positive",
+}
+const NOTE_LABEL: Record<string, string> = {
+  neutral: "Merk",
+  key: "Viktig",
+  caution: "Vær oppmerksom",
+  positive: "Konklusjon",
+  info: "Merk",
+  warning: "Vær oppmerksom",
+  success: "Konklusjon",
+}
+function Note(props: {
+  variant?: string
+  label?: string
+  children: React.ReactNode
+}) {
+  const variant = props.variant ?? "neutral"
+  return (
+    <div className={NOTE_CLASS[variant] ?? "ae-note"}>
+      <span className="ae-label">{props.label ?? NOTE_LABEL[variant] ?? "Merk"}</span>
+      {props.children}
+    </div>
+  )
+}
+
+/* -- ASIDE (also serves the legacy "Info" / Fun fact box) -- */
+function Aside(props: { label?: string; children: React.ReactNode }) {
+  return (
+    <div className="ae-aside">
+      <span className="ae-label">{props.label ?? "Visste du"}</span>
+      {props.children}
+    </div>
+  )
+}
+
+/* -- FACT BOX --------------------------------------------- */
+function Fact(props: {
+  term: React.ReactNode
+  inline?: boolean
+  children: React.ReactNode
+}) {
+  return (
+    <div className={props.inline === false ? "ae-fact" : "ae-fact is-inline"}>
+      <div className="ae-term">{props.term}</div>
+      <div className="ae-def">{props.children}</div>
+    </div>
+  )
+}
+
+/* -- STAT STRIP ------------------------------------------- */
+function StatStrip(props: {
+  items: {
+    value: string
+    unit?: string
+    label: string
+    delta?: { dir: "up" | "down"; text: string }
+  }[]
+}) {
+  return (
+    <div
+      className="ae-stat-strip"
+      style={{ ["--ae-cols" as any]: props.items.length }}
+    >
+      {props.items.map((s, i) => (
+        <div className="ae-stat" key={i}>
+          <div className="ae-val">
+            {s.value}
+            {s.unit && <span className="unit">{s.unit}</span>}
+          </div>
+          <div className="ae-stat-label">{s.label}</div>
+          {s.delta && (
+            <span className={`ae-delta ${s.delta.dir}`}>{s.delta.text}</span>
+          )}
+        </div>
+      ))}
+    </div>
+  )
+}
+
+/* -- SUMMARY GRID ----------------------------------------- */
+const ROMAN = ["I", "II", "III", "IV", "V", "VI", "VII", "VIII"]
+function Summary(props: {
+  title?: React.ReactNode
+  // iconName accepted for backward compat with old articles; ignored.
+  points: { title: string; description?: string; iconName?: string }[]
+}) {
+  return (
+    <div className="ae-summary">
+      {props.title && <div className="ae-summary-head">{props.title}</div>}
+      <div className="ae-grid">
+        {props.points.map((p, i) => (
+          <div className="ae-item" key={i}>
+            <span className="ae-rn">{ROMAN[i] ?? i + 1}</span>
+            <h5>{p.title}</h5>
+            {p.description && <p>{p.description}</p>}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+/* -- STEPPER ---------------------------------------------- */
+function Stepper(props: {
+  items: { title: string; content: React.ReactNode }[]
+}) {
+  return (
+    <div className="ae-stepper">
+      {props.items.map((item, i) => (
+        <div className="ae-step" key={i}>
+          <div className="ae-sn">{i + 1}</div>
+          <div>
+            <h4>{item.title}</h4>
+            <div>{item.content}</div>
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+/* -- EXAMPLE / CALCULATION -------------------------------- */
+function Example(props: {
+  title?: string
+  steps: {
+    label: string
+    value: string | number
+    calculation?: string
+    isResult?: boolean
+  }[]
+}) {
+  const fmt = (v: string | number) =>
+    typeof v === "number" ? new Intl.NumberFormat("nb-NO").format(v) : v
+  return (
+    <div className="ae-example">
+      <div className="ae-ehead">
+        <span className="ae-label">Eksempel</span>
+        {props.title && <h4>{props.title}</h4>}
+      </div>
+      <table>
+        <tbody>
+          {props.steps.map((s, i) => (
+            <tr key={i} className={s.isResult ? "is-result" : undefined}>
+              <td className="ae-elabel">{s.label}</td>
+              {s.calculation && <td className="ae-ecalc">{s.calculation}</td>}
+              <td className="ae-eval">{fmt(s.value)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+/* -- PREREQUISITES ----------------------------------------
+   Backward-compatible: accepts either an `items` array (new
+   editorial API) or `children` (the markdown list used by the
+   existing help articles). */
+function Prerequisites(props: {
+  label?: string
+  items?: React.ReactNode[]
+  children?: React.ReactNode
+}) {
+  return (
+    <div className="ae-prereq">
+      <span className="ae-label">{props.label ?? "Forutsetninger"}</span>
+      {props.items ? (
+        <ul>
+          {props.items.map((it, i) => (
+            <li key={i}>{it}</li>
+          ))}
+        </ul>
+      ) : (
+        props.children
+      )}
+    </div>
+  )
+}
+
+/* -- QUOTE ------------------------------------------------
+   Backward-compatible: the editorial pull-quote takes
+   text / author / role / authorSrc. Existing articles pass the
+   older author / authorSrc / title / company / companySrc / text
+   shape — `title` maps to `role`; the company logo has no slot
+   in the editorial design and is intentionally dropped. */
+function Quote(props: {
+  text: React.ReactNode
+  author?: string
+  role?: string
+  title?: string
+  authorSrc?: string
+  company?: string
+  companySrc?: string
+}) {
+  const role = props.role ?? props.title
+  return (
+    <div className="ae-quote">
+      <div className="ae-q">{props.text}</div>
+      {(props.author || role) && (
+        <div className="ae-cite">
+          {props.authorSrc && (
+            <div
+              className="ae-av"
+              style={{ backgroundImage: `url('${props.authorSrc}')` }}
+            />
+          )}
+          <div className="meta">
+            {props.author && <span className="name">{props.author}</span>}
+            {role && <span className="role">{role}</span>}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+/* -- IN-ARTICLE CTA (editorial) --------------------------- */
+function CTA(props: {
+  badge?: string
+  title: React.ReactNode
+  description?: string
+  primaryAction?: { label: string; href: string }
+  secondaryAction?: { label: string; href: string }
+  light?: boolean
+}) {
+  return (
+    <div className={props.light ? "ae-cta is-light" : "ae-cta"}>
+      {props.badge && <span className="ae-label">{props.badge}</span>}
+      <h4>{props.title}</h4>
+      {props.description && <p>{props.description}</p>}
+      {(props.primaryAction || props.secondaryAction) && (
+        <div className="ae-actions">
+          {props.primaryAction && (
+            <Link
+              className="ae-btn ae-btn-primary"
+              href={props.primaryAction.href}
+            >
+              {props.primaryAction.label} <span aria-hidden>→</span>
+            </Link>
+          )}
+          {props.secondaryAction && (
+            <Link
+              className="ae-btn ae-btn-ghost"
+              href={props.secondaryAction.href}
+            >
+              {props.secondaryAction.label}
+            </Link>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+/* -- AnimatedCTA (legacy animated grid band) --------------
+   Kept as an opt-in component; the default <CTA> is now the
+   editorial band above. Use <AnimatedCTA> when an article
+   wants the animated treatment. */
 function AnimatedCTA(props: {
   badge?: string
   title: string
   description: string
-  primaryAction?: {
-    label: string
-    href: string
-  }
-  secondaryAction?: {
-    label: string
-    href: string
-  }
+  primaryAction?: { label: string; href: string }
+  secondaryAction?: { label: string; href: string }
   size?: "default" | "large"
 }) {
   return (
@@ -125,128 +390,184 @@ function AnimatedCTA(props: {
   )
 }
 
+/* -- FORMULA family ---------------------------------------
+   MathBlock is the editorial dark frame around the existing
+   KatexMath renderer. `Math` and `FormulaDisplay` are the same
+   component (FormulaDisplay was a byte-identical duplicate).
+   `Formula` is the new children-based editorial frame. */
+function MathBlock(props: {
+  formula: string
+  description?: string
+  mode?: "inline" | "block"
+}) {
+  return (
+    <div className="ae-formula">
+      <span className="ae-label">Formel</span>
+      <div className="ae-eq">
+        <KatexMath formula={props.formula} mode={props.mode} />
+      </div>
+      {props.description && <div className="ae-desc">{props.description}</div>}
+    </div>
+  )
+}
+function Formula(props: {
+  description?: string
+  light?: boolean
+  children: React.ReactNode
+}) {
+  return (
+    <div className={props.light ? "ae-formula is-light" : "ae-formula"}>
+      <span className="ae-label">Formel</span>
+      <div className="ae-eq">{props.children}</div>
+      {props.description && <div className="ae-desc">{props.description}</div>}
+    </div>
+  )
+}
+
+/* -- TIMELINE --------------------------------------------- */
+function Timeline(props: {
+  items: { date: string; title: string; body?: React.ReactNode }[]
+}) {
+  return (
+    <div className="ae-timeline">
+      {props.items.map((it, i) => (
+        <div className="ae-tl-item" key={i}>
+          <div className="ae-tl-date">{it.date}</div>
+          <h4>{it.title}</h4>
+          {it.body && <p>{it.body}</p>}
+        </div>
+      ))}
+    </div>
+  )
+}
+
+/* -- COMPARISON ------------------------------------------- */
+function Compare(props: {
+  pro: { head: string; items: React.ReactNode[] }
+  con: { head: string; items: React.ReactNode[] }
+}) {
+  return (
+    <div className="ae-compare">
+      <div className="ae-col is-accent">
+        <div className="ae-col-head">{props.pro.head}</div>
+        <ul>
+          {props.pro.items.map((it, i) => (
+            <li key={i}>{it}</li>
+          ))}
+        </ul>
+      </div>
+      <div className="ae-col is-con">
+        <div className="ae-col-head">{props.con.head}</div>
+        <ul>
+          {props.con.items.map((it, i) => (
+            <li key={i}>{it}</li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  )
+}
+
+/* -- READ MORE -------------------------------------------- */
+function ReadMore(props: {
+  title?: string
+  items: { href: string; pre: string; title: string }[]
+}) {
+  return (
+    <div className="ae-readmore">
+      <div className="ae-rm-head">{props.title ?? "Les videre."}</div>
+      <div className="ae-rm-list">
+        {props.items.map((it, i) => (
+          <Link className="ae-rm-item" href={it.href} key={i}>
+            <div>
+              <div className="ae-rm-pre">{it.pre}</div>
+              <h4>{it.title}</h4>
+            </div>
+            <span className="ae-rm-arrow" aria-hidden>
+              →
+            </span>
+          </Link>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+/* -- CHANGELOG / DATED LINKS ------------------------------ */
+function Changelog(props: {
+  items: { href: string; date: string; title: string; summary?: string }[]
+}) {
+  return (
+    <div className="ae-changelog">
+      {props.items.map((it, i) => (
+        <Link className="ae-cl-item" href={it.href} key={i}>
+          <div className="ae-cl-date">{it.date}</div>
+          <div>
+            <h4>{it.title}</h4>
+            {it.summary && <p>{it.summary}</p>}
+          </div>
+          <span className="ae-rm-arrow" aria-hidden>
+            →
+          </span>
+        </Link>
+      ))}
+    </div>
+  )
+}
+
+/* -- FIGURE -----------------------------------------------
+   Wraps the existing ZoomImage/BlurImage child. */
+function Figure(props: {
+  n?: string
+  caption: React.ReactNode
+  wide?: boolean
+  children: React.ReactNode
+}) {
+  return (
+    <figure className={props.wide ? "ae-figure is-wide" : "ae-figure"}>
+      <div className="ae-img">{props.children}</div>
+      <figcaption>
+        {props.n && <span className="ae-fig-n">{props.n}</span>}
+        <span>{props.caption}</span>
+      </figcaption>
+    </figure>
+  )
+}
+
+// Base markdown (h2/h3/p/ul/table…) intentionally has NO per-element
+// className overrides — typography is inherited from `.ks-prose` on the
+// <article> wrapper so blog, help, kunder, integrasjoner and eiendommer all
+// share one editorial type system. Only the custom components below are mapped.
 const components = {
-  h2: (props: any) => (
-    <h2
-      className="mb-4 mt-8 text-2xl font-semibold text-warm-grey underline-offset-4 hover:underline"
-      {...props}
-    />
+  a: CustomLink,
+  Note,
+  Aside,
+  // Legacy "Info" (Fun fact) box now renders as a margin aside.
+  Info: (props: { children: React.ReactNode }) => (
+    <Aside label="Visste du">{props.children}</Aside>
   ),
-  h3: (props: any) => (
-    <h3
-      className="mb-3 mt-6 text-xl font-medium text-warm-grey underline-offset-4 hover:underline"
-      {...props}
-    />
+  Fact,
+  StatStrip,
+  Summary,
+  Stepper,
+  Example,
+  Prerequisites,
+  Quote,
+  CTA,
+  AnimatedCTA,
+  Math: MathBlock,
+  FormulaDisplay: MathBlock,
+  InlineMath: (props: { formula: string }) => (
+    <span className="mx-1">
+      <KatexMath formula={props.formula} mode="inline" />
+    </span>
   ),
-  a: (props: any) => (
-    <CustomLink
-      className="font-medium text-warm-grey/80 underline underline-offset-4 hover:text-warm-grey"
-      {...props}
-    />
-  ),
-  code: (props: any) => (
-    <code
-      className="rounded-md border border-warm-grey-2/20 bg-warm-grey-2/10 px-2 py-1 font-medium text-warm-grey before:hidden after:hidden"
-      {...props}
-    />
-  ),
-  thead: (props: any) => (
-    <thead className="text-lg text-warm-grey" {...props} />
-  ),
-  th: (props: any) => (
-    <th className="p-4 text-left font-medium text-warm-grey" {...props} />
-  ),
-  td: (props: any) => (
-    <td
-      className="border-t border-warm-grey-2/20 p-4 text-warm-grey/80"
-      {...props}
-    />
-  ),
-  p: (props: any) => (
-    <p
-      className="my-4 text-base leading-relaxed text-warm-grey/80"
-      {...props}
-    />
-  ),
-  li: (props: any) => (
-    <li
-      className="mb-2 text-base leading-relaxed text-warm-grey/80 marker:text-warm-grey/60"
-      {...props}
-    />
-  ),
-  ul: (props: any) => (
-    <ul className="my-2 list-disc space-y-2 pl-6" {...props} />
-  ),
-  ol: (props: any) => (
-    <ol className="my-2 list-decimal space-y-2 pl-6" {...props} />
-  ),
-  Note: (props: {
-    variant?: "info" | "warning" | "success"
-    children: React.ReactNode
-  }) => {
-    return (
-      <div
-        className={cx(
-          "mt-4 rounded-md border-l-4 px-4 py-1 text-[0.95rem] leading-[1.4rem]",
-          {
-            "border-blue-500 bg-blue-500/10": props.variant === "info",
-            "border-yellow-500 bg-yellow-500/10": props.variant === "warning",
-            "border-green-500 bg-green-500/10": props.variant === "success",
-          },
-        )}
-      >
-        <div className="mt-1 flex items-start gap-3">
-          <div className="flex-1 text-warm-grey/80">{props.children}</div>
-        </div>
-      </div>
-    )
-  },
-  Quote: (props: {
-    author: string
-    authorSrc: string
-    title: string
-    company: string
-    companySrc: string
-    text: string
-  }) => (
-    <div className="my-10 flex flex-col items-center justify-center space-y-6 rounded-md border border-warm-grey-2/20 bg-warm-grey-2/10 p-10">
-      <div className="w-fit rounded-full bg-gradient-to-r from-warm-grey-2/20 to-warm-grey-1/20 p-1.5">
-        <BlurImage
-          className="h-20 w-20 rounded-full border-2 border-warm-grey-2/20"
-          src={props.authorSrc}
-          alt={props.author}
-          width={80}
-          height={80}
-        />
-      </div>
-      <p className="text-center text-lg leading-relaxed text-warm-grey/80 [text-wrap:balance]">
-        &ldquo;{props.text}&rdquo;
-      </p>
-      <div className="flex items-center justify-center space-x-4">
-        <BlurImage
-          className="h-12 w-12 rounded-md border-2 border-warm-grey-2/20"
-          src={props.companySrc}
-          alt={props.company}
-          width={48}
-          height={48}
-        />
-        <div className="flex flex-col">
-          <p className="font-semibold text-warm-grey">{props.author}</p>
-          <p className="text-sm text-warm-grey/80">{props.title}</p>
-        </div>
-      </div>
-    </div>
-  ),
-  Prerequisites: (props: { children: React.ReactNode }) => (
-    <div className="my-8 rounded-xl border border-warm-grey-2/20 bg-warm-grey-2/10 p-6 backdrop-blur-sm">
-      <div className="mb-4 flex items-center gap-3">
-        <h4 className="font-display text-lg font-semibold text-warm-grey">
-          Forutsetninger
-        </h4>
-      </div>
-      <div className="prose max-w-none">{props.children}</div>
-    </div>
-  ),
+  Formula,
+  Figure,
+  Timeline,
+  Compare,
+  ReadMore,
+  Changelog,
   CopyBox,
   HelpArticles: (props: { articles: string[] }) => (
     <div className="grid gap-2 rounded-xl border border-warm-grey-2/20 bg-warm-grey-2/10 p-4">
@@ -278,271 +599,6 @@ const components = {
       ))}
     </div>
   ),
-  Changelog: (props: any) => (
-    <ul className="grid list-none rounded-xl border border-warm-grey-2/20 bg-warm-grey-2/10 p-4">
-      {[...allBlogPosts, ...allChangelogPosts]
-        .filter((post) => post.publishedAt <= props.before)
-        .sort((a, b) => b.publishedAt.localeCompare(a.publishedAt))
-        .slice(0, props.count)
-        .map((post: any) => (
-          <li key={post.slug}>
-            <Link
-              href={`/${post.type === "BlogPost" ? "blog" : "changelog"}/${
-                post.slug
-              }`}
-              className="group flex items-center justify-between rounded-lg px-2 py-3 transition-colors hover:bg-warm-grey-2/20 active:bg-warm-grey-2/30 sm:px-4"
-            >
-              <div>
-                <p className="text-xs font-medium text-warm-grey/60 group-hover:text-warm-grey/80">
-                  {formatDate(post.publishedAt)}
-                </p>
-                <h3 className="my-px text-base font-medium text-warm-grey">
-                  {post.title}
-                </h3>
-                <p className="line-clamp-1 text-sm text-warm-grey/80 group-hover:text-warm-grey">
-                  {post.summary}
-                </p>
-              </div>
-              <ExpandingArrow className="-ml-4 h-4 w-4 text-warm-grey/60 group-hover:text-warm-grey/80" />
-            </Link>
-          </li>
-        ))}
-    </ul>
-  ),
-  strong: (props: any) => (
-    <strong className="font-semibold text-warm-grey" {...props} />
-  ),
-  Info: (props: any) => (
-    <div className="my-6 flex items-start gap-4 rounded-lg border border-warm-grey-2/20 bg-warm-grey-2/10 p-6 backdrop-blur-sm">
-      <div className="flex-1 text-[0.95rem] leading-relaxed">
-        <div className="font-medium text-warm-grey">Fun fact:</div>
-        <div className="mt-1 text-warm-grey/80">{props.children}</div>
-      </div>
-    </div>
-  ),
-  Math: (props: {
-    formula: string
-    description?: string
-    mode?: "inline" | "block"
-    className?: string
-  }) => (
-    <div
-      className={cx(
-        "my-6 flex flex-col space-y-2 rounded-lg border border-warm-grey-2/20 bg-warm-grey-2/10 px-6 py-4 backdrop-blur-sm",
-        props.className,
-      )}
-    >
-      <div className="flex items-center gap-3">
-        <div className="text-lg font-medium text-warm-grey">Formel</div>
-      </div>
-      <div className="w-full overflow-x-auto">
-        <div
-          className={cx(
-            "min-w-fit text-center",
-            props.mode === "inline" ? "py-2" : "py-4",
-          )}
-        >
-          <KatexMath formula={props.formula} mode={props.mode} />
-        </div>
-      </div>
-      {props.description && (
-        <p className="text-sm text-warm-grey/70">{props.description}</p>
-      )}
-    </div>
-  ),
-  // For inline math within text
-  InlineMath: (props: { formula: string }) => (
-    <span className="mx-1">
-      <KatexMath formula={props.formula} mode="inline" />
-    </span>
-  ),
-  FormulaDisplay: (props: {
-    formula: string
-    description?: string
-    mode?: "inline" | "block"
-    className?: string
-  }) => (
-    <div
-      className={cx(
-        "my-6 flex flex-col space-y-2 rounded-lg border border-warm-grey-2/20 bg-warm-grey-2/10 px-6 py-4 backdrop-blur-sm",
-        props.className,
-      )}
-    >
-      <div className="flex items-center gap-3">
-        <div className="text-lg font-medium text-warm-grey">Formel</div>
-      </div>
-      <div className="w-full overflow-x-auto">
-        <div
-          className={cx(
-            "min-w-fit text-center",
-            props.mode === "inline" ? "py-2" : "py-4",
-          )}
-        >
-          <KatexMath formula={props.formula} mode={props.mode} />
-        </div>
-      </div>
-      {props.description && (
-        <p className="text-sm text-warm-grey/70">{props.description}</p>
-      )}
-    </div>
-  ),
-  Stepper: (props: {
-    items: {
-      title: string
-      content: React.ReactNode
-      image?: {
-        src: string
-        alt: string
-        width?: number
-        height?: number
-      }
-      formula?: {
-        math: string
-        description?: string
-        mode?: "inline" | "block"
-      }
-    }[]
-  }) => {
-    const MDXImage = (props: any) => {
-      return <ZoomImage {...props} />
-    }
-
-    return (
-      <div className="my-8 flex flex-col space-y-12">
-        {props.items.map((item, idx) => (
-          <div key={idx} className="flex gap-6">
-            <div className="flex-none">
-              <div className="flex h-8 w-8 items-center justify-center rounded-full border border-warm-grey-2/20 bg-warm-grey-2/10 text-lg font-semibold text-warm-grey">
-                {idx + 1}
-              </div>
-            </div>
-            <div className="flex-1 space-y-4">
-              <h3 className="text-xl font-semibold text-warm-grey">
-                {item.title}
-              </h3>
-              <div className="text-base text-warm-grey/80">{item.content}</div>
-              {item.image && (
-                <div className="mt-4 overflow-hidden rounded-lg">
-                  <MDXImage
-                    src={item.image.src}
-                    alt={item.image.alt}
-                    width={item.image.width || 800}
-                    height={item.image.height || 400}
-                  />
-                </div>
-              )}
-              {item.formula && (
-                <div className="mt-4">
-                  <components.FormulaDisplay
-                    formula={item.formula.math}
-                    description={item.formula.description}
-                    mode={item.formula.mode}
-                  />
-                </div>
-              )}
-            </div>
-          </div>
-        ))}
-      </div>
-    )
-  },
-  Example: (props: {
-    title?: string
-    steps: {
-      label: string
-      value: string | number
-      calculation?: string
-      isResult?: boolean
-    }[]
-  }) => (
-    <div className="my-8 rounded-xl border border-warm-grey-2/20 bg-warm-grey-2/10 p-6 backdrop-blur-sm">
-      {props.title && (
-        <h4 className="font-display mb-4 text-lg font-semibold text-warm-grey">
-          {props.title}
-        </h4>
-      )}
-      <div className="flex flex-col space-y-3">
-        {props.steps.map((step, idx) => (
-          <div
-            key={idx}
-            className={cx("flex flex-col space-y-1", {
-              "mt-4 border-t border-warm-grey-2/20 pt-4": step.isResult,
-            })}
-          >
-            <div className="flex items-baseline justify-between">
-              <span className="text-warm-grey/80">{step.label}</span>
-              <span
-                className={cx(
-                  "font-mono text-lg",
-                  step.isResult
-                    ? "font-semibold text-warm-grey"
-                    : "text-warm-grey/80",
-                )}
-              >
-                {typeof step.value === "number"
-                  ? new Intl.NumberFormat("nb-NO").format(step.value)
-                  : step.value}
-              </span>
-            </div>
-            {step.calculation && (
-              <div className="text-sm text-warm-grey/60">
-                {step.calculation}
-              </div>
-            )}
-          </div>
-        ))}
-      </div>
-    </div>
-  ),
-  Summary: (props: {
-    title?: string
-    points: {
-      title: string
-      description?: string
-      iconName?: string
-    }[]
-  }) => {
-    return (
-      <div className="my-8 rounded-xl border border-warm-grey-2/20 bg-warm-grey-2/10 p-6 backdrop-blur-sm">
-        {props.title && (
-          <h4 className="font-display mb-6 text-xl font-semibold text-warm-grey">
-            {props.title}
-          </h4>
-        )}
-        <div className="grid gap-6 sm:grid-cols-2">
-          {props.points.map((point, idx) => (
-            <div
-              key={idx}
-              className="flex flex-col space-y-2 rounded-lg border border-warm-grey-2/20 bg-warm-grey-2/5 p-4 backdrop-blur-sm"
-            >
-              <div className="flex items-center gap-3">
-                <h5 className="font-medium text-warm-grey">{point.title}</h5>
-              </div>
-              {point.description && (
-                <p className="text-sm leading-relaxed text-warm-grey/70">
-                  {point.description}
-                </p>
-              )}
-            </div>
-          ))}
-        </div>
-      </div>
-    )
-  },
-  CTA: (props: {
-    badge?: string
-    title: string
-    description: string
-    primaryAction?: {
-      label: string
-      href: string
-    }
-    secondaryAction?: {
-      label: string
-      href: string
-    }
-    size?: "default" | "large"
-  }) => <AnimatedCTA {...props} />,
   DcfChart: (props: any) => (
     <div className="">
       <DcfChart {...props} />
@@ -568,17 +624,7 @@ export function MDX({ code, images, className }: MDXProps) {
   return (
     <article
       data-mdx-container
-      className={cx(
-        "prose max-w-none transition-all",
-        "prose-headings:relative prose-headings:scroll-mt-20 prose-headings:font-display prose-headings:font-bold prose-headings:text-warm-grey",
-        "prose-p:text-warm-grey/80 prose-p:leading-relaxed prose-p:my-4",
-        "prose-a:text-warm-grey/80 prose-a:underline prose-a:underline-offset-4 hover:prose-a:text-warm-grey",
-        "prose-code:text-warm-grey prose-code:bg-warm-grey-2/10 prose-code:px-2 prose-code:py-1",
-        "prose-li:text-warm-grey/80 prose-li:leading-relaxed prose-li:mb-2",
-        "prose-ul:my-8 prose-ul:space-y-6",
-        "prose-ol:my-4 prose-ol:space-y-2",
-        className,
-      )}
+      className={cx("ks-prose max-w-none transition-all", className)}
     >
       <MDXContent
         code={code}

--- a/src/components/blog/mdx.tsx
+++ b/src/components/blog/mdx.tsx
@@ -5,6 +5,7 @@ import { allHelpPosts } from "content-collections"
 import dynamic from "next/dynamic"
 import Link from "next/link"
 
+import BlurImage from "@/lib/blog/blur-image"
 import { HELP_CATEGORIES, POPULAR_ARTICLES } from "@/lib/blog/content"
 import { cx } from "@/lib/utils"
 
@@ -133,12 +134,10 @@ function StatStrip(props: {
     delta?: { dir: "up" | "down"; text: string }
   }[]
 }) {
+  const items = props.items ?? []
   return (
-    <div
-      className="ae-stat-strip"
-      style={{ ["--ae-cols" as any]: props.items.length }}
-    >
-      {props.items.map((s, i) => (
+    <div className="ae-stat-strip" style={{ ["--ae-cols" as any]: items.length }}>
+      {items.map((s, i) => (
         <div className="ae-stat" key={i}>
           <div className="ae-val">
             {s.value}
@@ -165,7 +164,7 @@ function Summary(props: {
     <div className="ae-summary">
       {props.title && <div className="ae-summary-head">{props.title}</div>}
       <div className="ae-grid">
-        {props.points.map((p, i) => (
+        {(props.points ?? []).map((p, i) => (
           <div className="ae-item" key={i}>
             <span className="ae-rn">{ROMAN[i] ?? i + 1}</span>
             <h5>{p.title}</h5>
@@ -177,18 +176,41 @@ function Summary(props: {
   )
 }
 
-/* -- STEPPER ---------------------------------------------- */
+/* -- STEPPER ----------------------------------------------
+   Supports optional per-step `formula` (rendered via the editorial
+   .ae-formula frame) and `image` — existing help articles rely on the
+   `formula` sub-prop, so dropping it silently hides their math. */
 function Stepper(props: {
-  items: { title: string; content: React.ReactNode }[]
+  items: {
+    title: string
+    content: React.ReactNode
+    image?: { src: string; alt: string; width?: number; height?: number }
+    formula?: { math: string; description?: string; mode?: "inline" | "block" }
+  }[]
 }) {
   return (
     <div className="ae-stepper">
-      {props.items.map((item, i) => (
+      {(props.items ?? []).map((item, i) => (
         <div className="ae-step" key={i}>
           <div className="ae-sn">{i + 1}</div>
           <div>
             <h4>{item.title}</h4>
             <div>{item.content}</div>
+            {item.formula && (
+              <MathBlock
+                formula={item.formula.math}
+                description={item.formula.description}
+                mode={item.formula.mode}
+              />
+            )}
+            {item.image && (
+              <ZoomImage
+                src={item.image.src}
+                alt={item.image.alt}
+                width={item.image.width || 800}
+                height={item.image.height || 400}
+              />
+            )}
           </div>
         </div>
       ))}
@@ -208,6 +230,11 @@ function Example(props: {
 }) {
   const fmt = (v: string | number) =>
     typeof v === "number" ? new Intl.NumberFormat("nb-NO").format(v) : v
+  const steps = props.steps ?? []
+  // Render the calculation column consistently across rows. If ANY row has a
+  // calculation, every row reserves the cell (empty when absent) so values
+  // stay in the same column. If no row has one, drop the column entirely.
+  const hasCalc = steps.some((s) => s.calculation)
   return (
     <div className="ae-example">
       <div className="ae-ehead">
@@ -216,10 +243,10 @@ function Example(props: {
       </div>
       <table>
         <tbody>
-          {props.steps.map((s, i) => (
+          {steps.map((s, i) => (
             <tr key={i} className={s.isResult ? "is-result" : undefined}>
               <td className="ae-elabel">{s.label}</td>
-              {s.calculation && <td className="ae-ecalc">{s.calculation}</td>}
+              {hasCalc && <td className="ae-ecalc">{s.calculation ?? ""}</td>}
               <td className="ae-eval">{fmt(s.value)}</td>
             </tr>
           ))}
@@ -276,10 +303,17 @@ function Quote(props: {
       {(props.author || role) && (
         <div className="ae-cite">
           {props.authorSrc && (
-            <div
-              className="ae-av"
-              style={{ backgroundImage: `url('${props.authorSrc}')` }}
-            />
+            // next/image (via BlurImage) so the avatar is optimized and
+            // honors next.config remotePatterns — a raw CSS background-image
+            // would bypass both and let any src trigger an unoptimized fetch.
+            <div className="ae-av">
+              <BlurImage
+                src={props.authorSrc}
+                alt={props.author ?? ""}
+                width={44}
+                height={44}
+              />
+            </div>
           )}
           <div className="meta">
             {props.author && <span className="name">{props.author}</span>}
@@ -430,7 +464,7 @@ function Timeline(props: {
 }) {
   return (
     <div className="ae-timeline">
-      {props.items.map((it, i) => (
+      {(props.items ?? []).map((it, i) => (
         <div className="ae-tl-item" key={i}>
           <div className="ae-tl-date">{it.date}</div>
           <h4>{it.title}</h4>
@@ -449,17 +483,17 @@ function Compare(props: {
   return (
     <div className="ae-compare">
       <div className="ae-col is-accent">
-        <div className="ae-col-head">{props.pro.head}</div>
+        <div className="ae-col-head">{props.pro?.head}</div>
         <ul>
-          {props.pro.items.map((it, i) => (
+          {(props.pro?.items ?? []).map((it, i) => (
             <li key={i}>{it}</li>
           ))}
         </ul>
       </div>
       <div className="ae-col is-con">
-        <div className="ae-col-head">{props.con.head}</div>
+        <div className="ae-col-head">{props.con?.head}</div>
         <ul>
-          {props.con.items.map((it, i) => (
+          {(props.con?.items ?? []).map((it, i) => (
             <li key={i}>{it}</li>
           ))}
         </ul>
@@ -477,7 +511,7 @@ function ReadMore(props: {
     <div className="ae-readmore">
       <div className="ae-rm-head">{props.title ?? "Les videre."}</div>
       <div className="ae-rm-list">
-        {props.items.map((it, i) => (
+        {(props.items ?? []).map((it, i) => (
           <Link className="ae-rm-item" href={it.href} key={i}>
             <div>
               <div className="ae-rm-pre">{it.pre}</div>
@@ -499,7 +533,7 @@ function Changelog(props: {
 }) {
   return (
     <div className="ae-changelog">
-      {props.items.map((it, i) => (
+      {(props.items ?? []).map((it, i) => (
         <Link className="ae-cl-item" href={it.href} key={i}>
           <div className="ae-cl-date">{it.date}</div>
           <div>

--- a/src/content/blog/AUTHORING.md
+++ b/src/content/blog/AUTHORING.md
@@ -1,0 +1,115 @@
+# Best practice — formatering av artikler
+
+Denne fila er ment som referanse for både redaktører og AI-assistenter (Claude).
+Komponentene den beskriver bor i `src/components/blog/mdx.tsx` (klasser i
+`src/styles/advanti-design.css`, BLOG-seksjonen). Mål: artikler skal bruke de
+redaksjonelle komponentene der de hører hjemme — ikke falle tilbake på
+**fete punktlister** og endeløs `##`-prosa.
+
+---
+
+## Gullregelen
+
+> Hvis du er i ferd med å skrive en **fet** etikett etterfulgt av en punktliste
+> med tall — stopp. Det finnes nesten alltid en komponent som gjør det bedre.
+
+**Før (dagens artikler):**
+
+```md
+**Nøkkeltall (Q4 2025):**
+- Prime yield Bodø: **5,80 %**
+- Prime yield Tromsø: **5,50 %**
+- Transaksjoner 2025E: **~103 mrd. NOK**
+```
+
+**Etter (best practice):**
+
+```jsx
+<Summary
+  title="Nøkkeltall · Q4 2025."
+  points={[
+    { title: "Prime yield Bodø", description: "5,80 % — ned 30 bps fra toppen." },
+    { title: "Prime yield Tromsø", description: "5,50 % — landsdelens laveste." },
+    { title: "Transaksjoner 2025E", description: "~103 mrd. NOK — opp fra 80 mrd." },
+  ]}
+/>
+```
+
+---
+
+## Når bruker jeg hva
+
+| Situasjon | Bruk | Ikke bruk |
+|---|---|---|
+| 2–6 nøkkelpunkter / takeaways | `<Summary>` | fet punktliste |
+| 2–4 harde tall som setter premisset | `<StatStrip>` | tabell med én rad |
+| Definere et fagbegrep første gang | `<Fact>` | parentes i brødteksten |
+| En sekvensiell prosess eller «N grep» | `<Stepper>` | `### 1.` overskrifter |
+| Et regnestykke med et resultat | `<Example>` | tabell uten resultatrad |
+| Forutsetninger / antakelser | `<Prerequisites>` | løpende prosa |
+| En matematisk formel | `<Formula>` | inline `kode` |
+| Et ekte kundeutsagn | `<Quote>` | generisk ros i brødtekst |
+| To sider av en avgjørelse | `<Compare>` | to punktlister etter hverandre |
+| Kronologi / markedshistorikk | `<Timeline>` | tabell med datoer |
+| Bilde som trenger kontekst | `<Figure>` | rått `![]()` uten bildetekst |
+| Avslutning med oppfordring | `<CTA>` | «Ta kontakt på …» i prosa |
+| Videre lesning | `<ReadMore>` | løse lenker i en liste |
+| Daterte hendelser / endringer | `<Changelog>` | — |
+| En kort sidebemerkning | `<Aside>` | `<Note>` til alt |
+
+## Callout-disiplin
+
+`<Note>` har fire varianter. Bruk dem sparsomt — som regel holder den nøytrale.
+
+- **(standard)** → nøytral presisering. Etikett: «Merk».
+- `variant="key"` → det viktigste poenget på siden. Etikett: «Viktig».
+- `variant="caution"` → forbehold, risiko, datakvalitet. Etikett: «Vær oppmerksom».
+- `variant="positive"` → konklusjon eller hovedpoeng. Etikett: «Hovedpoeng».
+
+Maks **én** `key`-callout per artikkel. Hvis alt er viktig, er ingenting det.
+
+## Rytme i en artikkel
+
+En god artikkel veksler mellom prosa og komponenter, og lar luft stå rundt dem:
+
+1. Åpningsavsnitt i ren prosa — sett premisset.
+2. `<Summary>` eller `<StatStrip>` som løfter nøkkeltallene.
+3. `##`-seksjoner med prosa + tabeller for selve innholdet.
+4. Komponenter der de hører hjemme (`<Stepper>`, `<Example>`, `<Quote>` …).
+5. Avslutt med `<CTA>` og evt. `<ReadMore>`.
+
+Ikke stable to komponenter rett på hverandre uten en setning prosa imellom —
+de trenger pusterom for å lese som redaksjonelt innhold, ikke som et dashbord.
+
+## Eksempelartikler
+
+| Fil | Type | Viser frem |
+|---|---|---|
+| `markedspuls-nord-norge-2026.mdx` | Markedsrapport | Summary, StatStrip, Note, Timeline, CTA |
+| `dcf-analyse-naringseiendom.mdx` | Metode / fag | Fact, Prerequisites, Stepper, Formula, Example |
+| `kjope-vs-leie-naringseiendom.mdx` | Beslutningsguide | Compare, Aside, Quote, ReadMore |
+| `verdivurdering-naringseiendom-guide.mdx` | Prosessguide | Figure, Stepper, Example, CTA (lys) |
+| `investere-kontorlokaler-nord-norge.mdx` | Investering / liste | StatStrip, Stepper, Note, Quote, Changelog |
+
+## Frontmatter
+
+Hold deg til skjemaet i `content-collections.ts`:
+
+```yaml
+---
+title: "…"
+publishedAt: 2026-02-04
+summary: …
+image: /building/….jpg
+author: codehagen        # eller vsoraas
+categories:
+  - market-analysis      # må matche en slug i BLOG_CATEGORIES
+related:
+  - en-annen-slug
+slug: artikkelens-slug
+---
+```
+
+> Merk: eksemplene bruker `market-analysis` som kategori fordi den er bekreftet
+> gyldig. Bytt til riktig kategori-slug per artikkel før publisering — en ugyldig
+> kategori gir `notFound()` på artikkelsiden.

--- a/src/styles/advanti-design.css
+++ b/src/styles/advanti-design.css
@@ -25,6 +25,12 @@
   --accent-soft:   var(--light-blue-2);
   --accent-faint:  var(--light-blue-1);
 
+  /* Two restrained, low-chroma support tones for editorial blog callout /
+     compare RULES only (never as the sole signal, never as small text — see
+     DESIGN.md §5 BLOG components). Added with the .ae-* family 2026-06-03. */
+  --ae-caution:  oklch(0.70 0.055 65);   /* muted ochre */
+  --ae-positive: oklch(0.66 0.045 155);  /* muted sage  */
+
   /* Type — D3: Inter for both display and body (var set by next/font in layout.tsx).
      TODO: swap --font-display to Reckless Neue once the ANTI licence is acquired. */
   --font-display: var(--font-inter), "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
@@ -4228,6 +4234,652 @@ h1, h2, h3 {
 }
 .ks-prose table tbody tr:hover td { background: var(--accent-faint); }
 .ks-prose table tbody td:first-child { color: var(--warm-grey); font-weight: 500; }
+
+/* ============================================================
+   BLOG · Editorial MDX components  (.ae-*)
+   ------------------------------------------------------------
+   Consolidated editorial component family for article bodies.
+   Replaces the rounded-card / backdrop-blur widgets with the
+   DESIGN.md vocabulary: hairlines, restrained type, numbered
+   labels, light-blue accent as a small detail. Icon-free.
+   Ported from the design handoff 2026-06-03. Wrappers live in
+   src/components/blog/mdx.tsx.
+
+   A11y deltas vs the raw handoff (plan-design-review F1–F3):
+   - :focus-visible accent ring on every interactive element.
+   - --ae-caution/--ae-positive used on RULES only; label TEXT
+     stays --warm-grey-85 so it meets contrast.
+   - hover shifts guarded behind (hover:hover) and (pointer:fine).
+   ============================================================ */
+
+/* -- 1 · NOTE / CALLOUT ------------------------------------ */
+.ae-note {
+  margin: 36px 0;
+  padding: 22px 26px 24px;
+  border: var(--hairline);
+  border-left: 2px solid var(--warm-grey-75);
+  background: transparent;
+  font-size: 15.5px;
+  line-height: 1.6;
+  color: var(--warm-grey);
+}
+.ae-note > :first-child { margin-top: 0; }
+.ae-note > :last-child { margin-bottom: 0; }
+.ae-note .ae-label {
+  display: block;
+  font-family: var(--font-body);
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  font-weight: 500;
+  color: var(--warm-grey-85);
+  margin-bottom: 10px;
+}
+.ae-note p { color: var(--warm-grey-85); }
+.ae-note a {
+  color: var(--warm-grey);
+  border-bottom: 1px solid var(--warm-grey-85);
+}
+.ae-note a:hover { border-color: var(--accent); }
+
+/* Variants — only the left rule (+ key fill/label) change. The caution
+   and positive tones live on the RULE only; the label text stays
+   warm-grey-85 for contrast (plan-design-review F2). */
+.ae-note.is-key {
+  border-left-color: var(--accent);
+  background: var(--accent-faint);
+}
+.ae-note.is-key .ae-label { color: var(--warm-grey); }
+.ae-note.is-caution { border-left-color: var(--ae-caution); }
+.ae-note.is-positive { border-left-color: var(--ae-positive); }
+
+/* -- 2 · ASIDE -------------------------------------------- */
+.ae-aside {
+  margin: 36px 0;
+  padding-top: 18px;
+  border-top: var(--hairline);
+  font-size: 15px;
+  line-height: 1.6;
+  color: var(--warm-grey-85);
+}
+.ae-aside .ae-label {
+  display: block;
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  font-weight: 500;
+  color: var(--warm-grey-85);
+  margin-bottom: 8px;
+}
+
+/* -- 3 · FACT BOX ----------------------------------------- */
+.ae-fact {
+  margin: 36px 0;
+  border-top: 2px solid var(--warm-grey);
+  border-bottom: var(--hairline);
+  padding: 18px 0 22px;
+}
+.ae-fact .ae-term {
+  font-family: var(--font-display);
+  font-size: 21px;
+  font-weight: 400;
+  letter-spacing: -0.012em;
+  color: var(--warm-grey);
+  margin-bottom: 8px;
+}
+.ae-fact .ae-term .italic { font-style: italic; font-weight: 300; color: var(--warm-grey-85); }
+.ae-fact .ae-def {
+  font-size: 15.5px;
+  line-height: 1.6;
+  color: var(--warm-grey-85);
+}
+.ae-fact .ae-def p + p { margin-top: 10px; }
+@media (min-width: 720px) {
+  .ae-fact.is-inline {
+    display: grid;
+    grid-template-columns: 200px 1fr;
+    gap: 32px;
+    align-items: baseline;
+  }
+  .ae-fact.is-inline .ae-term { margin-bottom: 0; }
+}
+
+/* -- 4 · STAT STRIP --------------------------------------- */
+.ae-stat-strip {
+  margin: 48px 0;
+  border-top: var(--hairline);
+  border-bottom: var(--hairline);
+  display: grid;
+  grid-template-columns: repeat(var(--ae-cols, 3), 1fr);
+}
+.ae-stat-strip .ae-stat { padding: 26px 28px 26px 0; }
+.ae-stat-strip .ae-stat + .ae-stat {
+  padding-left: 28px;
+  border-left: var(--hairline);
+}
+.ae-stat-strip .ae-val {
+  font-family: var(--font-display);
+  font-size: clamp(34px, 4.4vw, 48px);
+  font-weight: 400;
+  letter-spacing: -0.02em;
+  line-height: 1;
+  font-variant-numeric: tabular-nums;
+  color: var(--warm-grey);
+}
+.ae-stat-strip .ae-val .unit {
+  font-size: 0.5em;
+  color: var(--warm-grey-85);
+  letter-spacing: 0;
+  margin-left: 4px;
+}
+.ae-stat-strip .ae-stat-label {
+  margin-top: 12px;
+  font-size: 13px;
+  color: var(--warm-grey-85);
+  line-height: 1.45;
+}
+.ae-stat-strip .ae-delta {
+  display: inline-block;
+  margin-top: 8px;
+  font-size: 12px;
+  letter-spacing: 0.04em;
+  color: var(--warm-grey-85);
+  font-variant-numeric: tabular-nums;
+}
+.ae-stat-strip .ae-delta.up::before { content: "↑ "; color: var(--ae-positive); }
+.ae-stat-strip .ae-delta.down::before { content: "↓ "; color: var(--ae-caution); }
+@media (max-width: 680px) {
+  .ae-stat-strip { grid-template-columns: 1fr 1fr; }
+  .ae-stat-strip .ae-stat:nth-child(odd) { border-left: 0; padding-left: 0; }
+  .ae-stat-strip .ae-stat { border-top: var(--hairline); padding: 22px 0; }
+  .ae-stat-strip .ae-stat:nth-child(2n) { padding-left: 24px; border-left: var(--hairline); }
+}
+
+/* -- 5 · SUMMARY GRID ------------------------------------- */
+.ae-summary {
+  margin: 56px 0;
+  border-top: var(--hairline);
+  border-bottom: var(--hairline);
+  padding: 30px 0;
+}
+.ae-summary .ae-summary-head {
+  font-family: var(--font-display);
+  font-size: 24px;
+  font-weight: 400;
+  letter-spacing: -0.015em;
+  margin-bottom: 26px;
+}
+.ae-summary .ae-summary-head .italic { font-style: italic; font-weight: 300; color: var(--warm-grey-85); }
+.ae-summary .ae-grid { display: grid; grid-template-columns: 1fr 1fr; }
+.ae-summary .ae-item {
+  padding: 20px 28px 20px 0;
+  border-bottom: var(--hairline);
+}
+.ae-summary .ae-item:nth-child(2n) {
+  padding-left: 28px;
+  padding-right: 0;
+  border-left: var(--hairline);
+}
+.ae-summary .ae-item:nth-last-child(-n+2) { border-bottom: 0; padding-bottom: 0; }
+.ae-summary .ae-rn {
+  display: block;
+  font-family: var(--font-display);
+  font-size: 17px;
+  font-style: italic;
+  font-weight: 300;
+  color: var(--accent);
+  margin-bottom: 8px;
+}
+.ae-summary .ae-item h5 {
+  font-size: 16px;
+  font-weight: 500;
+  margin-bottom: 6px;
+  letter-spacing: -0.005em;
+}
+.ae-summary .ae-item p {
+  font-size: 14px;
+  color: var(--warm-grey-85);
+  line-height: 1.5;
+}
+@media (max-width: 640px) {
+  .ae-summary .ae-grid { grid-template-columns: 1fr; }
+  .ae-summary .ae-item,
+  .ae-summary .ae-item:nth-child(2n) { padding: 18px 0; border-left: 0; }
+  .ae-summary .ae-item:nth-last-child(-n+2) { border-bottom: var(--hairline); }
+  .ae-summary .ae-item:last-child { border-bottom: 0; }
+}
+
+/* -- 6 · STEPPER ------------------------------------------ */
+.ae-stepper { margin: 44px 0; border-top: var(--hairline); }
+.ae-step {
+  display: grid;
+  grid-template-columns: 56px 1fr;
+  gap: 24px;
+  padding: 26px 0;
+  border-bottom: var(--hairline);
+  align-items: start;
+}
+.ae-step .ae-sn {
+  font-family: var(--font-display);
+  font-size: 28px;
+  font-weight: 400;
+  letter-spacing: -0.018em;
+  color: var(--warm-grey);
+  font-variant-numeric: tabular-nums;
+  line-height: 1.1;
+}
+.ae-step .ae-sn::after {
+  content: "";
+  display: block;
+  width: 22px;
+  height: 2px;
+  margin-top: 10px;
+  background: var(--accent);
+}
+.ae-step h4 {
+  font-family: var(--font-display);
+  font-size: 20px;
+  font-weight: 400;
+  letter-spacing: -0.012em;
+  margin-bottom: 8px;
+}
+.ae-step p { font-size: 15px; color: var(--warm-grey-85); line-height: 1.6; }
+.ae-step p + p { margin-top: 10px; }
+
+/* -- 7 · EXAMPLE / CALCULATION ---------------------------- */
+.ae-example {
+  margin: 48px 0;
+  border: var(--hairline);
+  background: var(--warm-white);
+  overflow: hidden;
+}
+.ae-example .ae-ehead {
+  padding: 18px 28px;
+  border-bottom: var(--hairline);
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+.ae-example .ae-ehead .ae-label {
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--warm-grey-85);
+  font-weight: 500;
+}
+.ae-example .ae-ehead h4 {
+  font-family: var(--font-display);
+  font-size: 20px;
+  font-weight: 400;
+  letter-spacing: -0.012em;
+  margin: 0;
+}
+.ae-example table { width: 100%; border-collapse: collapse; font-variant-numeric: tabular-nums; }
+.ae-example tr { border-bottom: var(--hairline); }
+.ae-example tr:last-child { border-bottom: 0; }
+.ae-example td { padding: 15px 28px; font-size: 15px; vertical-align: baseline; }
+.ae-example td.ae-elabel { color: var(--warm-grey-85); }
+.ae-example td.ae-ecalc { color: var(--warm-grey-85); font-size: 13px; font-style: italic; }
+.ae-example td.ae-eval {
+  text-align: right;
+  font-weight: 500;
+  font-family: var(--font-display);
+  font-size: 18px;
+  white-space: nowrap;
+}
+.ae-example tr.is-result {
+  background: var(--accent-faint);
+  border-top: 2px solid var(--warm-grey);
+}
+.ae-example tr.is-result td { padding-top: 18px; padding-bottom: 18px; }
+.ae-example tr.is-result td.ae-eval { color: var(--warm-grey); font-size: 26px; }
+
+/* -- 8 · PREREQUISITES ------------------------------------ */
+.ae-prereq { margin: 40px 0; border: var(--hairline); padding: 22px 26px 24px; }
+.ae-prereq .ae-label {
+  display: block;
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--warm-grey-85);
+  font-weight: 500;
+  margin-bottom: 14px;
+}
+.ae-prereq ul { list-style: none; margin: 0; padding: 0; }
+.ae-prereq li {
+  position: relative;
+  padding: 10px 0 10px 26px;
+  font-size: 15px;
+  color: var(--warm-grey-85);
+  line-height: 1.55;
+  border-top: var(--hairline);
+}
+.ae-prereq li:first-child { border-top: 0; }
+.ae-prereq li::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 19px;
+  width: 12px;
+  height: 1px;
+  background: var(--accent);
+}
+.ae-prereq li strong { color: var(--warm-grey); font-weight: 500; }
+
+/* -- 9 · QUOTE -------------------------------------------- */
+.ae-quote { margin: 56px 0; padding-left: 28px; border-left: 2px solid var(--accent); }
+.ae-quote .ae-q {
+  font-family: var(--font-display);
+  font-size: clamp(24px, 3.2vw, 32px);
+  font-weight: 300;
+  font-style: italic;
+  line-height: 1.32;
+  letter-spacing: -0.012em;
+  color: var(--warm-grey);
+  text-wrap: balance;
+}
+.ae-quote .ae-cite { display: flex; align-items: center; gap: 14px; margin-top: 24px; }
+.ae-quote .ae-av {
+  width: 44px; height: 44px;
+  border-radius: 50%;
+  background-size: cover;
+  background-position: center;
+  background-color: var(--warm-grey-75);
+  flex-shrink: 0;
+}
+.ae-quote .ae-cite .name { font-weight: 500; font-size: 14.5px; font-style: normal; }
+.ae-quote .ae-cite .role { font-size: 12.5px; color: var(--warm-grey-85); font-style: normal; }
+.ae-quote .ae-cite .meta { display: flex; flex-direction: column; }
+
+/* -- 10 · IN-ARTICLE CTA ---------------------------------- */
+.ae-cta {
+  margin: 56px 0;
+  background: var(--warm-grey);
+  color: var(--warm-white);
+  padding: 40px 44px;
+}
+.ae-cta .ae-label {
+  display: block;
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(243,241,239,0.72);
+  font-weight: 500;
+  margin-bottom: 14px;
+}
+.ae-cta h4 {
+  font-family: var(--font-display);
+  font-size: clamp(24px, 3vw, 30px);
+  font-weight: 400;
+  letter-spacing: -0.015em;
+  line-height: 1.12;
+  margin-bottom: 12px;
+}
+.ae-cta h4 .italic { font-style: italic; font-weight: 300; color: var(--accent); }
+.ae-cta p {
+  font-size: 15.5px;
+  line-height: 1.6;
+  color: rgba(243,241,239,0.78);
+  max-width: 52ch;
+  margin-bottom: 24px;
+}
+.ae-cta .ae-actions { display: flex; gap: 12px; flex-wrap: wrap; }
+.ae-cta .ae-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 24px;
+  border-radius: 999px;
+  font-size: 14px;
+  font-weight: 500;
+  transition: all 0.2s ease;
+}
+.ae-cta .ae-btn-primary { background: var(--warm-white); color: var(--warm-grey); }
+.ae-cta .ae-btn-primary:hover { background: var(--accent); }
+.ae-cta .ae-btn-ghost { border: 1px solid rgba(243,241,239,0.3); color: var(--warm-white); }
+.ae-cta .ae-btn-ghost:hover { border-color: var(--warm-white); }
+/* Keyboard focus ring (plan-design-review F1) */
+.ae-cta .ae-btn:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
+}
+
+.ae-cta.is-light {
+  background: transparent;
+  color: var(--warm-grey);
+  border: var(--hairline);
+  border-top: 2px solid var(--warm-grey);
+  padding: 36px 40px;
+}
+.ae-cta.is-light .ae-label { color: var(--warm-grey-85); }
+.ae-cta.is-light h4 .italic { color: var(--warm-grey-85); }
+.ae-cta.is-light p { color: var(--warm-grey-85); }
+.ae-cta.is-light .ae-btn-primary { background: var(--warm-grey); color: var(--warm-white); }
+.ae-cta.is-light .ae-btn-primary:hover { background: var(--warm-grey-85); }
+.ae-cta.is-light .ae-btn-ghost { border-color: var(--warm-grey-75); color: var(--warm-grey); }
+.ae-cta.is-light .ae-btn-ghost:hover { border-color: var(--warm-grey); }
+
+/* -- 11 · FORMULA ----------------------------------------- */
+.ae-formula {
+  background: var(--warm-grey);
+  color: var(--warm-white);
+  padding: 34px 40px;
+  margin: 48px 0;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+.ae-formula .ae-label {
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(243,241,239,0.72);
+  font-weight: 500;
+}
+.ae-formula .ae-eq {
+  font-family: var(--font-display);
+  font-style: italic;
+  font-size: clamp(22px, 3vw, 30px);
+  font-weight: 300;
+  letter-spacing: 0.01em;
+  line-height: 1.4;
+}
+.ae-formula .ae-eq sub { font-style: normal; font-size: 0.62em; }
+.ae-formula .ae-desc {
+  font-size: 13px;
+  color: rgba(243,241,239,0.78);
+  line-height: 1.55;
+  letter-spacing: 0.01em;
+}
+.ae-formula.is-light { background: var(--accent-faint); color: var(--warm-grey); border: var(--hairline); }
+.ae-formula.is-light .ae-label { color: var(--warm-grey-85); }
+.ae-formula.is-light .ae-desc { color: var(--warm-grey-85); }
+
+/* -- 12 · FIGURE ------------------------------------------ */
+.ae-figure { margin: 48px 0; }
+.ae-figure .ae-img {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  overflow: hidden;
+  background: var(--warm-grey-75);
+}
+.ae-figure .ae-img img { width: 100%; height: 100%; object-fit: cover; }
+.ae-figure figcaption {
+  margin-top: 12px;
+  padding-top: 10px;
+  border-top: var(--hairline);
+  display: flex;
+  gap: 12px;
+  font-size: 12.5px;
+  color: var(--warm-grey-85);
+  line-height: 1.5;
+}
+.ae-figure figcaption .ae-fig-n {
+  flex-shrink: 0;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 500;
+  color: var(--warm-grey);
+}
+.ae-figure.is-wide { margin-left: calc(50% - 50vw); margin-right: calc(50% - 50vw); }
+.ae-figure.is-wide .ae-img { aspect-ratio: 21 / 9; }
+.ae-figure.is-wide figcaption { max-width: var(--max-w); margin-left: auto; margin-right: auto; padding-left: var(--gutter); padding-right: var(--gutter); }
+
+/* -- 13 · TIMELINE ---------------------------------------- */
+.ae-timeline { margin: 48px 0; padding-left: 24px; border-left: var(--hairline); }
+.ae-tl-item { position: relative; padding: 0 0 32px 28px; }
+.ae-tl-item:last-child { padding-bottom: 0; }
+.ae-tl-item::before {
+  content: "";
+  position: absolute;
+  left: -29px;
+  top: 6px;
+  width: 9px; height: 9px;
+  border-radius: 50%;
+  background: var(--warm-grey);
+  border: 2px solid var(--warm-grey);
+}
+.ae-tl-item .ae-tl-date {
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--warm-grey);
+  font-weight: 500;
+  font-variant-numeric: tabular-nums;
+  margin-bottom: 6px;
+}
+.ae-tl-item h4 {
+  font-family: var(--font-display);
+  font-size: 19px;
+  font-weight: 400;
+  letter-spacing: -0.01em;
+  margin-bottom: 6px;
+}
+.ae-tl-item p { font-size: 14.5px; color: var(--warm-grey-85); line-height: 1.55; }
+
+/* -- 14 · COMPARISON -------------------------------------- */
+.ae-compare { margin: 48px 0; display: grid; grid-template-columns: 1fr 1fr; border: var(--hairline); }
+.ae-compare .ae-col { padding: 24px 26px 26px; }
+.ae-compare .ae-col + .ae-col { border-left: var(--hairline); }
+.ae-compare .ae-col-head {
+  font-size: 11px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  font-weight: 500;
+  color: var(--warm-grey-85);
+  padding-bottom: 14px;
+  margin-bottom: 4px;
+  border-bottom: var(--hairline);
+}
+.ae-compare .ae-col.is-accent .ae-col-head { color: var(--warm-grey); }
+.ae-compare .ae-col.is-accent { background: var(--accent-faint); }
+.ae-compare ul { list-style: none; margin: 0; padding: 0; }
+.ae-compare li {
+  position: relative;
+  padding: 12px 0 12px 22px;
+  font-size: 14.5px;
+  color: var(--warm-grey-85);
+  line-height: 1.5;
+  border-bottom: var(--hairline);
+}
+.ae-compare li:last-child { border-bottom: 0; }
+.ae-compare li::before {
+  content: "+";
+  position: absolute;
+  left: 0;
+  top: 11px;
+  font-family: var(--font-display);
+  color: var(--ae-positive);
+  font-size: 15px;
+}
+.ae-compare .ae-col.is-con li::before { content: "–"; color: var(--ae-caution); }
+@media (max-width: 600px) {
+  .ae-compare { grid-template-columns: 1fr; }
+  .ae-compare .ae-col + .ae-col { border-left: 0; border-top: var(--hairline); }
+}
+
+/* -- 15 · READ MORE --------------------------------------- */
+.ae-readmore { margin: 56px 0 0; }
+.ae-readmore .ae-rm-head {
+  font-family: var(--font-display);
+  font-size: 24px;
+  font-weight: 400;
+  letter-spacing: -0.015em;
+  margin-bottom: 8px;
+}
+.ae-readmore .ae-rm-list { border-top: var(--hairline); }
+.ae-readmore .ae-rm-item {
+  display: grid;
+  grid-template-columns: 1fr 24px;
+  gap: 20px;
+  align-items: center;
+  padding: 22px 0;
+  border-bottom: var(--hairline);
+  transition: padding 0.2s ease;
+}
+.ae-readmore .ae-rm-pre {
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--warm-grey-85);
+  font-weight: 500;
+  margin-bottom: 8px;
+}
+.ae-readmore .ae-rm-item h4 {
+  font-family: var(--font-display);
+  font-size: 21px;
+  font-weight: 400;
+  letter-spacing: -0.012em;
+  line-height: 1.2;
+  color: var(--warm-grey);
+}
+.ae-readmore .ae-rm-arrow { color: var(--warm-grey-75); transition: color 0.2s; }
+.ae-readmore .ae-rm-item:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 4px;
+}
+
+/* -- 16 · CHANGELOG / DATED LINKS ------------------------- */
+.ae-changelog { margin: 40px 0; border-top: var(--hairline); }
+.ae-changelog .ae-cl-item {
+  display: grid;
+  grid-template-columns: 120px 1fr 24px;
+  gap: 24px;
+  align-items: baseline;
+  padding: 20px 0;
+  border-bottom: var(--hairline);
+}
+.ae-changelog .ae-cl-date {
+  font-size: 12px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--warm-grey-85);
+  font-variant-numeric: tabular-nums;
+  font-weight: 500;
+}
+.ae-changelog .ae-cl-item h4 { font-size: 16px; font-weight: 500; margin-bottom: 4px; }
+.ae-changelog .ae-cl-item p { font-size: 14px; color: var(--warm-grey-85); line-height: 1.5; }
+.ae-changelog .ae-rm-arrow { color: var(--warm-grey-75); }
+.ae-changelog .ae-cl-item:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 4px;
+}
+@media (max-width: 600px) {
+  .ae-changelog .ae-cl-item { grid-template-columns: 1fr 24px; }
+  .ae-changelog .ae-cl-date { grid-column: 1 / -1; margin-bottom: 4px; }
+}
+
+/* Hover shifts/colour changes guarded to real pointers so a tap on a
+   touch device doesn't leave a row stuck in its hover state
+   (plan-design-review F3; matches the eiendommer hover guards). */
+@media (hover: hover) and (pointer: fine) {
+  .ae-readmore .ae-rm-item:hover { padding-left: 8px; }
+  .ae-readmore .ae-rm-item:hover .ae-rm-arrow { color: var(--warm-grey); }
+  .ae-changelog .ae-cl-item:hover .ae-rm-arrow { color: var(--warm-grey); }
+}
 
 /* ============================================================
    EIENDOMMER — listings index page (/eiendommer)

--- a/src/styles/advanti-design.css
+++ b/src/styles/advanti-design.css
@@ -4584,11 +4584,11 @@ h1, h2, h3 {
 .ae-quote .ae-av {
   width: 44px; height: 44px;
   border-radius: 50%;
-  background-size: cover;
-  background-position: center;
+  overflow: hidden;
   background-color: var(--warm-grey-75);
   flex-shrink: 0;
 }
+.ae-quote .ae-av img { width: 100%; height: 100%; object-fit: cover; }
 .ae-quote .ae-cite .name { font-weight: 500; font-size: 14.5px; font-style: normal; }
 .ae-quote .ae-cite .role { font-size: 12.5px; color: var(--warm-grey-85); font-style: normal; }
 .ae-quote .ae-cite .meta { display: flex; flex-direction: column; }

--- a/src/styles/advanti-design.css
+++ b/src/styles/advanti-design.css
@@ -4685,6 +4685,10 @@ h1, h2, h3 {
   font-weight: 300;
   letter-spacing: 0.01em;
   line-height: 1.4;
+  /* Wide KatexMath can exceed the block on narrow screens — scroll the
+     formula within the block instead of overflowing the whole page. */
+  max-width: 100%;
+  overflow-x: auto;
 }
 .ae-formula .ae-eq sub { font-style: normal; font-size: 0.62em; }
 .ae-formula .ae-desc {

--- a/tests/editorial-mdx.spec.ts
+++ b/tests/editorial-mdx.spec.ts
@@ -1,0 +1,52 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Editorial MDX component regression — locks the backward-compatible prop
+ * mappings in src/components/blog/mdx.tsx that the sitemap crawl only proves
+ * "doesn't crash". These assert the rendered markup so a future refactor of
+ * the wrappers can't silently drop a legacy mapping.
+ *
+ * Added with the .ae-* editorial component family (2026-06-03).
+ */
+
+test("Quote renders legacy customer-quote props (title → role)", async ({
+  page,
+}) => {
+  // corponor.mdx passes the OLD shape: author / authorSrc / title / company /
+  // companySrc / text. The editorial .ae-quote must map `title` → `.role` and
+  // keep `author` → `.name` (company/companySrc intentionally dropped).
+  await page.goto("/kunder/corponor", { waitUntil: "domcontentloaded" });
+  const quote = page.locator(".ae-quote").first();
+  await expect(quote).toBeVisible();
+  await expect(quote.locator(".ae-q")).not.toBeEmpty();
+  await expect(quote.locator(".ae-cite .name")).toHaveText("Steffen Knudsen");
+  await expect(quote.locator(".ae-cite .role")).toHaveText("Daglig leder");
+});
+
+test("Prerequisites renders the legacy markdown-children form", async ({
+  page,
+}) => {
+  // The 3 help articles use <Prerequisites>…markdown list…</Prerequisites>
+  // (children), not the new items={[]} array. The wrapper must render the
+  // children list inside .ae-prereq.
+  await page.goto("/help/article/diskontert-kontantstrom", {
+    waitUntil: "domcontentloaded",
+  });
+  const prereq = page.locator(".ae-prereq").first();
+  await expect(prereq).toBeVisible();
+  await expect(prereq.locator("ul li").first()).toBeVisible();
+});
+
+test("blog article renders editorial Note, Formula and Example components", async ({
+  page,
+}) => {
+  // dcf-analyse exercises legacy Note variant → editorial .ae-note (with a
+  // label), Math → editorial .ae-formula frame, and Example with an emphasized
+  // result row.
+  await page.goto("/blog/dcf-analyse-naringseiendom", {
+    waitUntil: "domcontentloaded",
+  });
+  await expect(page.locator(".ae-note .ae-label").first()).toBeVisible();
+  await expect(page.locator(".ae-formula .ae-eq").first()).toBeVisible();
+  await expect(page.locator(".ae-example tr.is-result").first()).toBeVisible();
+});

--- a/tests/editorial-mdx.spec.ts
+++ b/tests/editorial-mdx.spec.ts
@@ -49,4 +49,21 @@ test("blog article renders editorial Note, Formula and Example components", asyn
   await expect(page.locator(".ae-note .ae-label").first()).toBeVisible();
   await expect(page.locator(".ae-formula .ae-eq").first()).toBeVisible();
   await expect(page.locator(".ae-example tr.is-result").first()).toBeVisible();
+  // Stepper (numbered step) and CTA (editorial band) are the two most-shipped
+  // editorial components after Note — assert they render here too.
+  await expect(page.locator(".ae-stepper .ae-step .ae-sn").first()).toBeVisible();
+  await expect(page.locator(".ae-cta h4").first()).toBeVisible();
+});
+
+test("Summary renders roman numerals (legacy iconName prop ignored)", async ({
+  page,
+}) => {
+  // esg-barekraft-naringseiendom passes the legacy `iconName` field on points;
+  // the editorial Summary must ignore it and render the I/II/III numerals.
+  await page.goto("/blog/esg-barekraft-naringseiendom", {
+    waitUntil: "domcontentloaded",
+  });
+  const summary = page.locator(".ae-summary").first();
+  await expect(summary).toBeVisible();
+  await expect(summary.locator(".ae-item .ae-rn").first()).toHaveText("I");
 });


### PR DESCRIPTION
## Summary

Adopts the `design_handoff_blog_components` editorial system into the blog MDX
renderer — backward-compatibly, so all existing articles keep working.

**Components & styling**
- New `.ae-*` editorial CSS layer in `advanti-design.css` (BLOG section) + two
  low-chroma support tokens (`--ae-caution`, `--ae-positive`). Hairlines,
  restrained type, numbered labels, icon-free — matches DESIGN.md.
- 16 component wrappers in `src/components/blog/mdx.tsx` (6 net-new: Fact,
  StatStrip, Aside, Figure, Timeline, Compare, ReadMore).
- `Note` normalizes legacy `info/warning/success` + editorial
  `neutral/key/caution/positive`. `CTA` → editorial `.ae-cta`; `AnimatedCTA`
  kept as an opt-in. `Math` → editorial frame, `FormulaDisplay` aliases it
  (dedup), children-based `Formula` added.

**Backward compat (verified on live content)**
- `Quote` accepts the legacy customer-quote shape (`title` → `role`); `Prerequisites`
  accepts both `items` and markdown `children`; `Stepper` keeps per-step `formula`
  rendering (6 help articles depend on it).

**Shared renderer**
- MDX wrapper now carries `.ks-prose` (not Tailwind `prose`); per-element
  overrides stripped; redundant `ProseShell` removed from blog/help/kunder pages
  (naringsmegler keeps it — it wraps LocationMdx). One editorial type system
  across all 5 MDX routes.

**A11y / docs**
- `:focus-visible` rings, caution/positive tones on rules only (labels stay
  readable), hover guarded behind `(hover:hover) and (pointer:fine)`.
- `AUTHORING.md` committed + linked from CLAUDE.md/AGENTS.md; `.ae-*` family +
  tokens documented in DESIGN.md §5.

Reviewed via the full pipeline: `/plan-eng-review` → `/plan-design-review` →
`/qa` → `/design-review` → `/ship` (pre-landing + cross-model adversarial).

## Test Coverage
AI-assessed coverage: **85%** (target 80%) — every backward-compat branch that
real content triggers is covered by the Playwright sitemap crawl + dedicated
assertions. Gaps are decorative components with zero shipped content.

New: `tests/editorial-mdx.spec.ts` (locks Quote `title→role`, Prerequisites
children, Note/Formula/Example, Summary roman numerals, Stepper, CTA).
**Full Playwright suite: 84 passing.**

## Pre-Landing Review
2 informational findings, both fixed:
- `.ks-prose` was double-applied on help/kunder (MDX self-applies it + ProseShell) → dropped redundant ProseShell.
- Regression spec omitted Summary/Stepper/CTA → extended.

Performance specialist: clean (the new `Changelog` even drops a whole-collection
barrel import from the client bundle). PR Quality Score: 9/10.

## Design Review
Full `/design-review` run (score A−, AI Slop A). FINDING-001 fixed:
`.ae-formula` lacked overflow containment → wide DCF formulas caused mobile
horizontal scroll (832px @ 375px viewport). Added `max-width:100%; overflow-x:auto`.
One pre-existing breadcrumb-overflow on help headers flagged, out of scope.

## Eval Results
No prompt-related files changed — evals skipped.

## Scope Drift
Scope Check: CLEAN. Delivered the editorial-components foundation plus the
review/QA fixes; the 21-article migration and 5 example articles were explicitly
deferred (TODO 19/20).

## Plan Completion
12/12 plan tasks (T1–T12) DONE — `.ae-*` CSS+tokens, 16 wrappers, Note/CTA/Formula
backward-compat, `.ks-prose` swap, AUTHORING.md, DESIGN.md, a11y (focus/contrast/
hover), build gate.

## Adversarial Review
Cross-model (Claude + Codex, GATE PASS — no P1). Caught and fixed regressions the
component rewrite introduced on live content:
- `Stepper` silently dropped per-step `formula` objects → 6 help articles lost
  their math. Restored.
- `Example` misaligned columns on mixed-calculation rows (live:
  markedsleie-og-leieniva) → calc cell now rendered consistently.
- `Quote` avatar bypassed next/image allowlist → restored `BlurImage`.
- Unguarded `.map` on required array props → defaulted to `[]` so a malformed
  MDX prop can't crash a whole article page.

## Verification Results
Playwright: 84 PASS, 0 FAIL (1 transient `networkidle` flake on a perf test passed
on retry). `tsc --noEmit` clean. `pnpm build` green.

## TODOS
No existing TODO completed by this PR. Two follow-ups added: TODO 19 (migrate the
21 existing articles to editorial components) and TODO 20 (add 5 example articles —
note 3 slug collisions).

## Test plan
- [x] Full Playwright suite passes (84 tests)
- [x] `tsc --noEmit` clean
- [x] `pnpm build` green
- [x] Manual QA on all 5 MDX routes (blog/help/kunder/integrasjoner/eiendommer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced editorial component system for blog posts (notes, facts, statistics, summaries, timelines, comparisons, etc.).
  * Added Supabase Storage CDN support for optimized image delivery.

* **Documentation**
  * Created comprehensive blog authoring guide with best practices and component patterns.
  * Updated design docs and contributor guidance for new editorial components.

* **Refactor**
  * Simplified MDX rendering by removing wrapper layer and implementing direct editorial component rendering.

* **Tests**
  * Added regression tests verifying backward compatibility of editorial components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->