### PR TITLE
test(ci): fix flaky /blog page.goto timeouts

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -11,6 +11,10 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   workers: process.env.CI ? 1 : undefined,
+  // Per-test timeout. Default is 30s; bumped to 60s because heavy /blog MDX
+  // pages occasionally take longer than 30s to settle on a cold CI runner,
+  // flaking page.goto. Only trips on a genuine hang, not normal slowness.
+  timeout: 60_000,
   reporter: "list",
   use: {
     baseURL: "http://localhost:3000",

--- a/tests/mobile-overflow.spec.ts
+++ b/tests/mobile-overflow.spec.ts
@@ -31,8 +31,11 @@ for (const route of ROUTES) {
   test(`no horizontal overflow at 375px — ${route}`, async ({ page }) => {
     const res = await page.goto(route);
     expect(res?.status()).toBeLessThan(400);
-    // Let late layout (fonts, images, client components) settle.
-    await page.waitForLoadState("networkidle");
+    // Let late layout (fonts, images, client components) settle. `goto` already
+    // waits for `load`; a short fixed settle catches font/hydration shift
+    // without `networkidle`, which flakes on blog pages that keep a connection
+    // alive and never reach idle under CI load.
+    await page.waitForTimeout(500);
     const { scrollWidth, clientWidth } = await page.evaluate(() => ({
       scrollWidth: document.documentElement.scrollWidth,
       clientWidth: document.documentElement.clientWidth,


### PR DESCRIPTION
## Problem

The `Build, test & perf budget` CI job has been flaking on `/blog` routes: `page.goto` hits the **30s test timeout**, and *which* blog page fails varies run to run (observed across 3 consecutive runs on PR #21 — `/blog`, `/blog/markedspuls-…`, `/blog/advanti-lansering-…`). This is unrelated to feature diffs and blocks unrelated PRs.

## Root cause

Heavy `/blog` MDX pages + `networkidle` waiting:
- `networkidle` never settles when a page keeps a connection alive under CI load — the most flake-prone Playwright wait.
- The default 30s per-test timeout leaves no headroom for a slow cold-start settle on the `pnpm build && pnpm start` server.

## Fix

- **`playwright.config.ts`**: per-test `timeout` 30s → **60s**. Only trips on a genuine hang, not normal slowness.
- **`tests/mobile-overflow.spec.ts`**: replace `waitForLoadState("networkidle")` with a fixed **500ms** settle. `goto` already waits for `load`; the overflow check only needs fonts/hydration settled, not network idle.
- `tests/perf-budget.spec.ts` keeps `networkidle` (it must capture lazy JS chunks) but now benefits from the 60s headroom.

No assertion weakened — the overflow threshold and JS budgets are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)