### PR TITLE
feat(eiendommer): restore Bodø Byport as featured listing

### DIFF
--- a/src/content/listings/bodo-byport-stormyra.mdx
+++ b/src/content/listings/bodo-byport-stormyra.mdx
@@ -10,8 +10,9 @@ city: bodo
 address: "Stormyrveien 49–61 · 8008 Bodø"
 reference: "AE-2026-011"
 cardEyebrow: "11 · Utvikling"
-featured: false
-order: 1
+featured: true
+featuredEyebrow: "Utvalgt oppdrag · Bodø"
+order: 0
 publishedAt: "2026-06-03"
 updatedAt: "2026-06-03"
 bta: 3012


### PR DESCRIPTION
Restores **Bodø Byport** (Stormyra) — a real development mandate with **9 real photos** in Supabase that was wrongly archived with the samples. Un-archives its MDX (full rich presentation: tenants, financials, location, downloads) while photos come from `crm_property_listing_media`. Featured → leads /eiendommer. Vikingveien unfeatured in DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * A Bodø listing is now featured and displays with the label "Utvalgt oppdrag · Bodø" with optimized ordering for improved visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->