### PR TITLE
feat(eiendommer): nedlastinger fra CRM + redirect-rute

### DIFF
--- a/src/app/eiendommer/[slug]/page.tsx
+++ b/src/app/eiendommer/[slug]/page.tsx
@@ -9,6 +9,7 @@ import { BreadcrumbStructuredData } from "@/components/StructuredData";
 import { siteConfig } from "@/app/siteConfig";
 import { getActiveListings, getListingPost } from "@/lib/content";
 import { getListingGallery } from "@/lib/listing/gallery";
+import { getListingDownloads } from "@/lib/listing/downloads";
 import { constructMetadata } from "@/lib/utils";
 
 // Gallery comes from the CRM Supabase projection (published via CRM). ISR so a
@@ -100,6 +101,10 @@ export default async function EiendomDetailPage({
         : [{ src: listing.coverImage, alt: listing.coverImageAlt }];
   const coverSrc = dbGallery?.cover?.src ?? listing.coverImage;
   const photoCount = dbGallery?.photoCount ?? listing.photoCount;
+
+  // Downloads: CRM-published projection, MDX fallback.
+  const dbDownloads = await getListingDownloads(slug);
+  const downloads = dbDownloads ?? listing.downloads;
   const mainImg = gallery[0];
   const sideImgs = gallery.slice(1, 3);
 
@@ -629,7 +634,7 @@ export default async function EiendomDetailPage({
       )}
 
       {/* DOWNLOADS */}
-      {listing.downloads && listing.downloads.length > 0 && (
+      {downloads && downloads.length > 0 && (
         <section className="ed-section">
           <div className="wrap">
             <div className="head">
@@ -646,7 +651,7 @@ export default async function EiendomDetailPage({
               </div>
             </div>
             <div className="ed-downloads">
-              {listing.downloads.map((dl) => (
+              {downloads.map((dl) => (
                 <Link
                   key={dl.label}
                   href={dl.href}

--- a/src/app/eiendommer/dokument/[id]/route.ts
+++ b/src/app/eiendommer/dokument/[id]/route.ts
@@ -1,0 +1,56 @@
+import "server-only"
+
+import { NextResponse } from "next/server"
+
+import { getSupabase } from "@/lib/supabase/server"
+
+export const runtime = "nodejs"
+export const dynamic = "force-dynamic"
+
+const PUBLIC_BUCKET = "listing-documents"
+
+/**
+ * Clean redirect for an open listing download. The CRM stores this route as the
+ * download's href (raw storage URLs are forbidden in the table); here we look up
+ * the row, verify it's a published open download, and 302 to the public Supabase
+ * object. `noindex` keeps the prospekt PDF out of search results.
+ *
+ *   GET /eiendommer/dokument/<id>
+ *     → row (public_approved=true, has storage_path) → 302 public URL + noindex
+ *     → else 404
+ */
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params
+  const supabase = getSupabase()
+  if (!supabase) return new NextResponse("Not available", { status: 503 })
+
+  const { data } = await supabase
+    .from("crm_property_listing_downloads")
+    .select("storage_path, public_approved, requires_nda")
+    .eq("id", id)
+    .maybeSingle()
+
+  const row = data as
+    | { storage_path: string | null; public_approved: boolean; requires_nda: boolean }
+    | null
+
+  // Open, published downloads only — never NDA rows, never unapproved/missing.
+  if (!row || !row.public_approved || row.requires_nda || !row.storage_path) {
+    return new NextResponse("Not found", { status: 404 })
+  }
+
+  const base = (process.env.SUPABASE_URL ?? "").replace(/\/+$/, "")
+  if (!base) return new NextResponse("Not available", { status: 503 })
+  const url = `${base}/storage/v1/object/public/${PUBLIC_BUCKET}/${row.storage_path}`
+
+  return NextResponse.redirect(url, {
+    status: 302,
+    headers: {
+      "X-Robots-Tag": "noindex",
+      "Cache-Control": "public, max-age=300",
+    },
+  })
+}

--- a/src/lib/listing/downloads.ts
+++ b/src/lib/listing/downloads.ts
@@ -1,0 +1,61 @@
+import "server-only"
+
+import { getSupabase } from "@/lib/supabase/server"
+
+/**
+ * Listing downloads from the CRM projection (crm_property_listing_downloads),
+ * published via the CRM. Open PDFs use the redirect route as their href (raw
+ * storage URLs are forbidden by the table CHECK constraint); NDA rows carry a
+ * broker-set "request access" CTA target. Falls back to MDX in the page.
+ *
+ * SECURITY: service-role bypasses RLS, so filter to public_approved=true. Only
+ * the publish action ever inserts approved rows; unpublish deletes them.
+ */
+
+export interface ListingDownload {
+  label: string
+  sub: string
+  href: string
+  kind: "pdf" | "nda"
+}
+
+interface DownloadRow {
+  label: string
+  description: string | null
+  href: string | null
+  requires_nda: boolean
+}
+
+export function mapDownloads(rows: DownloadRow[]): ListingDownload[] {
+  return rows.map((r) => ({
+    label: r.label,
+    sub: r.description ?? "",
+    href: r.href ?? "#",
+    kind: r.requires_nda ? "nda" : "pdf",
+  }))
+}
+
+export async function getListingDownloads(
+  slug: string,
+): Promise<ListingDownload[] | null> {
+  const supabase = getSupabase()
+  if (!supabase) return null
+
+  const { data: profile } = await supabase
+    .from("crm_property_listing_profiles")
+    .select("id")
+    .eq("public_slug", slug)
+    .maybeSingle()
+  if (!profile?.id) return null
+
+  const { data } = await supabase
+    .from("crm_property_listing_downloads")
+    .select("label, description, href, requires_nda")
+    .eq("listing_profile_id", profile.id)
+    .eq("public_approved", true)
+    .order("sort_order", { ascending: true })
+
+  const rows = (data ?? []) as DownloadRow[]
+  if (rows.length === 0) return null
+  return mapDownloads(rows)
+}


### PR DESCRIPTION
Lane B av nedlastinger→listing (par med Advanti-CRM Lane A).

## Hva
/eiendommer/[slug] henter downloads fra crm_property_listing_downloads (MDX-fallback). Åpne PDF-er via redirect-rute /eiendommer/dokument/[id] → 302 til public bøtte + X-Robots-Tag noindex (IDOR/SEO-herding). NDA-rad = låst CTA.

## NB
Avhenger av Advanti-CRM Lane A. Tomt DB-downloads → MDX-fallback (ingen regresjon).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Listing document downloads now source data from an enhanced CRM system with seamless fallback to existing records, ensuring complete backward compatibility while leveraging improved data organization and management.
  * Introduced a new document download routing service that intelligently handles download requests with automatic redirects, NDA validation, publication status controls, and optimized response caching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->