### PR TITLE
content: faktarettinger i markedsartikler + blogg-test-herding

### DIFF
--- a/src/content/blog/advanti-ise-samarbeid.mdx
+++ b/src/content/blog/advanti-ise-samarbeid.mdx
@@ -41,8 +41,8 @@ Denne kombinasjonen av regulatoriske krav, markedsforventninger og store tilgjen
 <Summary
   title="Slik finansieres energitiltakene."
   points={[
-    { title: "Enova-støtte til kartlegging", description: "Enova kan dekke inntil 50 % (maks 400 000 kr) av kostnaden ved energikartlegging for yrkesbygg. De fleste prosjekter får 30–40 % dekning [5]." },
-    { title: "Støtte til energitiltak", description: "Tiltak som forbedrer energitilstanden med minst 20 % kan få opptil 30 % støtte, begrenset til 10 millioner kroner [6]." },
+    { title: "Enova-støtte til kartlegging", description: "Enova kan dekke inntil 30 % (maks 400 000 kr) av kostnaden ved energikartlegging for yrkesbygg. Merk at ordningen er under utfasing – sjekk gjeldende vilkår hos Enova [5]." },
+    { title: "Støtte til energitiltak", description: "Tiltak som forbedrer energitilstanden med minst 20 % kan få inntil 25 % støtte, begrenset til 10 millioner kroner [6]." },
     { title: "Grønne bedriftslån", description: "Banker som Nordea tilbyr grønne bedriftslån med gunstigere vilkår for prosjekter som reduserer klimaavtrykket [7]." },
   ]}
 />
@@ -110,12 +110,12 @@ For et næringsbygg på 3 000 m² med årlige energikostnader på 1,2 millioner 
 
 Samarbeidet mellom Advanti Estate og ISE gjør det mulig å levere en helhetlig energikartlegging og verdivurdering i ett løp. Tjenesten møter regulatoriske krav, tilfredsstiller investorenes forventninger til bærekraft og gir eiendomseiere dokumenterbare gevinster. For markedet i Nord-Norge betyr det raskere energiomstilling, bedre lønnsomhet og eiendommer med høyere verdi.
 
-Tenk deg å slippe bekymringen for om din eiendom møter fremtidige krav – og i stedet vite at den er forberedt for neste tiår. Vi garanterer at energikartlegging vil avdekke besparelsesmuligheter – ellers dekker vi kostnaden.
+Tenk deg å slippe bekymringen for om din eiendom møter fremtidige krav – og i stedet vite at den er forberedt for neste tiår. En grundig energikartlegging avdekker normalt konkrete besparelsesmuligheter og gir et tydelig grunnlag for videre tiltak.
 
 <CTA
   badge="Energikartlegging og verdsettelse"
   title="Få en gratis vurdering av energipotensialet i din eiendom"
-  description="Vi garanterer at energikartlegging vil avdekke besparelsesmuligheter – ellers dekker vi kostnaden."
+  description="En grundig energikartlegging avdekker normalt konkrete besparelsesmuligheter – vi hjelper deg å dokumentere potensialet og sikre støtte."
   primaryAction={{
     label: "Kontakt oss",
     href: "/kontakt"

--- a/src/content/blog/advanti-styrker-laget-bodo-2026.mdx
+++ b/src/content/blog/advanti-styrker-laget-bodo-2026.mdx
@@ -45,7 +45,7 @@ Advanti Estate sporer over 1 400 næringseiendommer på tvers av Bodø, Tromsø,
 
 ## Markedet i Bodø – sterk utvikling
 
-Samtidig som vi styrker teamet, ser vi positive signaler i markedet for øvrig. Equinor markerer 50 år i Nord-Norge, hvor de har 35 prosent av sin norske produksjon. Dette understreker den langsiktige industrielle tyngden i regionen. Nye eiendomsselskaper etableres i hele Nord-Norge, og både Harstad, Alta og Narvik ser ny aktivitet innen kjøp, salg og utleie av eiendom.
+Samtidig som vi styrker teamet, ser vi positive signaler i markedet for øvrig. Equinor markerer 50 år i Nord-Norge, der selskapet i dag har om lag 35 prosent av sin produksjon på norsk sokkel. Dette understreker den langsiktige industrielle tyngden i regionen. Nye eiendomsselskaper etableres i hele Nord-Norge, og både Harstad, Alta og Narvik ser ny aktivitet innen kjøp, salg og utleie av eiendom.
 
 Bodø er et regionalt knutepunkt med sterk offentlig sektor, gode logistikkfunksjoner og et voksende privat næringsliv – et stabilt grunnlag for kontor-, handels- og logistikkeiendom.
 

--- a/src/content/blog/esg-barekraft-naringseiendom.mdx
+++ b/src/content/blog/esg-barekraft-naringseiendom.mdx
@@ -43,7 +43,7 @@ ESG står for tre dimensjoner som til sammen avgjør hvor bærekraftig en eiendo
 <Summary
   title="Regulatoriske krav og hva de betyr."
   points={[
-    { title: "Nye krav", description: "Energiklasse C eller bedre ved utleie (fra 2025), dokumentert energieffektivitet, miljøsertifisering for større bygg og rapportering av klimapåvirkning." },
+    { title: "Nye krav", description: "Energiattest er påkrevd ved utleie og salg (siden 2010). EUs reviderte bygningsenergidirektiv (EPBD) er på høring i Norge og vil – når det innføres – stille minstekrav som først treffer de minst energieffektive yrkesbyggene (de dårligste 16 % innen 2030, 26 % innen 2033). I tillegg etterspørres dokumentert energieffektivitet og klimarapportering." },
     { title: "Påvirkning på eiendommen", description: "Eiendommer uten oppgradering kan ikke leies ut og får lavere verdi. Samtidig oppstår behov for investeringer i energieffektivisering – og muligheter for verdimaksimering." },
   ]}
 />
@@ -53,7 +53,7 @@ ESG står for tre dimensjoner som til sammen avgjør hvor bærekraftig en eiendo
 <Summary
   title="Endringer i leietakeretterspørselen."
   points={[
-    { title: "Endringer i etterspørsel", description: "Offentlige anbud krever energiklasse C eller bedre, større leietakere krever dokumentert bærekraft, og investorer spør aktivt etter ESG-kompatible eiendommer." },
+    { title: "Endringer i etterspørsel", description: "Offentlige anbud vektlegger i økende grad energieffektivitet, større leietakere krever dokumentert bærekraft, og investorer spør aktivt etter ESG-kompatible eiendommer." },
     { title: "Påvirkning på markedet", description: "Høyere etterspørsel og leiepriser for energieffektive eiendommer, lavere etterspørsel etter eldre eiendommer, og lavere tomgangsrisiko." },
   ]}
 />
@@ -90,15 +90,15 @@ ESG står for tre dimensjoner som til sammen avgjør hvor bærekraftig en eiendo
 
 ### Energiklasse og krav
 
-**Nye krav:**
-- Energiklasse C eller bedre ved utleie (fra 2025)
-- Dokumentert energieffektivitet
-- Energieffektiviseringsplan for eldre bygg
-- Krav om oppgradering ved større renoveringer
+**Krav og forventninger:**
+- Energiattest påkrevd ved utleie og salg (siden 2010)
+- EPBD på høring: minstekrav vil treffe de minst energieffektive yrkesbyggene først (de dårligste 16 % innen 2030, 26 % innen 2033)
+- Dokumentert energieffektivitet etterspørres av leietakere og investorer
+- Energikrav ved større ombygginger (TEK17)
 
 **Påvirkning:**
-- Eiendommer uten energiklasse C kan ikke leies ut
-- Lavere verdi for eiendommer som ikke møter krav
+- Bygg med svak energiattest blir mindre attraktive og vanskeligere å leie ut
+- Lavere verdi for eiendommer som ikke møter markedets forventninger
 - Behov for investeringer i energieffektivisering
 - Muligheter for verdimaksimering
 
@@ -210,9 +210,9 @@ ESG står for tre dimensjoner som til sammen avgjør hvor bærekraftig en eiendo
 <Summary
   title="Enova-støtte."
   points={[
-    { title: "Energikartlegging", description: "Opptil 50 % av kostnaden, maks 400 000 kr." },
-    { title: "Energieffektivisering", description: "Opptil 30 % av kostnaden, maks 10 millioner kr." },
-    { title: "Vilkår", description: "Minst 20 % forbedring i energiytelse." },
+    { title: "Energikartlegging", description: "Inntil 30 % av kostnaden, maks 400 000 kr. Ordningen er under utfasing – sjekk gjeldende vilkår hos Enova." },
+    { title: "Energieffektivisering", description: "Inntil 25 % av kostnaden, maks 10 millioner kr." },
+    { title: "Vilkår", description: "Minst 20 % forbedring i energitilstand." },
   ]}
 />
 

--- a/src/content/blog/handelseiendom-tilbake-2026.mdx
+++ b/src/content/blog/handelseiendom-tilbake-2026.mdx
@@ -23,7 +23,7 @@ I flere år har handelseiendom vært stemplet som en taper. Netthandel, pandemi 
 
 Ragde Eiendom kjøpte Kvantum Kjøpesenter og Semsvegen 46 på Notodden — 8.600 kvadratmeter handelsareal. Selskapet, med driftsinntekter på 2,3 milliarder kroner, fortsetter å ekspandere i dagligvare- og handelssegmentet.
 
-Reitan Eiendom er i en egen klasse. Gjennom AKA AS, Reitan Eiendom og Steensland-familiens selskap Straen ble 64 danske handelseiendommer kjøpt av Rema 1000 Danmark — til en verdi av 422 millioner kroner. Samtidig har Reitan Retail kjøpt 114 butikker av Aldi i Danmark.
+Reitan Eiendom er i en egen klasse. Gjennom konsortiet DK Retail Invest (AKA, Reitan Eiendom og Steensland-familiens selskap Straen) ble 64 danske handelseiendommer — med Rema 1000 Danmark som leietaker — kjøpt for rundt 2,8 milliarder kroner i januar 2024, og konsortiet overtok ytterligere 9 eiendommer høsten 2025. Samtidig har Reitan Retail kjøpt 114 butikker av Aldi i Danmark.
 
 Alti går inn i Sverige og overtar et svensk kjøpesenter, et tydelig signal om at den norske kjøpesenteraktøren ser muligheter også utenfor landegrensene.
 

--- a/src/content/blog/sydvaranger-kirkenes-naeringseiendom-2026.mdx
+++ b/src/content/blog/sydvaranger-kirkenes-naeringseiendom-2026.mdx
@@ -9,7 +9,7 @@ categories:
 slug: sydvaranger-kirkenes-naeringseiendom-2026
 ---
 
-En gruve på størrelse med Sydvaranger åpner ikke uten ringvirkninger. Når Grangex planlegger produksjonsstart i slutten av 2026, er det ikke bare jernmalm som skal opp av bakken — det er et helt lokalsamfunn og næringsliv som skal våkne til liv.
+En gruve på størrelse med Sydvaranger åpner ikke uten ringvirkninger. Når Grangex tar sikte på å gjenåpne gruven, er det ikke bare jernmalm som skal opp av bakken — det er et helt lokalsamfunn og næringsliv som skal våkne til liv.
 
 Spørsmålet er: Hvem er forberedt?
 
@@ -19,11 +19,11 @@ Spørsmålet er: Hvem er forberedt?
 
 ## Hva er faktisk i ferd med å skje?
 
-Sydvaranger Gruve i Kirkenes er Europas tredje største jernmalmsgruve. Grangex har fullført en gjennomføringsstudie som viser en netto nåverdi på 1,5 milliarder dollar over 25 års levetid.
+Sydvaranger i Kirkenes omtales av Grangex som Europas tredje største jernmalmsgruve. Selskapets gjennomføringsstudie (DFS, 2025) viser en netto nåverdi før skatt på rundt 1,5 milliarder dollar over 25 års levetid. Tallene under er Grangex' egne prosjektestimater fra studien.
 
 <StatStrip
   items={[
-    { value: "1,5 mrd.", unit: "USD", label: "Netto nåverdi over 25 års levetid" },
+    { value: "1,5 mrd.", unit: "USD", label: "Netto nåverdi (før skatt) over 25 års levetid" },
     { value: "56", unit: "USD/tonn", label: "Beregnet driftskostnad" },
     { value: "138", unit: "USD/tonn", label: "Estimert gjennomsnittlig salgspris" },
   ]}
@@ -34,14 +34,14 @@ Produksjonen starter i to faser:
 <Summary
   title="Produksjonsfaser."
   points={[
-    { title: "Fase 1 (år 1-4)", description: "2,5 millioner tonn magnetittkonsentrat årlig. Første kommersielle eksport ventes i slutten av 2026, med kapitalutgifter på 193,6 millioner dollar." },
+    { title: "Fase 1 (år 1-4)", description: "2,5 millioner tonn magnetittkonsentrat årlig, med kapitalutgifter på 193,6 millioner dollar. Oppstart avhenger av den endelige investeringsbeslutningen (FID), som Grangex har utsatt til tredje kvartal 2026 — og av at finansieringen kommer på plass." },
     { title: "Fase 2 (år 4+)", description: "3,0-3,5 millioner tonn årlig med ny knuser og infrastruktur. Investering på 223,8 millioner dollar." },
   ]}
 />
 
 Driftskostnadene er beregnet til 56 dollar per tonn, mens gjennomsnittlig salgspris er estimert til 138 dollar — marginene er solide.
 
-Allerede har finske Hartikainen, en av Nordens største gruveentreprenører, signert avtale og rekrutterer til norsk avdeling for oppstart i 2026.
+Finske E. Hartikainen Oy, en erfaren nordisk gruveentreprenør, signerte en tjenesteavtale med Grangex i januar 2026 og planlegger en norsk avdeling — men selve oppstarten er betinget av investeringsbeslutningen.
 
 ## Hva betyr dette for næringseiendom?
 

--- a/tests/mobile-overflow.spec.ts
+++ b/tests/mobile-overflow.spec.ts
@@ -27,17 +27,26 @@ const ROUTES = [
 
 test.use({ viewport: { width: 375, height: 812 } });
 
+// The overflow check must not depend on image loading: external avatar CDNs
+// (imagedelivery.net, avatar.vercel.sh) hang in CI where external egress is
+// slow/blocked, and the single-worker prod server optimizes many next/image
+// covers on demand — both push `load` past the 30s timeout. Abort every image
+// request: next/image reserves layout space via width/height, so document
+// width (the thing we measure) is unaffected, while `load` now fires fast with
+// CSS applied.
+test.beforeEach(async ({ page }) => {
+  await page.route(
+    /imagedelivery\.net|avatar\.vercel\.sh|\/_next\/image/,
+    (route) => route.abort(),
+  );
+});
+
 for (const route of ROUTES) {
   test(`no horizontal overflow at 375px — ${route}`, async ({ page }) => {
     const res = await page.goto(route);
     expect(res?.status()).toBeLessThan(400);
-    // Let late layout settle: the load event (fired by goto) plus web fonts,
-    // which affect text width. We deliberately avoid networkidle — pages like
-    // /blog fan out many on-demand next/image optimizations that keep the
-    // network busy past the 30s timeout in CI (a perf artifact, not an overflow
-    // bug). next/image reserves layout space via width/height, so image decode
-    // does not change document width.
-    await page.waitForLoadState("load");
+    // `load` (default) now resolves quickly since images are aborted, with CSS
+    // applied. Also wait for web fonts — they affect text width.
     await page.evaluate(() => document.fonts.ready.then(() => {}));
     const { scrollWidth, clientWidth } = await page.evaluate(() => ({
       scrollWidth: document.documentElement.scrollWidth,

--- a/tests/perf-budget.spec.ts
+++ b/tests/perf-budget.spec.ts
@@ -26,6 +26,18 @@ const JS_BUDGET_KB: Record<string, number> = {
   "/help/article/diskontert-kontantstrom": 710,
 };
 
+// Abort image requests (external avatar CDNs + the next/image optimizer) so
+// networkidle can settle in CI — external egress is slow/blocked there and the
+// single-worker prod server optimizes covers on demand, either of which would
+// otherwise hang the navigation past the 30s timeout. We only measure .js
+// transfer, so dropping images does not affect the budget.
+test.beforeEach(async ({ page }) => {
+  await page.route(
+    /imagedelivery\.net|avatar\.vercel\.sh|\/_next\/image/,
+    (route) => route.abort(),
+  );
+});
+
 for (const [route, budgetKb] of Object.entries(JS_BUDGET_KB)) {
   test(`JS budget: ${route}`, async ({ page }) => {
     await page.goto(route, { waitUntil: "networkidle" });


### PR DESCRIPTION
## Innhold (faktarettinger, verifisert mot kilder)
Dobbeltsjekk av Tier 2-fakta fant **3 reelle feil** + utdaterte tall:

- **handelseiendom**: 64-eiendomshandelen var **~2,8 mrd kr (jan 2024)**, ikke 422 mill (det var en separat 9-eiendoms tranche, okt 2025).
- **sydvaranger**: «produksjonsstart slutten av 2026» utdatert (**FID utsatt til Q3 2026**); DFS-tall rammet som Grangex' egne estimater + NPV **før skatt**; «Europas tredje største» attribuert.
- **esg**: «energiklasse C ved utleie fra 2025» **finnes ikke** — erstattet med korrekt EPBD-status; Enova 50%→30% / 30%→25%.
- **styrker-laget**: Equinor «~35 % av sin produksjon på **norsk sokkel**».
- **ise-samarbeid**: ISE bekreftet reelt og **registrert i CRM**. Beholdt, men rettet Enova-tall og dempet «vi garanterer … ellers dekker vi»-løftene.

## Test-herding (CI-flake, pre-eksisterende)
#24 var utilstrekkelig — `page.goto` selv timet ut på bloggsider, og `perf-budget` traff samme vegg. Rotårsak: bloggsider laster forfatter-avatarer fra eksterne CDN-er (imagedelivery.net, avatar.vercel.sh) + mange `next/image`-cover optimaliseres on-demand på én CI-worker. Begge `mobile-overflow` og `perf-budget` avbryter nå alle bilde-requests (eksterne + `/_next/image`) — `next/image` reserverer layout-plass via width/height, så hverken overflow- eller JS-måling påvirkes. **CI verifisert grønn.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)