### PR TITLE
feat(eiendommer): Fauske by-label (4 utleieoppdrag publisert)

### DIFF
--- a/src/app/eiendommer/[slug]/page.tsx
+++ b/src/app/eiendommer/[slug]/page.tsx
@@ -42,6 +42,7 @@ const CITY_LABELS: Record<string, string> = {
   glomfjord: "Glomfjord",
   steigen: "Steigen",
   saltstraumen: "Saltstraumen",
+  fauske: "Fauske",
 };
 
 function formatInt(value: number) {

--- a/src/app/eiendommer/page.tsx
+++ b/src/app/eiendommer/page.tsx
@@ -28,6 +28,7 @@ const CITY_LABELS: Record<string, string> = {
   glomfjord: "Glomfjord",
   steigen: "Steigen",
   saltstraumen: "Saltstraumen",
+  fauske: "Fauske",
 };
 
 const STATUS_LABELS: Record<string, string> = {

--- a/src/components/eiendommer/ActiveListingsStrip.tsx
+++ b/src/components/eiendommer/ActiveListingsStrip.tsx
@@ -20,6 +20,7 @@ const CITY_LABELS: Record<string, string> = {
   lofoten: "Lofoten",
   "mo-i-rana": "Mo i Rana",
   saltstraumen: "Saltstraumen",
+  fauske: "Fauske",
 };
 
 function formatInt(value: number) {


### PR DESCRIPTION
## Hva

Fire utleieoppdrag er publisert fra CRM til `/eiendommer` (status `til-leie`), med areal + beskrivelse hentet fra Advantis egne Finn-annonser:

| Ref | Eiendom | Areal | Type |
|---|---|---|---|
| ADV-116 | Jernbaneveien 61, Bodø | 840 m² | Kombinasjon |
| ADV-117 | Sandhorngata 43, Bodø (Innovation Gate) | 800 m² | Kombinasjon |
| ADV-118 | Klinkerveien 7, Bodø | 949 m² | Verksted/lager |
| ADV-119 | Finneidkaiveien 1, Fauske | 24–1 765 m² | Lager/logistikk |

Finneidkaiveien ligger i Fauske, så `fauske → "Fauske"` legges til i `CITY_LABELS` (3 filer) slik at bykortet viser riktig navn.

## Merk
- Leiepris vises ikke offentlig på Finn → listingene står med «Leie på forespørsel» til megler oppgir kr/m².
- Finneidkaiveien er omklassifisert fra salg til utleie (bekreftet mot Finn).
- `pnpm build` grønt (exit 0). Listingene er allerede live i Supabase; PR-en gjelder by-etiketten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)