### PR TITLE
fix(tests): green CI after #23 — corponor fixtures + /blog flake

### DIFF
--- a/tests/editorial-mdx.spec.ts
+++ b/tests/editorial-mdx.spec.ts
@@ -9,19 +9,11 @@ import { test, expect } from "@playwright/test";
  * Added with the .ae-* editorial component family (2026-06-03).
  */
 
-test("Quote renders legacy customer-quote props (title → role)", async ({
-  page,
-}) => {
-  // corponor.mdx passes the OLD shape: author / authorSrc / title / company /
-  // companySrc / text. The editorial .ae-quote must map `title` → `.role` and
-  // keep `author` → `.name` (company/companySrc intentionally dropped).
-  await page.goto("/kunder/corponor", { waitUntil: "domcontentloaded" });
-  const quote = page.locator(".ae-quote").first();
-  await expect(quote).toBeVisible();
-  await expect(quote.locator(".ae-q")).not.toBeEmpty();
-  await expect(quote.locator(".ae-cite .name")).toHaveText("Steffen Knudsen");
-  await expect(quote.locator(".ae-cite .role")).toHaveText("Daglig leder");
-});
+// NOTE: The "Quote renders legacy customer-quote props" case was removed when
+// the fabricated corponor.mdx case study (its only fixture) was deleted. No
+// content uses the legacy <Quote> shape anymore; the wrapper itself still
+// lives in src/components/blog/mdx.tsx. Re-add a case here if a real page
+// adopts <Quote> again.
 
 test("Prerequisites renders the legacy markdown-children form", async ({
   page,

--- a/tests/mobile-overflow.spec.ts
+++ b/tests/mobile-overflow.spec.ts
@@ -38,7 +38,7 @@ for (const route of ROUTES) {
     // bug). next/image reserves layout space via width/height, so image decode
     // does not change document width.
     await page.waitForLoadState("load");
-    await page.evaluate(() => document.fonts.ready);
+    await page.evaluate(() => document.fonts.ready.then(() => {}));
     const { scrollWidth, clientWidth } = await page.evaluate(() => ({
       scrollWidth: document.documentElement.scrollWidth,
       clientWidth: document.documentElement.clientWidth,

--- a/tests/mobile-overflow.spec.ts
+++ b/tests/mobile-overflow.spec.ts
@@ -31,8 +31,14 @@ for (const route of ROUTES) {
   test(`no horizontal overflow at 375px — ${route}`, async ({ page }) => {
     const res = await page.goto(route);
     expect(res?.status()).toBeLessThan(400);
-    // Let late layout (fonts, images, client components) settle.
-    await page.waitForLoadState("networkidle");
+    // Let late layout settle: the load event (fired by goto) plus web fonts,
+    // which affect text width. We deliberately avoid networkidle — pages like
+    // /blog fan out many on-demand next/image optimizations that keep the
+    // network busy past the 30s timeout in CI (a perf artifact, not an overflow
+    // bug). next/image reserves layout space via width/height, so image decode
+    // does not change document width.
+    await page.waitForLoadState("load");
+    await page.evaluate(() => document.fonts.ready);
     const { scrollWidth, clientWidth } = await page.evaluate(() => ({
       scrollWidth: document.documentElement.scrollWidth,
       clientWidth: document.documentElement.clientWidth,

--- a/tests/routes.spec.ts
+++ b/tests/routes.spec.ts
@@ -62,7 +62,6 @@ const CONVERTED_IMAGES: {
     strict: false,
   },
   { route: "/kunder", selector: ".op-img img", strict: false },
-  { route: "/kunder/corponor", selector: ".op-hero .img img", strict: false },
 ];
 
 for (const { route, selector, strict } of CONVERTED_IMAGES) {


### PR DESCRIPTION
CI på `main` var rød. To uavhengige feil — denne PR-en fikser begge:

## 1. Min regresjon fra #23
`editorial-mdx.spec.ts › Quote …` navigerte til `/kunder/corponor` (slettet i #23). Grønn på #21, rød på #23.
- Fjernet den utdaterte Quote-testen (ingen innhold bruker lenger den gamle `<Quote>`-formen).
- Fjernet `/kunder/corponor` fra `next/image`-rutelisten i `routes.spec.ts`.

## 2. Pre-eksisterende flake (rød siden #21)
`mobile-overflow.spec.ts › /blog` timet ut på `networkidle` (30s). Rotårsak: `/blog` + den tunge markedspuls-artikkelen fyrer av mange on-demand `next/image`-optimaliseringer som holder nettverket opptatt forbi timeouten (`/blog/category/valuation`, med færre cover-bilder, passerer). Det er et perf-artefakt, ikke en overflow-bug.
- Bytter `networkidle` → `load` + `document.fonts.ready`. `next/image` reserverer layout-plass via width/height, så bildedekoding endrer ikke dokumentbredden; fonter gjør det, derfor `fonts.ready`. Overflow-dekningen beholdes uten nettverks-avhengigheten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)