### PR TITLE
feat(eiendommer): «til leie»-støtte + megler-sjekkliste

### DIFF
--- a/docs/eiendommer-oppdrag-publisering.md
+++ b/docs/eiendommer-oppdrag-publisering.md
@@ -38,11 +38,11 @@ crm_cases (oppdrag)  →  crm_properties (eiendom)  →  crm_property_listing_pr
 
 ## 3. Nåværende tilstand
 
-> **Oppdatert 2026-06-08:** 3 salgsoppdrag publisert (ADV-112/113/114) — **14 profiler live nå** (var 11). Se §4B.
+> **Oppdatert 2026-06-08:** 3 salgsoppdrag (ADV-112/113/114) + 1 utleieoppdrag (ADV-115, Sjøgata 34/36) publisert — **15 profiler live nå** (var 11). «Til leie» er nå støttet (§6).
 
-- **14 profiler er live** (`is_public_ready = true`) — men de fleste mangler **bilder** (faller tilbake på placeholder-byggbilde). Flere mangler pris/yield/BTA.
+- **15 profiler er live** (`is_public_ready = true`) — men de fleste mangler **bilder** (faller tilbake på placeholder-byggbilde). Flere mangler pris/yield/BTA.
 - **1 profil ikke web-klar:** Bodø Byport (`bodo-byport-stormyra`) — drives fortsatt fra MDX, har 9 bilder.
-- **~22 aktive «markedsklare» oppdrag mangler fortsatt web-profil** (off-market, utleie, avventende + de med åpne spørsmål).
+- **~21 aktive «markedsklare» oppdrag mangler fortsatt web-profil** (off-market, resten av utleie, avventende + de med åpne spørsmål).
 
 Aktive faser i `case_fase` (rekkefølge): `oppdragsavtale_sendt → signert → sjekkliste_sendt → **markedsklart** → bud → bud_akseptert → due_diligence → kontrakt_ok → solgt`.
 «Markedsklart» og senere = aktivt i markedet. Alt under er for tidlig å publisere.
@@ -109,7 +109,7 @@ Web-modellen er **salgsorientert** (`website_status ∈ til-salgs / reservert / 
 | Adresse | By | Type | Ledig m² | Leie/yield | Megler |
 |---|---|---|---|---|---|
 | Storgata 42 | Tromsø | kontor | 450 | 1 850 kr/m² · yield 6,2 | *uten megler* |
-| Sjøgata 34/36 | Bodø | kontor | 320 (av 900) | 1 950 kr/m² · yield 7,1 | Christer Hagen |
+| ✅ Sjøgata 34/36 | Bodø | kontor | 320 (av 900) | 1 950 kr/m² · yield 7,1 | Christer Hagen — **Publisert ADV-115** |
 | Jernbaneveien 85 | Bodø | kontor | — | — | Mathias Nilsen |
 | Jernbaneveien 61 | Bodø | kontor | 840 | — | Christer Hagen |
 | Klinkerveien 7 | Bodø | industri | 949 | — | Christer Hagen |
@@ -233,16 +233,35 @@ from crm_property_listing_profiles where public_slug = 'sandgata-4b-bodo';
 
 ---
 
-## 6. Utleie — hva som må til (§4E)
+## 6. Utleie — «til leie» (✅ implementert 2026-06-08)
 
-Per nå viser `/eiendommer` kun salgsstatuser. For å vise de 13 utleieoppdragene ordentlig, velg én tilnærming:
+Status `til-leie` er nå støttet ende-til-ende:
+- DB: `website_status` tillater `'til-leie'`, og ny kolonne `leie_kr_m2` (NOK/m²/år).
+- Kode: «Til leie»-etikett + filter-chip + egen badge-farge (light-blue). Pris-cellen viser leie (kr/m²) i stedet for prisantydning, på både kort og detaljside (`listings.ts`, `page.tsx`, `[slug]/page.tsx`, `ListingsBrowser.tsx`, `advanti-design.css`).
+- **Demonstrator publisert:** Sjøgata 34/36 (ADV-115).
 
-1. **Minimal:** Legg til status `til-leie` (label «Til leie») i web-modellen og kort-rendering.
-   - Berørte steder: status-enum/label-mapping i `src/lib/listing/listings.ts`, statusfilter + KPI-telling i `src/app/eiendommer/page.tsx` (`activeCount`-filteret), og statusetikett på kort/detaljside.
-   - Bruk leiefelter i stedet for pris: `leie_nok_per_m2`, `ledig_m2`, evt. `yield_netto`.
-2. **Egen flate:** Eget filter/seksjon «Til leie» på siden, eller egen rute `/eiendommer/leie`.
+**Publiser et utleieoppdrag** (samme mal som §5.1, men):
+```sql
+-- website_status = 'til-leie', sett leie_kr_m2, og la bta_m2 være UTLEIBART areal
+insert into crm_property_listing_profiles (
+  property_id, public_slug, website_status, website_type, type_label, city_slug,
+  reference, title, title_head, title_tail, status_label, card_eyebrow,
+  sort_order, published_at, listing_updated_at, summary, body_mdx,
+  bta_m2, leie_kr_m2, prisantydning_estimat, yield_estimat,
+  address, megler, facts, is_public_ready
+) values (
+  '<property_id>', '<slug>', 'til-leie', 'kontor', 'Kontor', '<by>',
+  'ADV-1xx', '<tittel>', '<head>', '<tail>', 'Til leie', '<eyebrow>',
+  16, current_date, current_date, '<ingress>', '<brødtekst>',
+  320,            -- bta_m2 = utleibart areal
+  1950,           -- leie_kr_m2 (NOK/m²/år)
+  false, false,
+  '<adresse>', '<megler-jsonb>'::jsonb, '<facts-jsonb>'::jsonb,
+  false           -- kontroller, så true
+);
+```
 
-Anbefalt: alternativ 1 (minst arbeid, samler salg + leie ett sted). Tas som egen liten oppgave før utleie publiseres.
+De gjenstående 12 utleieoppdragene (§4E) er klare til publisering så snart **leiepris** og helst **ledig-fra/foto** er fylt inn per eiendom.
 
 ---
 

--- a/docs/megler-sjekkliste-eiendommer.md
+++ b/docs/megler-sjekkliste-eiendommer.md
@@ -1,0 +1,64 @@
+# Sjekkliste: legge et oppdrag ut på advantiestate.no
+
+> Til meglerne i Advanti. Fyll ut dette per oppdrag som skal publiseres på **/eiendommer**. Jo mer komplett, jo raskere og bedre blir listingen. Felt merket ⭐ er **påkrevd** — uten dem kan vi ikke publisere.
+
+Send utfylt info (eller legg det inn i CRM på eiendommen) til den som publiserer. Listingen er som regel ute på nett innen ~10 minutter.
+
+---
+
+## 1. Alltid (gjelder alle oppdrag)
+
+- ⭐ **Adresse** (eksakt) + by/sted + kommune
+- ⭐ **Hva slags eiendom:** kontor / logistikk / handel / kombinasjon / hotell-overnatting / utvikling-tomt / industri
+- ⭐ **Status:** Til salgs · Til leie · Reservert · Kommer · Solgt
+- ⭐ **Areal i m²** (BTA for salg / utleibart areal for leie)
+- ⭐ **Ansvarlig megler:** navn, **e-post som faktisk sjekkes**, mobil, og et profilbilde
+- ⭐ **Kort beskrivelse:** 1–2 setninger som «selger» eiendommen (vises på kortet)
+- ⭐ **Lengre tekst:** 1–3 avsnitt om eiendommen, beliggenhet og muligheter
+- ⭐ **Samtykke:** har oppdragsgiver sagt ja til at eiendommen markedsføres **åpent** på nett? (Hvis nei → off-market, se punkt 5.)
+
+## 2. Salgsoppdrag
+
+- ⭐ **Prisantydning** (kroner) — eller beskjed om at pris skal være skjult («pris på forespørsel»)
+- **Netto yield (%)** — og si fra om det er et estimat
+- **Nøkkeltall:** byggeår, tomteareal, standard, energimerking, regulering, eierform
+- **Hvis utleid bygg (investering):** leieoversikt (leietaker, areal, årlig leie, når kontrakten utløper), samt utleiegrad
+
+## 3. Utleieoppdrag
+
+- ⭐ **Ledig areal** (m²) — og totalt areal hvis bygget er større
+- ⭐ **Leiepris** — kr per m² per år (eller et intervall)
+- **Kan arealet deles?** (f.eks. «fra 100 m²»)
+- **Ledig fra** (dato)
+- **Felleskostnader** og hva som inngår
+- **Fasiliteter:** parkering, møterom, ventilasjon/standard, heis osv.
+
+## 4. Bilder og dokumenter
+
+- **Foto** (viktigst!): 3–6 gode bilder — fasade, interiør og gjerne beliggenhet/drone. *Uten foto viser vi et nøytralt placeholder-bilde inntil ekte foto er på plass.*
+- **Salgsprospekt** (PDF) — den åpne versjonen som alle kan laste ned
+- **Plantegninger**
+- **DD-pakke** — dokumenter som skal ligge bak signert taushetserklæring (NDA)
+- Ev. energiattest, takst/verdivurdering, reguleringsplan
+
+## 5. Off-market (konfidensielle oppdrag)
+
+Skal eiendommen **ikke** annonseres åpent? Da lager vi et anonymt teaser-kort. Send da kun:
+
+- Region (f.eks. «Alta sentrum») — **ikke** eksakt adresse
+- Type + omtrentlig størrelse (BTA)
+- Prisorden (~MNOK)
+- Status: NDA eller Aktiv
+
+❌ **Ikke** del adresse, eiernavn, foto eller andre detaljer som kan identifisere eiendommen offentlig.
+
+## 6. Husk (personvern)
+
+- Ikke oppgi **privatpersoners navn** som eier offentlig uten samtykke — vi viser selskap, eller «privat eier».
+- Kontroller at meglerens kontaktinfo er riktig **før** den vises offentlig (e-post og telefon brukes av interessenter).
+
+---
+
+### Kort oppsummert — minimum for å komme på nett
+**Adresse · type · status · areal · pris (eller leie) · megler · kort tekst · samtykke til åpen markedsføring.**
+Resten (foto, yield, dokumenter, nøkkeltall) løfter kvaliteten og legges gjerne til fortløpende.

--- a/src/app/eiendommer/[slug]/page.tsx
+++ b/src/app/eiendommer/[slug]/page.tsx
@@ -21,6 +21,7 @@ export const revalidate = 600;
 
 const STATUS_LABELS: Record<string, string> = {
   "til-salgs": "Til salgs",
+  "til-leie": "Til leie",
   reservert: "Reservert",
   kommer: "Kommer",
   solgt: "Solgt",
@@ -306,7 +307,16 @@ export default async function EiendomDetailPage({
                 </div>
               )}
             </div>
-            {listing.prisantydning !== undefined ? (
+            {listing.status === "til-leie" && listing.leieKrM2 !== undefined ? (
+              <div>
+                <div className="l">Leiepris</div>
+                <div className="v">
+                  {formatInt(listing.leieKrM2)}
+                  <span className="unit">kr/m²</span>
+                </div>
+                <div className="sub">Per år</div>
+              </div>
+            ) : listing.prisantydning !== undefined ? (
               <div>
                 <div className="l">Prisantydning</div>
                 <div className="v">

--- a/src/app/eiendommer/page.tsx
+++ b/src/app/eiendommer/page.tsx
@@ -32,6 +32,7 @@ const CITY_LABELS: Record<string, string> = {
 
 const STATUS_LABELS: Record<string, string> = {
   "til-salgs": "Til salgs",
+  "til-leie": "Til leie",
   reservert: "Reservert",
   kommer: "Kommer",
   solgt: "Solgt",
@@ -106,7 +107,10 @@ export default async function EiendommerPage() {
 
   // KPI totals
   const activeCount = listings.filter(
-    (listing) => listing.status === "til-salgs" || listing.status === "reservert",
+    (listing) =>
+      listing.status === "til-salgs" ||
+      listing.status === "til-leie" ||
+      listing.status === "reservert",
   ).length;
   const totalBta = listings.reduce((acc, listing) => acc + listing.bta, 0);
   const totalPrice = listings.reduce(
@@ -158,6 +162,7 @@ export default async function EiendommerPage() {
     bta: listing.bta,
     prisantydning: listing.prisantydning,
     prisantydningEstimat: listing.prisantydningEstimat ?? false,
+    leieKrM2: listing.leieKrM2,
     yieldNetto: listing.yieldNetto,
     yieldEstimat: listing.yieldEstimat ?? false,
     ferdig: listing.ferdig,
@@ -264,7 +269,7 @@ export default async function EiendommerPage() {
               <div className="label">Aktive oppdrag</div>
               <div className="val">
                 {activeCount}
-                <span className="unit">til salgs nå</span>
+                <span className="unit">aktive nå</span>
               </div>
               <div className="delta">Oppdatert {formatEditorialDate(newestUpdated)}</div>
             </div>

--- a/src/components/eiendommer/ListingsBrowser.tsx
+++ b/src/components/eiendommer/ListingsBrowser.tsx
@@ -14,7 +14,7 @@ const SAVED_SEARCH_INITIAL: EiendomVarselFormState = { status: "idle" };
 export type ListingCardData = {
   slug: string;
   href: string;
-  status: "til-salgs" | "reservert" | "kommer" | "solgt";
+  status: "til-salgs" | "reservert" | "kommer" | "solgt" | "til-leie";
   statusLabel: string;
   type:
     | "kontor"
@@ -41,6 +41,7 @@ export type ListingCardData = {
   bta: number;
   prisantydning?: number;
   prisantydningEstimat: boolean;
+  leieKrM2?: number;
   yieldNetto?: number;
   yieldEstimat: boolean;
   ferdig?: string;
@@ -65,6 +66,7 @@ type Counts = {
 const STATUS_OPTIONS: { value: string; label: string }[] = [
   { value: "alle", label: "Alle" },
   { value: "til-salgs", label: "Til salgs" },
+  { value: "til-leie", label: "Til leie" },
   { value: "reservert", label: "Reservert" },
   { value: "kommer", label: "Kommer" },
   { value: "solgt", label: "Solgt" },
@@ -97,6 +99,11 @@ function formatInt(value: number): string {
 }
 
 function priceLabel(card: ListingCardData) {
+  if (card.status === "til-leie") {
+    return card.leieKrM2 !== undefined
+      ? { label: "Leie", value: formatInt(card.leieKrM2), unit: "kr/m²" }
+      : { label: "Leie", value: "På forespørsel", unit: "" };
+  }
   if (card.ferdig) {
     return {
       label: "Ferdig",

--- a/src/lib/listing/listings.ts
+++ b/src/lib/listing/listings.ts
@@ -70,6 +70,7 @@ export interface Listing {
   bta: number
   prisantydning?: number
   prisantydningEstimat: boolean
+  leieKrM2?: number // asking rent NOK/m²/year — shown instead of price for "til-leie"
   yieldNetto?: number
   yieldEstimat: boolean
   utleiegrad?: number
@@ -204,6 +205,7 @@ interface ProfileRow {
   bta_m2: number | null
   prisantydning_nok: number | null
   prisantydning_estimat: boolean | null
+  leie_kr_m2: number | null
   yield_netto: number | null
   yield_estimat: boolean | null
   utleiegrad: number | null
@@ -252,6 +254,7 @@ const PROFILE_COLUMNS = [
   "bta_m2",
   "prisantydning_nok",
   "prisantydning_estimat",
+  "leie_kr_m2",
   "yield_netto",
   "yield_estimat",
   "utleiegrad",
@@ -323,6 +326,7 @@ function mapProfileToListing(row: ProfileRow): Listing {
     bta: row.bta_m2 ?? 0,
     prisantydning: nok(row.prisantydning_nok),
     prisantydningEstimat: row.prisantydning_estimat ?? false,
+    leieKrM2: row.leie_kr_m2 ?? undefined,
     yieldNetto: row.yield_netto ?? undefined,
     yieldEstimat: row.yield_estimat ?? false,
     utleiegrad: row.utleiegrad ?? undefined,

--- a/src/styles/advanti-design.css
+++ b/src/styles/advanti-design.css
@@ -5136,6 +5136,8 @@ h1, h2, h3 {
 }
 .ei-status.til-salgs { background: var(--warm-white); }
 .ei-status.til-salgs .dot { background: var(--accent); }
+.ei-status.til-leie { background: var(--light-blue); color: #0f5b62; }
+.ei-status.til-leie .dot { background: #0f8a93; }
 .ei-status.reservert { background: #f4ecdc; color: #6e5418; }
 .ei-status.reservert .dot { background: #c89327; }
 .ei-status.solgt { background: var(--warm-grey); color: var(--warm-white); }


### PR DESCRIPTION
## Hva

Gjør at **utleieoppdrag** kan publiseres på `/eiendommer` (siden var tidligere kun salgsorientert).

### Endringer
- **DB-migrasjon** (kjørt i Supabase: `listing_profiles_add_til_leie_support`):
  - `website_status` tillater nå `'til-leie'`
  - ny kolonne `leie_kr_m2` (NOK/m²/år)
- **«Til leie»-status** ende-til-ende: label, eget filter-chip, og egen badge-farge (light-blue).
- **Pris-cellen** viser leie (`kr/m²`) i stedet for prisantydning for til-leie — på kort (featured + grid) og detaljside.
- **KPI** «Aktive oppdrag» teller nå også til-leie (undertekst endret til «aktive nå»).
- **Demonstrator publisert:** Sjøgata 34/36, Bodø (ADV-115) — 320 m² ledig, 1 950 kr/m², megler Christer Hagen.

### Dokumentasjon
- **`docs/megler-sjekkliste-eiendommer.md`** — megler-vennlig sjekkliste over hva som trengs per oppdrag for å publisere (kan deles direkte med meglerne).
- Runbook oppdatert: §6 markert implementert + publiseringsmønster for utleie, status nå 15 live profiler.

## Merk
- `pnpm build` kjørt lokalt — grønt (exit 0).
- Migrasjonen er allerede aktiv i Supabase; denne PR-en er kode + dokumentasjon.
- De resterende 12 utleieoppdragene er klare når leiepris/foto er fylt inn per eiendom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)