### PR TITLE
feat(seo): tjeneste×by-landingssider + AEO/LLM-search-forbedringer

### DIFF
--- a/src/app/llms.txt/route.ts
+++ b/src/app/llms.txt/route.ts
@@ -3,14 +3,24 @@ import {
   allHelpPosts,
   allLocationPosts,
   allCustomersPosts,
-  allListingPosts,
 } from "content-collections";
 import { siteConfig } from "../siteConfig";
+import { getListings } from "@/lib/listing/listings";
+import {
+  SERVICE_SLUGS,
+  SERVICE_CITY_SLUGS,
+  getServiceDef,
+  getServiceCityLocation,
+} from "@/lib/service-cities";
 
-// llmstxt.org-compliant Markdown for AI engines (ChatGPT, Claude, Perplexity).
-// Hand-curated section headings + descriptions; auto-listed entries inside each
-// section from the same content collections that drive sitemap.ts.
-export const dynamic = "force-static";
+// llmstxt.org-compliant Markdown for AI engines (ChatGPT, Claude, Perplexity,
+// Google AI Overviews). Hand-curated section headings + descriptions; auto-listed
+// entries inside each section from the same sources that drive sitemap.ts.
+//
+// ISR (not force-static): the listing section is sourced from the CRM (Supabase)
+// via getListings(), so revalidate on the same window as /eiendommer + sitemap so
+// a newly published mandate is exposed to AI engines without a redeploy.
+export const revalidate = 600;
 
 const SERVICES: Array<{
   path: string;
@@ -61,20 +71,20 @@ function line(title: string, url: string, description?: string): string {
     : `- [${title}](${url})`;
 }
 
-function buildBody(baseUrl: string): string {
+async function buildBody(baseUrl: string): Promise<string> {
   const sections: string[] = [];
 
   // H1 + blockquote summary per llmstxt.org spec.
   sections.push(`# Advanti`);
   sections.push(
-    `> Næringsmegler i Nord-Norge. Salg, utleie, verdivurdering og rådgivning for næringseiendom i Nordland og Troms. Datadrevet, lokalt forankret, partnerstyrt.`,
+    `> Næringsmegler i Nord-Norge. Salg, utleie, verdivurdering og rådgivning for næringseiendom i Nordland, Troms og Finnmark. Datadrevet, lokalt forankret, partnerstyrt.`,
   );
 
   sections.push(
     [
       `Advanti er et meglerhus for næringseiendom med kontorer i Nord-Norge.`,
       `Vi kombinerer lokal markedskunnskap med kvantitativ analyse (DCF, yield, sensitivitet) for å hjelpe eiere, investorer og leietakere ta bedre beslutninger.`,
-      `Hovedmarkedet er Bodø, Tromsø, Alta, Narvik og Lofoten.`,
+      `Hovedmarkedene er Bodø, Tromsø, Alta, Harstad, Narvik, Mo i Rana og Lofoten.`,
       `Kontakt: ${siteConfig.contact?.email ?? "post@advantiestate.no"}.`,
     ].join(" "),
   );
@@ -85,6 +95,29 @@ function buildBody(baseUrl: string): string {
       "\n",
     ),
   );
+
+  // Service × city landing pages — the high-intent combinations ("salg av
+  // næringseiendom i Bodø" etc.) that AI engines map directly to a query.
+  const serviceCityLines: string[] = [];
+  for (const citySlug of SERVICE_CITY_SLUGS) {
+    const location = getServiceCityLocation(citySlug);
+    if (!location) continue;
+    for (const serviceSlug of SERVICE_SLUGS) {
+      const service = getServiceDef(serviceSlug);
+      if (!service) continue;
+      serviceCityLines.push(
+        line(
+          `${service.noun} i ${location.name}`,
+          `${baseUrl}/tjenester/${service.slug}/${location.slug}`,
+          service.metaDescription(location.name, location.region),
+        ),
+      );
+    }
+  }
+  if (serviceCityLines.length > 0) {
+    sections.push(`## Tjenester per by`);
+    sections.push(serviceCityLines.join("\n"));
+  }
 
   sections.push(`## Lokasjoner`);
   const orderedLocations = [...allLocationPosts].sort(
@@ -103,14 +136,15 @@ function buildBody(baseUrl: string): string {
   );
 
   // Active mandates — surfaces the eiendommer inventory directly to AI engines
-  // (ChatGPT, Claude, Perplexity, Google AI Overviews). Listed by the same
-  // collection that drives the public /eiendommer index and sitemap, so the
+  // (ChatGPT, Claude, Perplexity, Google AI Overviews). Source of truth is the
+  // CRM (Supabase) via getListings(), with MDX folded in as a fallback — the
+  // same source that drives the public /eiendommer index and sitemap, so the
   // three sources cannot drift apart. Excludes sold listings.
-  const activeListings = [...allListingPosts]
+  const activeListings = (await getListings())
     .filter((listing) => listing.status !== "solgt")
     .sort((a, b) => a.order - b.order);
   if (activeListings.length > 0) {
-    sections.push(`## Eiendommer for salg`);
+    sections.push(`## Eiendommer for salg og leie`);
     sections.push(
       activeListings
         .map((listing) =>
@@ -194,8 +228,8 @@ function buildBody(baseUrl: string): string {
   return sections.join("\n\n") + "\n";
 }
 
-export function GET(): Response {
-  const body = buildBody(siteConfig.url);
+export async function GET(): Promise<Response> {
+  const body = await buildBody(siteConfig.url);
   return new Response(body, {
     status: 200,
     headers: {

--- a/src/app/markedsinnsikt/page.tsx
+++ b/src/app/markedsinnsikt/page.tsx
@@ -3,6 +3,7 @@ import { SubHero } from "@/components/site/SubHero"
 import { CtaStrip } from "@/components/site/CtaStrip"
 import { NewsletterSection } from "@/components/site/NewsletterSection"
 import { MarkedsinnsiktShell } from "@/components/markedsinnsikt/MarkedsinnsiktShell"
+import { MarketDataSummary } from "@/components/markedsinnsikt/MarketDataSummary"
 
 export const metadata = constructMetadata({
   path: "/markedsinnsikt",
@@ -78,6 +79,11 @@ export default function MarkedsinnsiktPage() {
           <MarkedsinnsiktShell />
         </div>
       </section>
+
+      {/* Server-rendered data tables — always in the initial HTML for crawlers
+          and AI engines (the shell above renders only the active tab + charts
+          client-side). */}
+      <MarketDataSummary />
 
       <NewsletterSection
         source="markedsinnsikt"

--- a/src/app/naringsmegler/[slug]/page.tsx
+++ b/src/app/naringsmegler/[slug]/page.tsx
@@ -12,6 +12,11 @@ import { LocationMdx } from "@/components/locations/LocationMdx";
 import { ActiveListingsStrip } from "@/components/eiendommer/ActiveListingsStrip";
 import { siteConfig } from "@/app/siteConfig";
 import { constructMetadata } from "@/lib/utils";
+import {
+  SERVICE_SLUGS,
+  isServiceCity,
+  getServiceDef,
+} from "@/lib/service-cities";
 
 /** Picks the value of the first marketStat whose label matches a keyword. */
 function findStat(
@@ -434,6 +439,43 @@ export default async function LocationPage({
           </div>
         </div>
       </section>
+
+      {/* TJENESTER I BYEN — intern lenking til tjeneste×by-sidene */}
+      {isServiceCity(location.slug) && (
+        <section className="section section-divider">
+          <div className="wrap">
+            <div className="head-compact">
+              <span className="eyebrow">Tjenester i {location.name}</span>
+              <div>
+                <h2>
+                  Hva vi kan gjøre{" "}
+                  <span className="italic">i {location.name}.</span>
+                </h2>
+              </div>
+            </div>
+
+            <div className="feat-3">
+              {SERVICE_SLUGS.map((slug) => {
+                const svc = getServiceDef(slug);
+                if (!svc) return null;
+                return (
+                  <Link
+                    key={slug}
+                    className="feat"
+                    href={`/tjenester/${slug}/${location.slug}`}
+                  >
+                    <h3>
+                      {svc.label} i {location.name}
+                    </h3>
+                    <p>{svc.heroLede(location.name)}</p>
+                    <span className="eyebrow no-rule">Les mer →</span>
+                  </Link>
+                );
+              })}
+            </div>
+          </div>
+        </section>
+      )}
 
       {/* ANDRE BYER */}
       {suggestedNearby.length > 0 && (

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -10,6 +10,7 @@ import {
 import { MetadataRoute } from "next";
 import { siteConfig } from "./siteConfig";
 import { getListings } from "@/lib/listing/listings";
+import { SERVICE_SLUGS, SERVICE_CITY_SLUGS } from "@/lib/service-cities";
 
 // ISR: the listing section is sourced from the CRM (Supabase). Revalidate on the
 // same window as the /eiendommer pages so a newly published mandate appears in
@@ -120,6 +121,16 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     priority: 0.85,
   }));
 
+  // Service × city landing pages (/tjenester/{service}/{by}) — enumerated from
+  // the curated allowlist that the routes' generateStaticParams use.
+  const serviceCityPages = SERVICE_CITY_SLUGS.flatMap((by) =>
+    SERVICE_SLUGS.map((service) => ({
+      url: `${baseUrl}/tjenester/${service}/${by}`,
+      changeFrequency: "weekly" as const,
+      priority: 0.75,
+    })),
+  );
+
   // Active listing detail pages. Source of truth is the CRM (Supabase) via
   // getListings(), with MDX listings folded in as a fallback — iterating the
   // MDX collection alone would omit every CRM-published mandate that has no MDX
@@ -143,6 +154,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     ...integrationPages,
     ...personPages,
     ...locationPages,
+    ...serviceCityPages,
     ...listingPages,
   ];
 }

--- a/src/app/tjenester/salg/[by]/page.tsx
+++ b/src/app/tjenester/salg/[by]/page.tsx
@@ -1,0 +1,38 @@
+import { notFound } from "next/navigation";
+import type { Metadata } from "next";
+
+import { ServiceCityPage } from "@/components/tjenester/ServiceCityPage";
+import {
+  SERVICE_CITY_SLUGS,
+  buildServiceCityMetadata,
+  isServiceCity,
+} from "@/lib/service-cities";
+
+// ISR: ActiveListingsStrip pulls CRM data (Supabase); revalidate so a publish
+// appears without a redeploy, same window as /eiendommer.
+export const revalidate = 600;
+// Only the curated city allowlist is valid — no thin auto-generated pages.
+export const dynamicParams = false;
+
+export function generateStaticParams() {
+  return SERVICE_CITY_SLUGS.map((by) => ({ by }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ by: string }>;
+}): Promise<Metadata | undefined> {
+  const { by } = await params;
+  return buildServiceCityMetadata("salg", by);
+}
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ by: string }>;
+}) {
+  const { by } = await params;
+  if (!isServiceCity(by)) notFound();
+  return <ServiceCityPage serviceSlug="salg" citySlug={by} />;
+}

--- a/src/app/tjenester/utleie/[by]/page.tsx
+++ b/src/app/tjenester/utleie/[by]/page.tsx
@@ -1,0 +1,38 @@
+import { notFound } from "next/navigation";
+import type { Metadata } from "next";
+
+import { ServiceCityPage } from "@/components/tjenester/ServiceCityPage";
+import {
+  SERVICE_CITY_SLUGS,
+  buildServiceCityMetadata,
+  isServiceCity,
+} from "@/lib/service-cities";
+
+// ISR: ActiveListingsStrip pulls CRM data (Supabase); revalidate so a publish
+// appears without a redeploy, same window as /eiendommer.
+export const revalidate = 600;
+// Only the curated city allowlist is valid — no thin auto-generated pages.
+export const dynamicParams = false;
+
+export function generateStaticParams() {
+  return SERVICE_CITY_SLUGS.map((by) => ({ by }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ by: string }>;
+}): Promise<Metadata | undefined> {
+  const { by } = await params;
+  return buildServiceCityMetadata("utleie", by);
+}
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ by: string }>;
+}) {
+  const { by } = await params;
+  if (!isServiceCity(by)) notFound();
+  return <ServiceCityPage serviceSlug="utleie" citySlug={by} />;
+}

--- a/src/app/tjenester/verdivurdering/[by]/page.tsx
+++ b/src/app/tjenester/verdivurdering/[by]/page.tsx
@@ -1,0 +1,38 @@
+import { notFound } from "next/navigation";
+import type { Metadata } from "next";
+
+import { ServiceCityPage } from "@/components/tjenester/ServiceCityPage";
+import {
+  SERVICE_CITY_SLUGS,
+  buildServiceCityMetadata,
+  isServiceCity,
+} from "@/lib/service-cities";
+
+// ISR: ActiveListingsStrip pulls CRM data (Supabase); revalidate so a publish
+// appears without a redeploy, same window as /eiendommer.
+export const revalidate = 600;
+// Only the curated city allowlist is valid — no thin auto-generated pages.
+export const dynamicParams = false;
+
+export function generateStaticParams() {
+  return SERVICE_CITY_SLUGS.map((by) => ({ by }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ by: string }>;
+}): Promise<Metadata | undefined> {
+  const { by } = await params;
+  return buildServiceCityMetadata("verdivurdering", by);
+}
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ by: string }>;
+}) {
+  const { by } = await params;
+  if (!isServiceCity(by)) notFound();
+  return <ServiceCityPage serviceSlug="verdivurdering" citySlug={by} />;
+}

--- a/src/components/markedsinnsikt/MarkedsinnsiktShell.tsx
+++ b/src/components/markedsinnsikt/MarkedsinnsiktShell.tsx
@@ -8,7 +8,20 @@ import { Fragment, useEffect, useState } from "react"
 import dynamic from "next/dynamic"
 import Link from "next/link"
 import { MapErrorBoundary } from "./MapErrorBoundary"
-import type { MapCity } from "./types"
+import {
+  QUARTERS,
+  RATES,
+  YIELD,
+  LEIE,
+  VOLUME,
+  VACANCY,
+  TX,
+  CITIES,
+  fmtNoComma,
+  fmtPct1,
+  fmtNum,
+  type Segment,
+} from "./marketData"
 
 // Leaflet needs `window`, so the overview map loads browser-only. This
 // dynamic({ ssr: false }) call is legal here because MarkedsinnsiktShell is a
@@ -47,92 +60,17 @@ const MarketLineChart = dynamic(
 )
 
 // ════════════════════════════════════════════════════════════════════════
-// DATA — ported verbatim from markedsinnsikt.js
+// HELPERS
 // ════════════════════════════════════════════════════════════════════════
-
-const QUARTERS = [
-  "Q1 21", "Q2 21", "Q3 21", "Q4 21",
-  "Q1 22", "Q2 22", "Q3 22", "Q4 22",
-  "Q1 23", "Q2 23", "Q3 23", "Q4 23",
-  "Q1 24", "Q2 24", "Q3 24", "Q4 24",
-  "Q1 25", "Q2 25", "Q3 25", "Q4 25",
-]
-
-const RATES = {
-  swap5y: [1.2, 1.45, 1.65, 1.95, 2.3, 2.85, 3.4, 3.85, 4.1, 4.25, 4.3, 4.35, 4.2, 4.05, 3.95, 3.9, 3.85, 3.8, 3.85, 3.82],
-  gov10y: [0.95, 1.2, 1.4, 1.65, 1.95, 2.4, 2.95, 3.3, 3.55, 3.65, 3.7, 3.75, 3.6, 3.5, 3.4, 3.45, 3.45, 3.5, 3.55, 3.55],
-}
-
-type Segment = "kontor" | "handel" | "logistikk"
-
-const YIELD: Record<Segment, number[]> = {
-  kontor: [4.2, 4.2, 4.25, 4.3, 4.4, 4.55, 4.85, 5.2, 5.6, 5.85, 6.0, 6.15, 6.2, 6.2, 6.15, 6.1, 6.05, 6.0, 6.05, 6.1],
-  handel: [4.6, 4.6, 4.65, 4.7, 4.8, 4.95, 5.25, 5.55, 5.95, 6.2, 6.4, 6.55, 6.65, 6.65, 6.6, 6.55, 6.5, 6.45, 6.5, 6.55],
-  logistikk: [5.1, 5.1, 5.1, 5.15, 5.25, 5.4, 5.65, 5.95, 6.3, 6.55, 6.7, 6.85, 6.95, 6.95, 6.9, 6.85, 6.85, 6.8, 6.85, 6.85],
-}
-
-const LEIE: Record<Segment, Record<string, number[]>> = {
-  kontor: {
-    Bodø: [2050, 2070, 2090, 2120, 2150, 2180, 2220, 2260, 2290, 2310, 2330, 2340, 2355, 2370, 2380, 2385, 2390, 2395, 2400, 2400],
-    Tromsø: [2550, 2570, 2600, 2640, 2680, 2720, 2780, 2830, 2860, 2880, 2900, 2910, 2925, 2935, 2940, 2945, 2945, 2950, 2950, 2950],
-    Harstad: [1620, 1640, 1650, 1670, 1690, 1710, 1740, 1770, 1790, 1810, 1820, 1830, 1845, 1855, 1860, 1865, 1870, 1870, 1875, 1875],
-  },
-  handel: {
-    Bodø: [2750, 2770, 2790, 2820, 2850, 2880, 2920, 2960, 2990, 3020, 3040, 3060, 3080, 3095, 3105, 3115, 3120, 3125, 3130, 3135],
-    Tromsø: [3200, 3220, 3250, 3280, 3320, 3360, 3400, 3440, 3470, 3500, 3520, 3540, 3560, 3580, 3600, 3610, 3620, 3625, 3630, 3635],
-    Harstad: [2100, 2110, 2120, 2140, 2160, 2180, 2210, 2240, 2260, 2280, 2290, 2300, 2315, 2325, 2335, 2340, 2345, 2350, 2355, 2360],
-  },
-  logistikk: {
-    Bodø: [1200, 1205, 1215, 1225, 1240, 1255, 1275, 1295, 1310, 1325, 1335, 1345, 1360, 1370, 1380, 1385, 1390, 1395, 1400, 1405],
-    Tromsø: [1450, 1455, 1465, 1475, 1490, 1505, 1525, 1545, 1560, 1575, 1585, 1595, 1610, 1620, 1630, 1635, 1640, 1645, 1650, 1655],
-    "Mo i Rana": [1050, 1055, 1060, 1070, 1085, 1100, 1115, 1130, 1140, 1150, 1160, 1170, 1180, 1190, 1195, 1200, 1205, 1210, 1215, 1220],
-  },
-}
-
-const VOLUME = {
-  years: ["2018", "2019", "2020", "2021", "2022", "2023", "2024", "2025"],
-  total: [1.8, 2.4, 2.1, 3.6, 4.5, 3.2, 4.1, 4.8],
-}
-
-const VACANCY = [
-  { city: "Bodø", kontor: 4.6, handel: 3.1, logistikk: 2.4 },
-  { city: "Tromsø", kontor: 3.4, handel: 2.8, logistikk: 1.9 },
-  { city: "Alta", kontor: 6.2, handel: 4.4, logistikk: 3.8 },
-  { city: "Harstad", kontor: 5.8, handel: 3.9, logistikk: 3.2 },
-  { city: "Narvik", kontor: 7.5, handel: 5.1, logistikk: 4.2 },
-  { city: "Mo i Rana", kontor: 5.4, handel: 4.0, logistikk: 2.8 },
-]
-
-const TX = [
-  { date: "Des 25", name: "Storgata 73, Tromsø", loc: "Kontortårn · 11 400 m²", seg: "Kontor", value: "285 mnok", yield: "5,9 %" },
-  { date: "Nov 25", name: "Bodø Logistikkpark — fase 2", loc: "Logistikk · 18 200 m²", seg: "Logistikk", value: "215 mnok", yield: "6,8 %" },
-  { date: "Okt 25", name: "AMFI Alta — anchor", loc: "Handel · 6 800 m²", seg: "Handel", value: "118 mnok", yield: "6,5 %" },
-  { date: "Sep 25", name: "Tromsdalen Næringspark", loc: "Komb. · 9 400 m²", seg: "Kombinasjon", value: "164 mnok", yield: "6,3 %" },
-  { date: "Aug 25", name: "Sjøgata 15, Bodø", loc: "Kontor · 4 200 m²", seg: "Kontor", value: "98 mnok", yield: "6,1 %" },
-  { date: "Jun 25", name: "Mo i Rana Industripark", loc: "Logistikk · 22 600 m²", seg: "Logistikk", value: "245 mnok", yield: "7,2 %" },
-]
-
-const CITIES: MapCity[] = [
-  { id: "bodo", name: "Bodø", lat: 67.28, lon: 14.4, yield: "6,35 %", leie: "2 400 kr/m²", vac: "4,6 %", note: "Hovedkontor for Advanti. Voksende logistikkhubb." },
-  { id: "tromso", name: "Tromsø", lat: 69.65, lon: 18.95, yield: "6,10 %", leie: "2 950 kr/m²", vac: "3,4 %", note: "Største kontormarkedet i Nord-Norge." },
-  { id: "alta", name: "Alta", lat: 69.97, lon: 23.27, yield: "6,75 %", leie: "1 950 kr/m²", vac: "6,2 %", note: "Sterkt handelsmarked i Finnmark." },
-  { id: "mo", name: "Mo i Rana", lat: 66.32, lon: 14.14, yield: "6,80 %", leie: "1 750 kr/m²", vac: "5,4 %", note: "Industri og logistikk. Stor industriutbygging." },
-  { id: "narvik", name: "Narvik", lat: 68.44, lon: 17.43, yield: "6,90 %", leie: "1 820 kr/m²", vac: "7,5 %", note: "Transport- og næringspark. Lavere likviditet." },
-  { id: "harstad", name: "Harstad", lat: 68.8, lon: 16.55, yield: "6,55 %", leie: "1 875 kr/m²", vac: "5,8 %", note: "Stabilt kontor- og handelsmarked." },
-]
-
-// ════════════════════════════════════════════════════════════════════════
-// HELPERS — ported from markedsinnsikt.js
-// ════════════════════════════════════════════════════════════════════════
+// Data (QUARTERS, RATES, YIELD, LEIE, VOLUME, VACANCY, TX, CITIES) and the
+// number formatters now live in ./marketData so the server-rendered
+// MarketDataSummary tables share the exact same source.
 
 const SECTOR_COLORS = [
   "var(--warm-grey)",
   "var(--warm-grey-85)",
   "var(--warm-grey-85)",
 ]
-const fmtNoComma = (v: number) => v.toFixed(2).replace(".", ",")
-const fmtPct1 = (v: number) => `${v.toFixed(1).replace(".", ",")} %`
-const fmtNum = (v: number) => v.toLocaleString("no-NO")
 
 type SectorId =
   | "yield"

--- a/src/components/markedsinnsikt/MarketDataSummary.tsx
+++ b/src/components/markedsinnsikt/MarketDataSummary.tsx
@@ -1,0 +1,201 @@
+// Server-rendered (NO "use client") plain-text market data tables for
+// /markedsinnsikt. The interactive MarkedsinnsiktShell renders only the active
+// tab on the server and loads its charts client-only (ssr:false), so the bulk of
+// the figures never reach the initial HTML. This component mirrors the same data
+// (from ./marketData) as semantic tables that are always in the server HTML —
+// crawlable and citable by Google and AI engines (ChatGPT, Claude, Perplexity),
+// and a useful, accessible reference for visitors.
+import {
+  CITIES,
+  YIELD,
+  LEIE,
+  VACANCY,
+  TX,
+  LATEST_QUARTER,
+  fmtNoComma,
+  fmtNum,
+  fmtPct1,
+  type Segment,
+} from "./marketData"
+
+const SEGMENTS: { key: Segment; label: string }[] = [
+  { key: "kontor", label: "Kontor" },
+  { key: "handel", label: "Handel" },
+  { key: "logistikk", label: "Logistikk" },
+]
+
+const last = (arr: number[]) => arr[arr.length - 1]
+
+// Flatten LEIE[segment][city] → latest value per (segment, city) pair.
+const leieRows = SEGMENTS.flatMap((seg) =>
+  Object.entries(LEIE[seg.key]).map(([city, values]) => ({
+    segment: seg.label,
+    city,
+    value: last(values),
+  })),
+)
+
+export function MarketDataSummary() {
+  return (
+    <section
+      className="section section-divider"
+      id="markedsdata-tall"
+      aria-label={`Markedsdata i tall, ${LATEST_QUARTER}`}
+    >
+      <div className="wrap">
+        <div className="head-compact">
+          <span className="eyebrow">Markedsdata i tall · {LATEST_QUARTER}</span>
+          <div>
+            <h2>
+              Tallene, <span className="italic">i ren tekst.</span>
+            </h2>
+            <p>
+              Nøkkeltall for næringseiendom i Nord-Norge per {LATEST_QUARTER} —
+              prime yield, markedsleie og ledighet, by for by og segment for
+              segment. Samme datagrunnlag som de interaktive grafene over.
+            </p>
+          </div>
+        </div>
+
+        {/* Per-by snapshot */}
+        <h3 className="mi-data-h3">Markedsoversikt per by</h3>
+        <table className="mi-table">
+          <caption className="sr-only">
+            Prime yield, markedsleie og ledighet for kontor per by, {LATEST_QUARTER}
+          </caption>
+          <thead>
+            <tr>
+              <th>By</th>
+              <th className="r">Prime yield (kontor)</th>
+              <th className="r">Markedsleie kontor</th>
+              <th className="r">Kontorledighet</th>
+              <th>Kommentar</th>
+            </tr>
+          </thead>
+          <tbody>
+            {CITIES.map((c) => (
+              <tr key={c.id}>
+                <td>{c.name}</td>
+                <td className="r">{c.yield}</td>
+                <td className="r">{c.leie}</td>
+                <td className="r">{c.vac}</td>
+                <td>{c.note}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+
+        {/* Prime yield per segment */}
+        <h3 className="mi-data-h3">Prime yield per segment</h3>
+        <table className="mi-table">
+          <caption className="sr-only">
+            Prime yield per segment i Nord-Norge, {LATEST_QUARTER}
+          </caption>
+          <thead>
+            <tr>
+              <th>Segment</th>
+              <th className="r">Prime yield {LATEST_QUARTER}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {SEGMENTS.map((seg) => (
+              <tr key={seg.key}>
+                <td>{seg.label}</td>
+                <td className="r">{fmtNoComma(last(YIELD[seg.key]))} %</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+
+        {/* Markedsleie per segment & by */}
+        <h3 className="mi-data-h3">Markedsleie per by og segment</h3>
+        <table className="mi-table">
+          <caption className="sr-only">
+            Prime markedsleie i kr/m²/år per by og segment, {LATEST_QUARTER}
+          </caption>
+          <thead>
+            <tr>
+              <th>Segment</th>
+              <th>By</th>
+              <th className="r">Markedsleie {LATEST_QUARTER}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {leieRows.map((row) => (
+              <tr key={`${row.segment}-${row.city}`}>
+                <td>{row.segment}</td>
+                <td>{row.city}</td>
+                <td className="r">{fmtNum(row.value)} kr/m²/år</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+
+        {/* Ledighet per by & segment */}
+        <h3 className="mi-data-h3">Ledighet per by og segment</h3>
+        <table className="mi-table">
+          <caption className="sr-only">
+            Andel ledig næringsareal i prosent per by og segment, {LATEST_QUARTER}
+          </caption>
+          <thead>
+            <tr>
+              <th>By</th>
+              <th className="r">Kontor</th>
+              <th className="r">Handel</th>
+              <th className="r">Logistikk</th>
+            </tr>
+          </thead>
+          <tbody>
+            {VACANCY.map((row) => (
+              <tr key={row.city}>
+                <td>{row.city}</td>
+                <td className="r">{fmtPct1(row.kontor)}</td>
+                <td className="r">{fmtPct1(row.handel)}</td>
+                <td className="r">{fmtPct1(row.logistikk)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+
+        {/* Recent transactions */}
+        <h3 className="mi-data-h3">Utvalgte transaksjoner 2025</h3>
+        <table className="mi-table">
+          <caption className="sr-only">
+            Utvalgte næringseiendomstransaksjoner i Nord-Norge, 2025
+          </caption>
+          <thead>
+            <tr>
+              <th>Dato</th>
+              <th>Eiendom</th>
+              <th>Segment</th>
+              <th className="r">Verdi</th>
+              <th className="r">Yield</th>
+            </tr>
+          </thead>
+          <tbody>
+            {TX.map((t) => (
+              <tr key={t.name}>
+                <td>{t.date}</td>
+                <td>
+                  {t.name}
+                  <span className="mi-data-sub"> · {t.loc}</span>
+                </td>
+                <td>{t.seg}</td>
+                <td className="r">{t.value}</td>
+                <td className="r">{t.yield}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+
+        <div className="mi-footnote" style={{ marginTop: 24 }}>
+          <span className="source">
+            Tall er indikative og reflekterer prime kvalitet. Kilde: Advanti
+            markedsdata. For en konkret vurdering av din eiendom — ta kontakt.
+          </span>
+          <span>{LATEST_QUARTER} · Advanti</span>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/components/markedsinnsikt/marketData.ts
+++ b/src/components/markedsinnsikt/marketData.ts
@@ -1,0 +1,84 @@
+// Shared market dataset for /markedsinnsikt.
+//
+// Single source of truth so the interactive (client) charts in
+// MarkedsinnsiktShell and the server-rendered MarketDataSummary tables cannot
+// drift apart. Pure data + formatters — no "use client", importable from both
+// server and client components. Ported verbatim from markedsinnsikt.js.
+import type { MapCity } from "./types"
+
+export const LATEST_QUARTER = "Q4 2025"
+
+export const QUARTERS = [
+  "Q1 21", "Q2 21", "Q3 21", "Q4 21",
+  "Q1 22", "Q2 22", "Q3 22", "Q4 22",
+  "Q1 23", "Q2 23", "Q3 23", "Q4 23",
+  "Q1 24", "Q2 24", "Q3 24", "Q4 24",
+  "Q1 25", "Q2 25", "Q3 25", "Q4 25",
+]
+
+export const RATES = {
+  swap5y: [1.2, 1.45, 1.65, 1.95, 2.3, 2.85, 3.4, 3.85, 4.1, 4.25, 4.3, 4.35, 4.2, 4.05, 3.95, 3.9, 3.85, 3.8, 3.85, 3.82],
+  gov10y: [0.95, 1.2, 1.4, 1.65, 1.95, 2.4, 2.95, 3.3, 3.55, 3.65, 3.7, 3.75, 3.6, 3.5, 3.4, 3.45, 3.45, 3.5, 3.55, 3.55],
+}
+
+export type Segment = "kontor" | "handel" | "logistikk"
+
+export const YIELD: Record<Segment, number[]> = {
+  kontor: [4.2, 4.2, 4.25, 4.3, 4.4, 4.55, 4.85, 5.2, 5.6, 5.85, 6.0, 6.15, 6.2, 6.2, 6.15, 6.1, 6.05, 6.0, 6.05, 6.1],
+  handel: [4.6, 4.6, 4.65, 4.7, 4.8, 4.95, 5.25, 5.55, 5.95, 6.2, 6.4, 6.55, 6.65, 6.65, 6.6, 6.55, 6.5, 6.45, 6.5, 6.55],
+  logistikk: [5.1, 5.1, 5.1, 5.15, 5.25, 5.4, 5.65, 5.95, 6.3, 6.55, 6.7, 6.85, 6.95, 6.95, 6.9, 6.85, 6.85, 6.8, 6.85, 6.85],
+}
+
+export const LEIE: Record<Segment, Record<string, number[]>> = {
+  kontor: {
+    Bodø: [2050, 2070, 2090, 2120, 2150, 2180, 2220, 2260, 2290, 2310, 2330, 2340, 2355, 2370, 2380, 2385, 2390, 2395, 2400, 2400],
+    Tromsø: [2550, 2570, 2600, 2640, 2680, 2720, 2780, 2830, 2860, 2880, 2900, 2910, 2925, 2935, 2940, 2945, 2945, 2950, 2950, 2950],
+    Harstad: [1620, 1640, 1650, 1670, 1690, 1710, 1740, 1770, 1790, 1810, 1820, 1830, 1845, 1855, 1860, 1865, 1870, 1870, 1875, 1875],
+  },
+  handel: {
+    Bodø: [2750, 2770, 2790, 2820, 2850, 2880, 2920, 2960, 2990, 3020, 3040, 3060, 3080, 3095, 3105, 3115, 3120, 3125, 3130, 3135],
+    Tromsø: [3200, 3220, 3250, 3280, 3320, 3360, 3400, 3440, 3470, 3500, 3520, 3540, 3560, 3580, 3600, 3610, 3620, 3625, 3630, 3635],
+    Harstad: [2100, 2110, 2120, 2140, 2160, 2180, 2210, 2240, 2260, 2280, 2290, 2300, 2315, 2325, 2335, 2340, 2345, 2350, 2355, 2360],
+  },
+  logistikk: {
+    Bodø: [1200, 1205, 1215, 1225, 1240, 1255, 1275, 1295, 1310, 1325, 1335, 1345, 1360, 1370, 1380, 1385, 1390, 1395, 1400, 1405],
+    Tromsø: [1450, 1455, 1465, 1475, 1490, 1505, 1525, 1545, 1560, 1575, 1585, 1595, 1610, 1620, 1630, 1635, 1640, 1645, 1650, 1655],
+    "Mo i Rana": [1050, 1055, 1060, 1070, 1085, 1100, 1115, 1130, 1140, 1150, 1160, 1170, 1180, 1190, 1195, 1200, 1205, 1210, 1215, 1220],
+  },
+}
+
+export const VOLUME = {
+  years: ["2018", "2019", "2020", "2021", "2022", "2023", "2024", "2025"],
+  total: [1.8, 2.4, 2.1, 3.6, 4.5, 3.2, 4.1, 4.8],
+}
+
+export const VACANCY = [
+  { city: "Bodø", kontor: 4.6, handel: 3.1, logistikk: 2.4 },
+  { city: "Tromsø", kontor: 3.4, handel: 2.8, logistikk: 1.9 },
+  { city: "Alta", kontor: 6.2, handel: 4.4, logistikk: 3.8 },
+  { city: "Harstad", kontor: 5.8, handel: 3.9, logistikk: 3.2 },
+  { city: "Narvik", kontor: 7.5, handel: 5.1, logistikk: 4.2 },
+  { city: "Mo i Rana", kontor: 5.4, handel: 4.0, logistikk: 2.8 },
+]
+
+export const TX = [
+  { date: "Des 25", name: "Storgata 73, Tromsø", loc: "Kontortårn · 11 400 m²", seg: "Kontor", value: "285 mnok", yield: "5,9 %" },
+  { date: "Nov 25", name: "Bodø Logistikkpark — fase 2", loc: "Logistikk · 18 200 m²", seg: "Logistikk", value: "215 mnok", yield: "6,8 %" },
+  { date: "Okt 25", name: "AMFI Alta — anchor", loc: "Handel · 6 800 m²", seg: "Handel", value: "118 mnok", yield: "6,5 %" },
+  { date: "Sep 25", name: "Tromsdalen Næringspark", loc: "Komb. · 9 400 m²", seg: "Kombinasjon", value: "164 mnok", yield: "6,3 %" },
+  { date: "Aug 25", name: "Sjøgata 15, Bodø", loc: "Kontor · 4 200 m²", seg: "Kontor", value: "98 mnok", yield: "6,1 %" },
+  { date: "Jun 25", name: "Mo i Rana Industripark", loc: "Logistikk · 22 600 m²", seg: "Logistikk", value: "245 mnok", yield: "7,2 %" },
+]
+
+export const CITIES: MapCity[] = [
+  { id: "bodo", name: "Bodø", lat: 67.28, lon: 14.4, yield: "6,35 %", leie: "2 400 kr/m²", vac: "4,6 %", note: "Hovedkontor for Advanti. Voksende logistikkhubb." },
+  { id: "tromso", name: "Tromsø", lat: 69.65, lon: 18.95, yield: "6,10 %", leie: "2 950 kr/m²", vac: "3,4 %", note: "Største kontormarkedet i Nord-Norge." },
+  { id: "alta", name: "Alta", lat: 69.97, lon: 23.27, yield: "6,75 %", leie: "1 950 kr/m²", vac: "6,2 %", note: "Sterkt handelsmarked i Finnmark." },
+  { id: "mo", name: "Mo i Rana", lat: 66.32, lon: 14.14, yield: "6,80 %", leie: "1 750 kr/m²", vac: "5,4 %", note: "Industri og logistikk. Stor industriutbygging." },
+  { id: "narvik", name: "Narvik", lat: 68.44, lon: 17.43, yield: "6,90 %", leie: "1 820 kr/m²", vac: "7,5 %", note: "Transport- og næringspark. Lavere likviditet." },
+  { id: "harstad", name: "Harstad", lat: 68.8, lon: 16.55, yield: "6,55 %", leie: "1 875 kr/m²", vac: "5,8 %", note: "Stabilt kontor- og handelsmarked." },
+]
+
+export const fmtNoComma = (v: number) => v.toFixed(2).replace(".", ",")
+export const fmtPct1 = (v: number) => `${v.toFixed(1).replace(".", ",")} %`
+export const fmtNum = (v: number) => v.toLocaleString("no-NO")

--- a/src/components/tjenester/ServiceCityPage.tsx
+++ b/src/components/tjenester/ServiceCityPage.tsx
@@ -1,0 +1,330 @@
+import Link from "next/link";
+
+import { SubHero } from "@/components/site/SubHero";
+import { CtaStrip } from "@/components/site/CtaStrip";
+import { PhotoBand } from "@/components/site/PhotoBand";
+import { Faq, type FaqItem } from "@/components/site/Faq";
+import { ActiveListingsStrip } from "@/components/eiendommer/ActiveListingsStrip";
+import StructuredData, {
+  BreadcrumbStructuredData,
+} from "@/components/StructuredData";
+import {
+  SERVICE_SLUGS,
+  getServiceCityLocation,
+  getServiceDef,
+  type ServiceDef,
+} from "@/lib/service-cities";
+
+/** Picks the value of the first marketStat whose label matches a keyword. */
+function findStat(
+  stats: { label: string; value: string }[],
+  keyword: string,
+): string | undefined {
+  return stats.find((s) =>
+    s.label.toLowerCase().includes(keyword.toLowerCase()),
+  )?.value;
+}
+
+/**
+ * Shared renderer for every /tjenester/{service}/{by} landing page. Combines the
+ * static per-service copy (process, value props, FAQ) with the city's real
+ * market data and active mandates so each page carries substantial unique
+ * content rather than a templated city-name swap.
+ */
+export function ServiceCityPage({
+  serviceSlug,
+  citySlug,
+}: {
+  serviceSlug: string;
+  citySlug: string;
+}) {
+  const service = getServiceDef(serviceSlug);
+  const location = getServiceCityLocation(citySlug);
+  // Routes gate on notFound() before rendering; this guard is a type narrow.
+  if (!service || !location) return null;
+
+  const city = location.name;
+  const region = location.region;
+  const primeYield = findStat(location.marketStats, "prime yield");
+  const officeHigh = findStat(location.marketStats, "kontorleie høy");
+  const vacancy = findStat(location.marketStats, "ledighet");
+  const secondaryYield = findStat(location.marketStats, "sekundær");
+
+  const metaRow = [
+    { value: primeYield ?? "—", label: "Prime yield" },
+    { value: officeHigh ?? "—", label: "Kontorleie (høy std.)" },
+    vacancy
+      ? { value: vacancy, label: "Ledighet" }
+      : { value: secondaryYield ?? "—", label: "Sekundær yield" },
+  ];
+
+  const introParagraphs = service.intro(city, region, primeYield);
+
+  // Service FAQ + two city-specific questions for genuinely local depth.
+  const faqItems: FaqItem[] = [
+    ...service.baseFaqs,
+    {
+      question: `Hvilke områder dekker Advanti ved ${service.label.toLowerCase()} i ${city}?`,
+      answer: `Vi bistår med ${service.keyword} i ${city} og ellers i ${region} og Nord-Norge. Ta kontakt for en lokal vurdering.`,
+    },
+    {
+      question: `Hvordan kommer jeg i gang med ${service.label.toLowerCase()} i ${city}?`,
+      answer: `Ta kontakt for en uforpliktende samtale. Vi setter sammen et team som kjenner ${city} og segmentet ditt, og legger en konkret plan.`,
+    },
+  ];
+
+  // Sibling services in the same city + the city hub — internal linking that
+  // keeps these pages out of orphan status.
+  const otherServices = SERVICE_SLUGS.map((slug) => getServiceDef(slug))
+    .filter((s): s is ServiceDef => !!s && s.slug !== service.slug);
+
+  const canonicalPath = `/tjenester/${service.slug}/${location.slug}`;
+
+  return (
+    <>
+      <BreadcrumbStructuredData
+        items={[
+          { name: "Hjem", url: "/" },
+          { name: "Tjenester", url: "/tjenester" },
+          { name: service.label, url: `/tjenester/${service.slug}` },
+          { name: city, url: canonicalPath },
+        ]}
+      />
+      <StructuredData
+        type="service"
+        data={{
+          name: `${service.noun} i ${city}`,
+          description: service.serviceSchemaDesc(city),
+        }}
+      />
+      <StructuredData type="faq" data={{ faqs: faqItems }} />
+
+      <SubHero
+        crumb={[
+          { label: "Hjem", href: "/" },
+          { label: "Tjenester", href: "/tjenester" },
+          { label: service.label, href: `/tjenester/${service.slug}` },
+          { label: city },
+        ]}
+        eyebrow={`${service.heroEyebrow} · ${city}`}
+        title={
+          <>
+            {service.noun} <span className="italic">i {city}.</span>
+          </>
+        }
+        lede={service.heroLede(city)}
+        actions={[
+          { label: "Få lokal vurdering", href: "/kontakt" },
+          { label: "Se markedsdata", href: "#marked", variant: "outline" },
+        ]}
+        metaRow={metaRow}
+        photo={service.heroPhoto}
+      />
+
+      {/* INTRO + MARKEDSDATA */}
+      <section className="section section-divider" id="marked">
+        <div className="wrap">
+          <div className="head-compact">
+            <span className="eyebrow">
+              01 — {service.label} i {city}
+            </span>
+            <div>
+              <h2>
+                Lokalt marked,{" "}
+                <span className="italic">lokal vurdering.</span>
+              </h2>
+              {introParagraphs.map((para, i) => (
+                <p key={i}>{para}</p>
+              ))}
+            </div>
+          </div>
+
+          <table className="cy-stats-table">
+            <thead>
+              <tr>
+                <th style={{ width: "32%" }}>Indikator</th>
+                <th style={{ width: "24%" }}>Nivå</th>
+                <th>Kommentar</th>
+              </tr>
+            </thead>
+            <tbody>
+              {location.marketStats.map((stat) => (
+                <tr key={stat.label}>
+                  <td>
+                    <span className="label">{stat.label}</span>
+                  </td>
+                  <td>
+                    <span className="val">{stat.value}</span>
+                  </td>
+                  <td>
+                    <span className="detail">{stat.detail ?? ""}</span>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+
+          <div className="mi-footnote" style={{ marginTop: 24 }}>
+            <span className="source">
+              Tall er indikative. For nøyaktig vurdering av din eiendom — ta
+              kontakt.
+            </span>
+            <span>
+              <Link href={`/naringsmegler/${location.slug}`}>
+                Mer om markedet i {city} →
+              </Link>
+            </span>
+          </div>
+        </div>
+      </section>
+
+      {/* PROSESS */}
+      <section className="section" id="prosess">
+        <div className="wrap">
+          <div className="head-compact">
+            <span className="eyebrow">{service.processEyebrow}</span>
+            <div>
+              <h2>
+                {service.processLead}{" "}
+                <span className="italic">{service.processItalic}</span>
+              </h2>
+              <p>{service.processIntro}</p>
+            </div>
+          </div>
+
+          <div className="method-grid">
+            {service.steps.map((step) => (
+              <div className="method" key={step.h3}>
+                <div className="pre">{step.pre}</div>
+                <h3>{step.h3}</h3>
+                <p>{step.p}</p>
+                <div className="meta">
+                  <span>{step.meta[0]}</span>
+                  <span>{step.meta[1]}</span>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* HVORFOR ADVANTI */}
+      <section
+        className="section"
+        style={{
+          background: "var(--accent-faint)",
+          borderTop: "var(--hairline)",
+          borderBottom: "var(--hairline)",
+        }}
+      >
+        <div className="wrap">
+          <div className="head-compact">
+            <span className="eyebrow">02 — Hvorfor Advanti</span>
+            <div>
+              <h2>
+                {service.whyLead}{" "}
+                <span className="italic">{service.whyItalic}</span>
+              </h2>
+              <p>{service.whyIntro}</p>
+            </div>
+          </div>
+
+          <div className="feat-3">
+            {service.feats.map((feat) => (
+              <div className="feat" key={feat.num}>
+                <div className="num">{feat.num}</div>
+                <h3>{feat.h3}</h3>
+                <p>{feat.p}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <ActiveListingsStrip
+        eyebrow={`${service.listingsEyebrow} · ${city}`}
+        title={
+          <>
+            Eiendommer vi formidler{" "}
+            <span className="italic">i {city}.</span>
+          </>
+        }
+        lede={service.listingsLede}
+        city={location.slug}
+        limit={3}
+      />
+
+      <Faq
+        eyebrow="Ofte stilte spørsmål"
+        title={
+          <>
+            Spørsmål om {service.label.toLowerCase()}{" "}
+            <span className="italic">i {city}.</span>
+          </>
+        }
+        lede="Finner du ikke svaret? Ta kontakt — vi setter av tid til en uforpliktende samtale uansett."
+        items={faqItems}
+      />
+
+      {/* ANDRE TJENESTER I BYEN — intern lenking */}
+      <section className="section">
+        <div className="wrap">
+          <div className="head-compact">
+            <span className="eyebrow">Andre tjenester i {city}</span>
+            <div>
+              <h2>
+                Vi bistår også med{" "}
+                <span className="italic">mer i {city}.</span>
+              </h2>
+            </div>
+          </div>
+
+          <div className="feat-3">
+            {otherServices.map((other) => (
+              <Link
+                key={other.slug}
+                className="feat"
+                href={`/tjenester/${other.slug}/${location.slug}`}
+              >
+                <h3>
+                  {other.label} i {city}
+                </h3>
+                <p>{other.heroLede(city)}</p>
+                <span className="eyebrow no-rule">Les mer →</span>
+              </Link>
+            ))}
+            <Link className="feat" href={`/naringsmegler/${location.slug}`}>
+              <h3>Næringsmegler i {city}</h3>
+              <p>
+                Lokal markedsoversikt, team og hvordan vi jobber i {city}.
+              </p>
+              <span className="eyebrow no-rule">Les mer →</span>
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      <PhotoBand
+        src={service.heroPhoto.src}
+        alt={`${service.noun} i ${city}`}
+        caption={`${service.label} · ${city}`}
+      />
+
+      <CtaStrip
+        eyebrow={service.ctaEyebrow}
+        title={
+          <>
+            {service.label} av næringseiendom{" "}
+            <span className="italic">i {city}?</span>
+          </>
+        }
+        sub={service.ctaSub(city)}
+        primary={{ label: "Ta kontakt", href: "/kontakt" }}
+        secondary={{
+          label: `Alt om ${service.label.toLowerCase()}`,
+          href: `/tjenester/${service.slug}`,
+        }}
+      />
+    </>
+  );
+}

--- a/src/lib/service-cities.ts
+++ b/src/lib/service-cities.ts
@@ -1,0 +1,434 @@
+// Data layer for the service × city landing pages
+// (/tjenester/{salg|verdivurdering|utleie}/{by}). Pure data + lookups, no JSX —
+// the rendering lives in components/tjenester/ServiceCityPage.tsx, and sitemap.ts
+// imports the slug lists from here to enumerate the routes.
+import type { Metadata } from "next";
+import { allLocationPosts } from "content-collections";
+import { constructMetadata } from "@/lib/utils";
+
+export const SERVICE_SLUGS = ["salg", "verdivurdering", "utleie"] as const;
+export type ServiceSlug = (typeof SERVICE_SLUGS)[number];
+
+// Curated to the strongest markets (richest marketStats + an office or active
+// mandates). Kept deliberately tight — quality over a thin 60-page matrix.
+export const SERVICE_CITY_SLUGS = [
+  "bodo",
+  "tromso",
+  "alta",
+  "harstad",
+  "narvik",
+  "mo-i-rana",
+] as const;
+export type ServiceCitySlug = (typeof SERVICE_CITY_SLUGS)[number];
+
+export type ProcessStep = {
+  pre: string;
+  h3: string;
+  p: string;
+  meta: [string, string];
+};
+export type Feat = { num: string; h3: string; p: string };
+export type Faq = { question: string; answer: string };
+
+export type ServiceDef = {
+  slug: ServiceSlug;
+  /** Short label, e.g. "Salg". */
+  label: string;
+  /** Full noun phrase for titles/H1, e.g. "Salg av næringseiendom". */
+  noun: string;
+  /** Target keyword, lowercase, e.g. "salg av næringseiendom". */
+  keyword: string;
+  heroEyebrow: string;
+  heroLede: (city: string) => string;
+  heroPhoto: { src: string; alt: string };
+  metaDescription: (city: string, region: string) => string;
+  serviceSchemaDesc: (city: string) => string;
+  /** City-unique intro paragraphs (the bulk of the per-page unique content). */
+  intro: (city: string, region: string, primeYield?: string) => string[];
+  processEyebrow: string;
+  processLead: string;
+  processItalic: string;
+  processIntro: string;
+  steps: ProcessStep[];
+  whyLead: string;
+  whyItalic: string;
+  whyIntro: string;
+  feats: Feat[];
+  listingsEyebrow: string;
+  listingsLede: string;
+  baseFaqs: Faq[];
+  ctaEyebrow: string;
+  ctaSub: (city: string) => string;
+};
+
+const SALG: ServiceDef = {
+  slug: "salg",
+  label: "Salg",
+  noun: "Salg av næringseiendom",
+  keyword: "salg av næringseiendom",
+  heroEyebrow: "Tjeneste · Salg",
+  heroLede: (city) =>
+    `Strukturert salgsprosess i ${city} — fra verdivurdering og prospekt til budrunde, kontrakt og overtakelse. Vi sikrer at riktig kjøper finner riktig eiendom, til riktig pris.`,
+  heroPhoto: {
+    src: "/building/pexels-abshky-18566965.jpg",
+    alt: "Næringseiendom i salgsprosess",
+  },
+  metaDescription: (city, region) =>
+    `Skal du selge næringseiendom i ${city}? Advanti bistår med hele salgsprosessen — verdivurdering, prospekt, budrunde og oppgjør — med lokal markedskunnskap i ${region}.`,
+  serviceSchemaDesc: (city) =>
+    `Profesjonell bistand ved salg av næringseiendom i ${city}, fra verdivurdering til oppgjør.`,
+  intro: (city, region, primeYield) => [
+    `Vurderer du salg av næringseiendom i ${city}? Et vellykket salg avhenger av riktig prising, riktig kjøper og en profesjonell prosess. Advanti gjennomfører strukturerte salgsprosesser i ${city} og resten av ${region}, med lokal markedskunnskap og datadrevet verdivurdering i bunn.`,
+    `Vi posisjonerer eiendommen mot de rette kjøperne — åpent eller diskré — og følger oppdraget tett fra verdivurdering og prospekt til budrunde, kontrakt og overtakelse.${
+      primeYield
+        ? ` Indikativ prime yield i ${city} ligger nå rundt ${primeYield}.`
+        : ""
+    }`,
+  ],
+  processEyebrow: "01 — Salgsprosessen",
+  processLead: "En strukturert",
+  processItalic: "salgsprosess.",
+  processIntro:
+    "Vi følger en transparent, dokumentert prosess i seks faser. Du vet til enhver tid hvor prosessen står, hva som skjer neste fase, og hvilke beslutninger som ligger foran.",
+  steps: [
+    {
+      pre: "01 · Fase",
+      h3: "Forberedelse og verdivurdering",
+      p: "Grundig gjennomgang av eiendommen, innhenting av dokumentasjon og en nøyaktig verdivurdering for å fastsette korrekt markedspris.",
+      meta: ["2–4 uker", "Rapport + strategi"],
+    },
+    {
+      pre: "02 · Fase",
+      h3: "Markedsføring og prospekt",
+      p: "Utvikling av profesjonelt salgsmateriell og en målrettet strategi for å nå de rette kjøperne — diskré eller åpent.",
+      meta: ["2–3 uker", "Prospekt + lansering"],
+    },
+    {
+      pre: "03 · Fase",
+      h3: "Visninger og interessenter",
+      p: "Profesjonell gjennomføring av visninger og kontinuerlig oppfølging av interessenter for god dialog og fremdrift.",
+      meta: ["Løpende", "NDA-styrt"],
+    },
+    {
+      pre: "04 · Fase",
+      h3: "Budrunde og forhandlinger",
+      p: "Effektiv håndtering av budrunder og erfarne forhandlinger for best mulig pris og betingelser for deg som selger.",
+      meta: ["1–2 uker", "Senior partner"],
+    },
+    {
+      pre: "05 · Fase",
+      h3: "Kontrakt og oppgjør",
+      p: "Utarbeidelse av kjøpekontrakt og en trygg, etterprøvbar gjennomføring av det økonomiske oppgjøret.",
+      meta: ["2–4 uker", "Eksterne advokater"],
+    },
+    {
+      pre: "06 · Fase",
+      h3: "Overtakelse og oppfølging",
+      p: "Bistand med en ryddig overtakelse — og oppfølging i etterkant for å sikre at alle parter er trygge på handelen.",
+      meta: ["Etter signering", "Garantert"],
+    },
+  ],
+  whyLead: "Din fordel",
+  whyItalic: "med Advanti.",
+  whyIntro:
+    "Med oss får du en partner som kjenner markedet, jobber målrettet og dedikert — og oppnår resultater som tåler å bli målt.",
+  feats: [
+    {
+      num: "I",
+      h3: "Lokalkunnskap og nettverk",
+      p: "Dyptgående kjennskap til markedet i Nord-Norge og et omfattende nettverk sikrer maksimal eksponering for din eiendom.",
+    },
+    {
+      num: "II",
+      h3: "Dedikert seniorteam",
+      p: "Et erfarent og dedikert team følger deg tett gjennom hele prosessen, med personlig service og profesjonell håndtering.",
+    },
+    {
+      num: "III",
+      h3: "Resultatorientert",
+      p: "Vi jobber målrettet for best mulig pris og vilkår. Honoraret er resultatbasert — vi tjener når du tjener.",
+    },
+  ],
+  listingsEyebrow: "Aktuelle salgsoppdrag",
+  listingsLede:
+    "Et utvalg aktive mandater. Se hele inventaret på /eiendommer.",
+  baseFaqs: [
+    {
+      question: "Hvor lang tid tar en salgsprosess for næringseiendom?",
+      answer:
+        "En typisk salgsprosess hos Advanti tar tre til seks måneder, og følger seks dokumenterte faser: forberedelse og verdivurdering, markedsføring og prospekt, visninger, budrunde og forhandlinger, kontrakt og oppgjør, og til slutt overtakelse og oppfølging.",
+    },
+    {
+      question: "Hva koster det å selge næringseiendom gjennom Advanti?",
+      answer:
+        "Honoraret er resultatbasert — vi tjener når du tjener. Det gir oss alle insentiver til å oppnå best mulig pris og vilkår for deg som selger. Ta kontakt for en konfidensiell salgsvurdering.",
+    },
+    {
+      question: "Kan eiendommen selges uten åpen markedsføring?",
+      answer:
+        "Ja. Vi tilbyr en diskré prosess der vi går målrettet til en kuratert liste investorer under NDA, uten åpen markedsføring eller offentlig omtale. Vi velger spor sammen med deg ut fra eiendomstype, marked og konfidensialitetskrav.",
+    },
+  ],
+  ctaEyebrow: "Klar til å selge?",
+  ctaSub: (city) =>
+    `Ta kontakt for en konfidensiell samtale om salg av eiendommen din i ${city} og hvordan vi kan oppnå best mulig resultat.`,
+};
+
+const VERDIVURDERING: ServiceDef = {
+  slug: "verdivurdering",
+  label: "Verdivurdering",
+  noun: "Verdivurdering av næringseiendom",
+  keyword: "verdivurdering av næringseiendom",
+  heroEyebrow: "Tjeneste · Verdivurdering",
+  heroLede: (city) =>
+    `Profesjonell verdivurdering av næringseiendom i ${city}, basert på DCF-analyse, yield og reelle, lokale markedsdata — for salg, refinansiering eller strategisk planlegging.`,
+  heroPhoto: {
+    src: "/building/pexels-glass-panels-10156132.jpg",
+    alt: "Verdivurdering av næringseiendom",
+  },
+  metaDescription: (city, region) =>
+    `Profesjonell verdivurdering av næringseiendom i ${city}. DCF, yield og lokale markedsdata for salg, refinansiering og strategi. Advanti — næringsmegler i ${region}.`,
+  serviceSchemaDesc: (city) =>
+    `Profesjonell verdivurdering og analyse av næringseiendom i ${city}, basert på DCF, yield og lokale markedsdata.`,
+  intro: (city, region, primeYield) => [
+    `Trenger du en verdivurdering av næringseiendom i ${city}? Advanti leverer profesjonelle verdivurderinger basert på DCF-analyse, yield og reelle, lokale markedsdata — for salg, refinansiering, regnskap eller strategisk planlegging.`,
+    `Vi kjenner markedet i ${city} og ${region}, og bygger hver vurdering på sammenlignbare transaksjoner, faktiske leienivåer og kontantstrømanalyser — ikke nasjonale gjennomsnitt.${
+      primeYield
+        ? ` Indikativ prime yield i ${city} ligger nå rundt ${primeYield}.`
+        : ""
+    }`,
+  ],
+  processEyebrow: "01 — Verdivurderingen",
+  processLead: "En etterprøvbar",
+  processItalic: "metodikk.",
+  processIntro:
+    "Hver verdivurdering bygges i seks steg — fra datagrunnlag til verdikonklusjon — slik at forutsetningene er transparente og tåler å bli etterprøvd av bank, revisor og motpart.",
+  steps: [
+    {
+      pre: "01 · Steg",
+      h3: "Befaring og dokumentasjon",
+      p: "Gjennomgang av eiendom, leiekontrakter, kostnader og teknisk tilstand for et korrekt datagrunnlag.",
+      meta: ["1–2 uker", "Datagrunnlag"],
+    },
+    {
+      pre: "02 · Steg",
+      h3: "Markeds- og leieanalyse",
+      p: "Analyse av lokale leienivåer, ledighet og etterspørsel i markedet for å forankre forutsetningene.",
+      meta: ["Lokale data", "Kvartalsvis"],
+    },
+    {
+      pre: "03 · Steg",
+      h3: "Kontantstrøm og DCF",
+      p: "Modellering av netto kontantstrøm og diskontert nåverdi (DCF) over analyseperioden, med sensitiviteter.",
+      meta: ["DCF", "Sensitivitet"],
+    },
+    {
+      pre: "04 · Steg",
+      h3: "Yield og sammenlignbare",
+      p: "Avkastningskrav avstemt mot sammenlignbare transaksjoner og segment i det lokale markedet.",
+      meta: ["Yield", "Transaksjoner"],
+    },
+    {
+      pre: "05 · Steg",
+      h3: "Rapport og verdikonklusjon",
+      p: "En tydelig, etterprøvbar rapport med verdikonklusjon, forutsetninger og metodikk.",
+      meta: ["Rapport", "Verdikonklusjon"],
+    },
+    {
+      pre: "06 · Steg",
+      h3: "Gjennomgang og rådgivning",
+      p: "Vi går gjennom vurderingen med deg og rådgir om bruk mot bank, ved salg eller i strategisk planlegging.",
+      meta: ["Gjennomgang", "Rådgivning"],
+    },
+  ],
+  whyLead: "Hvorfor",
+  whyItalic: "Advanti.",
+  whyIntro:
+    "Verdivurdering er kjernen i alt vi gjør. Vi kombinerer finansiell metodikk fra de største transaksjonshusene med lokale data fra landsdelen.",
+  feats: [
+    {
+      num: "I",
+      h3: "Datadrevet metodikk",
+      p: "DCF, yield og sensitivitetsanalyser — en vurdering fundert i tall, ikke skjønn alene.",
+    },
+    {
+      num: "II",
+      h3: "Lokale markedsdata",
+      p: "Vi sporer over 1 400 eiendommer i landsdelen, kvartalsvis oppdatert. Hver vurdering hviler på reelle tall.",
+    },
+    {
+      num: "III",
+      h3: "Står seg mot bank",
+      p: "Etterprøvbare rapporter som tåler gjennomgang av bank, revisor og motpart ved refinansiering og salg.",
+    },
+  ],
+  listingsEyebrow: "Aktuelle oppdrag",
+  listingsLede:
+    "Et utvalg aktive mandater i markedet. Se hele inventaret på /eiendommer.",
+  baseFaqs: [
+    {
+      question: "Hva koster en verdivurdering av næringseiendom?",
+      answer:
+        "Honorar avhenger av eiendomstype, størrelse og kompleksitet. Ta kontakt for et konkret tilbud basert på din eiendom.",
+    },
+    {
+      question: "Hvilke metoder bruker dere i verdivurderingen?",
+      answer:
+        "Vi kombinerer DCF-analyse, yield og avkastningskrav og sammenlignbare transaksjoner, forankret i lokale leie- og markedsdata.",
+    },
+    {
+      question: "Kan verdivurderingen brukes mot bank og refinansiering?",
+      answer:
+        "Ja. Rapportene er etterprøvbare og brukes til refinansiering, salg, regnskap og strategisk planlegging.",
+    },
+  ],
+  ctaEyebrow: "Trenger du en verdivurdering?",
+  ctaSub: (city) =>
+    `Ta kontakt for en profesjonell verdivurdering av eiendommen din i ${city}, basert på lokale markedsdata.`,
+};
+
+const UTLEIE: ServiceDef = {
+  slug: "utleie",
+  label: "Utleie",
+  noun: "Utleie av næringseiendom",
+  keyword: "utleie av næringseiendom",
+  heroEyebrow: "Tjeneste · Utleie",
+  heroLede: (city) =>
+    `Vi bistår både utleiere og leietakere i ${city} — med leieprisanalyse, markedsføring av lokalet, leietakersøk og forhandling av leiekontrakt.`,
+  heroPhoto: {
+    src: "/building/pexels-building-10156174.jpg",
+    alt: "Næringslokaler til leie",
+  },
+  metaDescription: (city, region) =>
+    `Utleie av næringslokaler i ${city}. Advanti bistår utleiere og leietakere med leieprisanalyse, markedsføring, leietakersøk og forhandling i ${region}.`,
+  serviceSchemaDesc: (city) =>
+    `Utleie og leietakerhåndtering for næringslokaler i ${city}, for både utleiere og leietakere.`,
+  intro: (city, region) => [
+    `Skal du leie ut næringslokaler i ${city}, eller leter du etter lokaler? Advanti bistår både utleiere og leietakere i ${city} med leieprisanalyse, markedsføring, leietakersøk og forhandling av leiekontrakter.`,
+    `Målet er riktig leienivå, høyt belegg og solide, langsiktige leietakere. Vi kjenner leietakermarkedet i ${city} og ${region}, og gjennomfører ryddige prosesser fra strategi til signert kontrakt.`,
+  ],
+  processEyebrow: "01 — Utleieprosessen",
+  processLead: "En målrettet",
+  processItalic: "utleieprosess.",
+  processIntro:
+    "Vi følger en strukturert prosess i seks faser — fra leieprisanalyse til signert kontrakt og videre oppfølging — som balanserer leienivå mot belegg.",
+  steps: [
+    {
+      pre: "01 · Fase",
+      h3: "Leieprisanalyse og strategi",
+      p: "Vi fastsetter riktig leienivå og utleiestrategi basert på lokale markedsdata og segment.",
+      meta: ["Leienivå", "Strategi"],
+    },
+    {
+      pre: "02 · Fase",
+      h3: "Klargjøring og markedsføring",
+      p: "Profesjonell presentasjon og målrettet markedsføring av lokalet mot relevante leietakere.",
+      meta: ["Prospekt", "Annonsering"],
+    },
+    {
+      pre: "03 · Fase",
+      h3: "Leietakersøk og visninger",
+      p: "Aktiv prospektering i nettverket og gjennomføring av visninger med kvalifiserte leietakere.",
+      meta: ["Løpende", "Nettverk"],
+    },
+    {
+      pre: "04 · Fase",
+      h3: "Forhandling av leievilkår",
+      p: "Forhandling av leie, varighet, opsjoner og betingelser som sikrer langsiktig verdi.",
+      meta: ["Vilkår", "Opsjoner"],
+    },
+    {
+      pre: "05 · Fase",
+      h3: "Kontrakt og inngåelse",
+      p: "Utarbeidelse av leiekontrakt og en ryddig inngåelse mellom partene.",
+      meta: ["Leiekontrakt", "Signering"],
+    },
+    {
+      pre: "06 · Fase",
+      h3: "Oppfølging og reforhandling",
+      p: "Oppfølging gjennom leieforholdet og bistand ved reforhandling og fornyelse.",
+      meta: ["Oppfølging", "Reforhandling"],
+    },
+  ],
+  whyLead: "Din fordel",
+  whyItalic: "med Advanti.",
+  whyIntro:
+    "Vi jobber for høyt belegg og stabil kontantstrøm — med markedsbasert prising og solide leietakere som står seg over tid.",
+  feats: [
+    {
+      num: "I",
+      h3: "Riktig leienivå",
+      p: "Markedsbasert prising som balanserer leieinntekt og belegg, forankret i lokale data.",
+    },
+    {
+      num: "II",
+      h3: "Solide leietakere",
+      p: "Vi kvalifiserer leietakere for langsiktig, stabil kontantstrøm — ikke bare rask utleie.",
+    },
+    {
+      num: "III",
+      h3: "Lokalt nettverk",
+      p: "Direkte tilgang til leietakere og aktører i landsdelen gir raskere og bedre treff.",
+    },
+  ],
+  listingsEyebrow: "Ledige lokaler",
+  listingsLede:
+    "Et utvalg lokaler i markedet. Se hele inventaret på /eiendommer.",
+  baseFaqs: [
+    {
+      question: "Bistår dere både utleiere og leietakere?",
+      answer:
+        "Ja. Vi representerer utleiere i utleieprosesser og bistår leietakere med å finne og forhandle riktige lokaler.",
+    },
+    {
+      question: "Hvordan fastsetter dere riktig leienivå?",
+      answer:
+        "Vi analyserer lokale leienivåer, ledighet og etterspørsel i segmentet, og setter en markedsbasert leie som balanserer inntjening og belegg.",
+    },
+    {
+      question: "Hva koster utleiemegling?",
+      answer:
+        "Honoraret tilpasses oppdragets omfang. Ta kontakt for et konkret tilbud basert på lokalet og markedet.",
+    },
+  ],
+  ctaEyebrow: "Skal du leie ut?",
+  ctaSub: (city) =>
+    `Ta kontakt for en uforpliktende prat om utleie av lokalet ditt i ${city} — vi finner riktig leietaker til riktig leie.`,
+};
+
+export const SERVICES: Record<ServiceSlug, ServiceDef> = {
+  salg: SALG,
+  verdivurdering: VERDIVURDERING,
+  utleie: UTLEIE,
+};
+
+export function getServiceDef(slug: string): ServiceDef | undefined {
+  return (SERVICES as Record<string, ServiceDef>)[slug];
+}
+
+export function getServiceCityLocation(citySlug: string) {
+  return allLocationPosts.find((location) => location.slug === citySlug) ?? null;
+}
+
+/** True only for an allowlisted city slug that also resolves to a location. */
+export function isServiceCity(citySlug: string): boolean {
+  return (
+    (SERVICE_CITY_SLUGS as readonly string[]).includes(citySlug) &&
+    !!getServiceCityLocation(citySlug)
+  );
+}
+
+/** Per-page metadata for a service × city route. Undefined for unknown combos. */
+export function buildServiceCityMetadata(
+  serviceSlug: string,
+  citySlug: string,
+): Metadata | undefined {
+  const service = getServiceDef(serviceSlug);
+  const location = getServiceCityLocation(citySlug);
+  if (!service || !location) return undefined;
+  return constructMetadata({
+    title: `${service.noun} i ${location.name} | Advanti`,
+    description: service.metaDescription(location.name, location.region),
+    path: `/tjenester/${service.slug}/${location.slug}`,
+  });
+}

--- a/src/styles/advanti-design.css
+++ b/src/styles/advanti-design.css
@@ -2148,6 +2148,18 @@ h1, h2, h3 {
 .mi-table .down { color: #b04a3a; }
 .mi-table .label-cell { font-weight: 500; color: var(--warm-grey); }
 
+/* Server-rendered data summary (MarketDataSummary) headings */
+.mi-data-h3 {
+  font-family: var(--font-display);
+  font-size: 20px;
+  font-weight: 400;
+  letter-spacing: -0.012em;
+  color: var(--warm-grey);
+  margin: 48px 0 4px;
+}
+.mi-data-h3:first-of-type { margin-top: 24px; }
+.mi-data-sub { color: var(--warm-grey-85); }
+
 /* Footnote */
 .mi-footnote {
   margin-top: 16px;


### PR DESCRIPTION
## Hva

### 1. Tjeneste×by-landingssider (18 sider)
`/tjenester/{salg|verdivurdering|utleie}/{by}` for **Bodø, Tromsø, Alta, Harstad, Narvik, Mo i Rana**. Målretter høyeste kjøpsintent: «salg av næringseiendom Bodø», «verdivurdering næringseiendom Tromsø» osv.
- Delt data-lag (`src/lib/service-cities.ts`) + delt komponent (`ServiceCityPage.tsx`) + 3 tynne ruter.
- Hver side: ekte byunike markedsdata, byfiltrerte oppdrag, unik intro + by-FAQ, Service/FAQ/breadcrumb-schema.
- `dynamicParams=false` → bare de 6 byene er gyldige (ingen tynne auto-sider).
- By-hubene (`/naringsmegler/{by}`) lenker til sine tjeneste×by-sider; alle 18 i sitemap.

### 2. AEO / LLM-search
- **`llms.txt`:** henter oppdrag fra CRM (`getListings`, 21 i prod) i stedet for MDX (1), ISR i stedet for `force-static`, og ny «Tjenester per by»-seksjon med alle 18.
- **`/markedsinnsikt`:** dataene lå kun i en klientkomponent (aktiv fane + `ssr:false`-grafer), så tallene nådde aldri server-HTML. Trukket ut til delt `marketData.ts`; ny **server-rendret `MarketDataSummary`** legger yield/leie/ledighet/transaksjoner per by som semantiske tabeller i initial HTML — crawl- og siterbart for Google og AI.

## Verifisering
- `pnpm build` rent — 105 → **123 sider** (+18), alle 18 prerendret.
- `/markedsinnsikt` server-HTML inneholder nå alle datatabellene (verifisert med stikkprøver: Tromsø-leie 2 950, Narvik yield 6,90 %, ledighet 7,5 %, TX 285 mnok).
- Ingen datadrift: grafer og tabeller deler `marketData.ts`.

## Etter merge
- Sjekk live: 18 sider 200, `llms.txt` viser alle oppdrag + tjeneste×by, `/markedsinnsikt` har tabellene i kildekoden.
- Search Console: send sitemap på nytt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)