### PR TITLE
feat(eiendommer): CRM-cover consistency på related + ActiveListingsStrip

### DIFF
--- a/src/app/eiendommer/[slug]/page.tsx
+++ b/src/app/eiendommer/[slug]/page.tsx
@@ -8,7 +8,7 @@ import { PropertyMap } from "@/components/eiendommer/PropertyMap";
 import { BreadcrumbStructuredData } from "@/components/StructuredData";
 import { siteConfig } from "@/app/siteConfig";
 import { getActiveListings, getListingPost } from "@/lib/content";
-import { getListingGallery } from "@/lib/listing/gallery";
+import { getListingGallery, getListingCovers } from "@/lib/listing/gallery";
 import { getListingDownloads } from "@/lib/listing/downloads";
 import { constructMetadata } from "@/lib/utils";
 
@@ -121,6 +121,11 @@ export default async function EiendomDetailPage({
       return aSame - bSame || a.order - b.order;
     })
     .slice(0, 2);
+
+  // CRM-published covers (Supabase) for the related cards — same source as the
+  // hero gallery above, so the "Lignende oppdrag" thumbnails don't show a stale
+  // MDX photo after a publish. MDX cover is the fallback.
+  const relatedCovers = await getListingCovers(related.map((r) => r.slug));
 
   // RealEstateListing JSON-LD — schema.org type that AI Overviews and search
   // engines treat as a first-class property listing. Keeps the @id linked to
@@ -725,8 +730,8 @@ export default async function EiendomDetailPage({
                 >
                   <div className="ei-card-photo">
                     <Image
-                      src={other.coverImage}
-                      alt={other.coverImageAlt}
+                      src={relatedCovers[other.slug]?.src ?? other.coverImage}
+                      alt={relatedCovers[other.slug]?.alt ?? other.coverImageAlt}
                       fill
                       sizes="(max-width: 980px) 50vw, 33vw"
                       style={{ objectFit: "cover" }}

--- a/src/app/naringsmegler/[slug]/page.tsx
+++ b/src/app/naringsmegler/[slug]/page.tsx
@@ -23,6 +23,10 @@ function findStat(
   )?.value;
 }
 
+// ISR: the ActiveListingsStrip pulls CRM-published covers (Supabase); revalidate
+// so a publish appears without a redeploy, same window as /eiendommer.
+export const revalidate = 600;
+
 export async function generateStaticParams() {
   return allLocationPosts.map((location) => ({
     slug: location.slug,

--- a/src/app/tjenester/salg/page.tsx
+++ b/src/app/tjenester/salg/page.tsx
@@ -10,6 +10,10 @@ import StructuredData, {
 
 const LAST_UPDATED = "2026-05-22";
 
+// ISR: the ActiveListingsStrip pulls CRM-published covers (Supabase); revalidate
+// so a publish appears without a redeploy, same window as /eiendommer.
+export const revalidate = 600;
+
 export const metadata = constructMetadata({
   path: "/tjenester/salg",
   title: "Salg av Næringseiendom i Nord-Norge | Advanti",

--- a/src/components/eiendommer/ActiveListingsStrip.tsx
+++ b/src/components/eiendommer/ActiveListingsStrip.tsx
@@ -2,6 +2,7 @@ import Image from "next/image";
 import Link from "next/link";
 
 import { getActiveListings } from "@/lib/content";
+import { getListingCovers } from "@/lib/listing/gallery";
 
 const STATUS_LABELS: Record<string, string> = {
   "til-salgs": "Til salgs",
@@ -53,7 +54,7 @@ interface ActiveListingsStripProps {
  * from advanti-design.css so it visually matches the public listings
  * grid.
  */
-export function ActiveListingsStrip({
+export async function ActiveListingsStrip({
   eyebrow,
   title,
   lede,
@@ -78,6 +79,10 @@ export function ActiveListingsStrip({
   const cards = sorted.slice(0, limit);
 
   if (cards.length === 0) return null;
+
+  // CRM-published covers (Supabase), keyed by slug; MDX cover is the fallback —
+  // same source as the /eiendommer grid so a publish updates every card.
+  const covers = await getListingCovers(cards.map((c) => c.slug));
 
   return (
     <section className="section section-divider">
@@ -105,8 +110,8 @@ export function ActiveListingsStrip({
               >
                 <div className="ei-card-photo">
                   <Image
-                    src={listing.coverImage}
-                    alt={listing.coverImageAlt}
+                    src={covers[listing.slug]?.src ?? listing.coverImage}
+                    alt={covers[listing.slug]?.alt ?? listing.coverImageAlt}
                     fill
                     sizes="(max-width: 680px) 100vw, (max-width: 980px) 50vw, 33vw"
                     style={{ objectFit: "cover" }}


### PR DESCRIPTION
## Hva

Bildene på eiendomskort kommer fra CRM-publisering (Supabase). Etter forrige PR viste `/eiendommer`-grid og detaljsidens hero CRM-cover, men tre andre steder brukte fortsatt **stale MDX-cover** etter en publisering:

- detaljsidens «Lignende oppdrag»-kort
- `ActiveListingsStrip` (på `/tjenester/salg` + `/naringsmegler/[slug]`)

## Endring

- Disse henter nå `getListingCovers` med MDX-cover som fallback (`covers[slug]?.src ?? listing.coverImage`), så en CRM-publisering oppdaterer **alle** kort konsistent.
- `ActiveListingsStrip` er nå `async` (server component).
- La til `revalidate = 600` på `/tjenester/salg` og `/naringsmegler/[slug]` så covers oppdateres uten redeploy (samme ISR-vindu som `/eiendommer`).

Tall og innhold (yield, BTA, fakta, økonomi) forblir MDX-styrt — bevisst valg, CRM publiserer i dag kun bilder.

## Test
- `pnpm build` grønn; `/tjenester/salg` viser nå ISR (10m).
- `tsc` rent på berørte filer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)