### PR TITLE
perf(seo): next/image på by-sider (CWV/LCP) + fjern duplisert FAQ-schema

### DIFF
--- a/src/app/naringsmegler/[slug]/page.tsx
+++ b/src/app/naringsmegler/[slug]/page.tsx
@@ -1,6 +1,7 @@
 import { notFound } from "next/navigation";
 import type { Metadata } from "next";
 import Link from "next/link";
+import Image from "next/image";
 import { allLocationPosts } from "content-collections";
 
 import StructuredData, {
@@ -209,10 +210,13 @@ export default async function LocationPage({
               </div>
             </div>
             <div className="subhero-photo">
-              {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img
+              <Image
                 src={location.hero.image}
                 alt={`Næringseiendom i ${location.name}`}
+                fill
+                priority
+                sizes="(max-width: 980px) 100vw, 45vw"
+                style={{ objectFit: "cover" }}
               />
             </div>
           </div>
@@ -510,14 +514,16 @@ export default async function LocationPage({
                     href={`/naringsmegler/${nearby.slug}`}
                   >
                     <div className="cy-image">
+                      <Image
+                        src={nearby.hero.image}
+                        alt={`${nearby.name} næringseiendom`}
+                        fill
+                        sizes="(max-width: 980px) 100vw, 33vw"
+                        style={{ objectFit: "cover" }}
+                      />
                       <span className="label">
                         _0{index + 1} · {nearby.region}
                       </span>
-                      {/* eslint-disable-next-line @next/next/no-img-element */}
-                      <img
-                        src={nearby.hero.image}
-                        alt={`${nearby.name} næringseiendom`}
-                      />
                     </div>
                     <div>
                       <span className="reg">{nearby.region}</span>

--- a/src/app/naringsmegler/page.tsx
+++ b/src/app/naringsmegler/page.tsx
@@ -1,5 +1,6 @@
 import { allLocationPosts } from "content-collections";
 import Link from "next/link";
+import Image from "next/image";
 
 import StructuredData, {
   BreadcrumbStructuredData,
@@ -100,14 +101,16 @@ export default function NaringsmeglerHubPage() {
                   href={`/naringsmegler/${location.slug}`}
                 >
                   <div className="cy-image">
+                    <Image
+                      src={location.hero.image}
+                      alt={`${location.name} næringseiendom`}
+                      fill
+                      sizes="(max-width: 980px) 100vw, 33vw"
+                      style={{ objectFit: "cover" }}
+                    />
                     <span className="label">
                       {num} · {location.region}
                     </span>
-                    {/* eslint-disable-next-line @next/next/no-img-element */}
-                    <img
-                      src={location.hero.image}
-                      alt={`${location.name} næringseiendom`}
-                    />
                   </div>
                   <div>
                     <span className="reg">

--- a/src/components/tjenester/ServiceCityPage.tsx
+++ b/src/components/tjenester/ServiceCityPage.tsx
@@ -97,7 +97,8 @@ export function ServiceCityPage({
           description: service.serviceSchemaDesc(city),
         }}
       />
-      <StructuredData type="faq" data={{ faqs: faqItems }} />
+      {/* FAQ schema is emitted by the <Faq> component below — no standalone
+          StructuredData here, or the page would carry two FAQPage blocks. */}
 
       <SubHero
         crumb={[

--- a/src/styles/advanti-design.css
+++ b/src/styles/advanti-design.css
@@ -1095,6 +1095,7 @@ h1, h2, h3 {
   overflow-wrap: break-word;
 }
 .subhero-photo {
+  position: relative;
   aspect-ratio: 4/5;
   overflow: hidden;
   background: var(--warm-grey-75);


### PR DESCRIPTION
## Hva
On-site SEO-finpuss etter valideringsrunden.

- **CWV/LCP:** by-hubben (`/naringsmegler`) og by-sidene (`/naringsmegler/{by}`) brukte rå `<img>` for hero/kort. Hero er typisk LCP-elementet på nettopp de sidene vi vil ranke. Konvertert til `next/image` (fill + responsivt `sizes`, hero med `priority`) → automatisk resizing, moderne format (webp/avif) og lazy-load på kort. `.subhero-photo` får `position: relative` (kreves for `fill`); `Image` plassert før `.label` så badgen ikke dekkes.
- **Schema-fiks:** `ServiceCityPage` la til en egen `StructuredData faq` i tillegg til `<Faq>` (som allerede emitterer `FAQPage`) → 2× `FAQPage` på de 18 tjeneste×by-sidene. Duplikat fjernet.

## Verifisering
- `pnpm build` rent — 123 sider.
- 0 rå `<img>` igjen på rankingsidene; 0 standalone faq-schema i ServiceCityPage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized image loading and rendering across location detail pages, location listings, and city card pages for faster load times and improved responsiveness

* **Bug Fixes**
  * Removed duplicate FAQ structured data schema that could cause conflicts with page metadata
  * Corrected positioning and alignment of image overlays on location cards for proper visual display

<!-- end of auto-generated comment: release notes by coderabbit.ai -->