### PR TITLE
feat(eiendommer): add Steigen city label (Engeløya)

### DIFF
--- a/src/app/eiendommer/[slug]/page.tsx
+++ b/src/app/eiendommer/[slug]/page.tsx
@@ -38,6 +38,7 @@ const CITY_LABELS: Record<string, string> = {
   andenes: "Andenes",
   lodingen: "Lødingen",
   glomfjord: "Glomfjord",
+  steigen: "Steigen",
 };
 
 function formatInt(value: number) {

--- a/src/app/eiendommer/page.tsx
+++ b/src/app/eiendommer/page.tsx
@@ -26,6 +26,7 @@ const CITY_LABELS: Record<string, string> = {
   andenes: "Andenes",
   lodingen: "Lødingen",
   glomfjord: "Glomfjord",
+  steigen: "Steigen",
 };
 
 const STATUS_LABELS: Record<string, string> = {


### PR DESCRIPTION
Adds the `steigen` → "Steigen" label for the newly published Engeløyveien 287 listing (Engeløya, Steigen). Data already in Supabase (`is_public_ready=true`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)