### PR TITLE
feat(seo): markedsrapport som crawlbar HTML + lokal markedsartikkel

### DIFF
--- a/src/app/markedsrapport/page.tsx
+++ b/src/app/markedsrapport/page.tsx
@@ -1,6 +1,8 @@
+import Link from "next/link"
 import { constructMetadata } from "@/lib/utils"
 import { SubHero } from "@/components/site/SubHero"
 import { CtaStrip } from "@/components/site/CtaStrip"
+import { CITIES } from "@/components/markedsinnsikt/marketData"
 import { MarkedsrapportGate } from "./MarkedsrapportGate"
 
 export const metadata = constructMetadata({
@@ -102,6 +104,63 @@ export default function MarkedsrapportPage() {
                 </div>
               </div>
             ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Ungated, crawlbart HTML-sammendrag — de faktiske tallene, ikke bare
+          låst i PDF. Gir Google og AI-motorer noe å rangere/sitere; full
+          databredde + interaktive grafer ligger på /markedsinnsikt. */}
+      <section className="section section-divider" id="sammendrag">
+        <div className="wrap">
+          <div className="head-compact">
+            <span className="eyebrow">Sammendrag · Q4 2025</span>
+            <div>
+              <h2>
+                Markedet i tall, <span className="italic">by for by.</span>
+              </h2>
+              <p>
+                Næringseiendomsmarkedet i Nord-Norge går inn i 2026 med lav
+                ledighet og stabil etterspørsel. Tromsø er strammest med 3,4 %
+                kontorledighet og landsdelens laveste yield; de mindre byene
+                prises høyere, drevet av lavere likviditet snarere enn svak
+                etterspørsel. Tabellen under viser prime yield (kontor),
+                markedsleie og kontorledighet per by per Q4 2025.
+              </p>
+            </div>
+          </div>
+
+          <table className="mi-table">
+            <caption className="sr-only">
+              Prime yield, markedsleie og kontorledighet per by, Q4 2025
+            </caption>
+            <thead>
+              <tr>
+                <th>By</th>
+                <th className="r">Prime yield (kontor)</th>
+                <th className="r">Markedsleie kontor</th>
+                <th className="r">Kontorledighet</th>
+              </tr>
+            </thead>
+            <tbody>
+              {CITIES.map((c) => (
+                <tr key={c.id}>
+                  <td>{c.name}</td>
+                  <td className="r">{c.yield}</td>
+                  <td className="r">{c.leie}</td>
+                  <td className="r">{c.vac}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+
+          <div className="mi-footnote" style={{ marginTop: 24 }}>
+            <span className="source">
+              Tall er indikative og reflekterer prime kvalitet. Full segmentert
+              databredde (kontor, handel, logistikk) på{" "}
+              <Link href="/markedsinnsikt">markedsinnsikt</Link>.
+            </span>
+            <span>Q4 2025 · Advanti markedsdata</span>
           </div>
         </div>
       </section>

--- a/src/content/blog/naringseiendomsmarkedet-mo-i-rana-2026.mdx
+++ b/src/content/blog/naringseiendomsmarkedet-mo-i-rana-2026.mdx
@@ -1,0 +1,90 @@
+---
+title: "Næringseiendomsmarkedet i Mo i Rana 2026: industri, yield og leiepriser"
+publishedAt: "2026-06-08"
+summary: Markedsoversikt for næringseiendom i Mo i Rana — yield, leiepriser og ledighet per segment, med vekt på industri- og logistikkmarkedet rundt Mo Industripark.
+image: /building/pexels-bw-facade-35770652.jpg
+author: codehagen
+categories:
+  - market-analysis
+related:
+  - naringseiendomsmarkedet-bodo-2025
+  - markedspuls-nord-norge-2025-2026
+slug: naringseiendomsmarkedet-mo-i-rana-2026
+---
+
+Mo i Rana er administrasjonssenteret i Rana og et av Nord-Norges viktigste industriknutepunkt. Med Mo Industripark som motor, betydelige investeringer i grønn industri og gode transportforbindelser via Nordlandsbanen og E6, har byen et næringseiendomsmarked med tydelig vekt på industri-, lager- og kombinasjonsbygg — i tillegg til sentrumsnær kontor- og handelseiendom.
+
+Denne analysen gir en oversikt over markedet per Q4 2025: yield-nivåer, leiepriser og ledighet, med særskilt blikk på industri- og logistikksegmentet.
+
+<StatStrip
+  items={[
+    { value: "6,75–7,75", unit: "%", label: "Prime yield kontor" },
+    { value: "5,4", unit: "%", label: "Kontorledighet" },
+    { value: "2,8", unit: "%", label: "Ledighet logistikk" },
+    { value: "1 100–1 700", unit: "kr/m²/år", label: "Kontorleie høy standard" },
+  ]}
+/>
+
+## Yield og leiepriser (Q4 2025)
+
+Som et mindre og mer industriavhengig marked prises Mo i Rana høyere enn Bodø og Tromsø. Yield-gapet reflekterer lavere transaksjonsvolum og likviditet — ikke svak etterspørsel. For godt utleide bygg med solide leietakere ligger prime yield på kontor rundt 6,75–7,75 %, mens eldre eller mindre sentrale bygg krever vesentlig høyere avkastning.
+
+| Indikator | Nivå | Kommentar |
+| --- | --- | --- |
+| Prime yield (kontor) | 6,75–7,75 % | Påvirkes av leietakerprofil, standard og kontraktslengde |
+| Sekundær yield (kontor) | 8,25–9,75 % | Eldre eller mindre sentrale bygg |
+| Kontorleie høy standard | 1 100–1 700 kr/m²/år | Sentrum, moderne lokaler |
+| Kontorleie standard | 850–1 250 kr/m²/år | Sentrumsnære bygg, normal standard |
+| Lager/logistikk | 600–1 000 kr/m²/år | Stabilt nivå for moderne lager og kombinasjonsbygg |
+| Industri/verksted | 450–800 kr/m²/år | Spesialiserte lokaler, sterk kobling til Mo Industripark |
+
+*Tall er indikative og reflekterer prime kvalitet. Kilde: Advanti markedsdata (Q4 2025).*
+
+## Ledighet etter segment
+
+Mo i Rana har moderat kontorledighet, men et stramt logistikk- og lagermarked — drevet av industri, dagligvare og transport. Det er nettopp her byen skiller seg ut: etterspørselen etter areal knyttet til Mo Industripark og logistikk holder ledigheten lav i segmentet.
+
+| Segment | Ledighet Q4 2025 |
+| --- | --- |
+| Kontor | 5,4 % |
+| Handel | 4,0 % |
+| Logistikk | 2,8 % |
+
+<Note variant="key">
+Logistikk- og industrisegmentet er Mo i Ranas styrke: med kun 2,8 % ledighet og en sterk industripark er dette markedet der etterspørselen er mest robust — og der godt posisjonerte eiendommer prises deretter.
+</Note>
+
+## Markedsdrivere
+
+<Summary
+  title="Hva som driver markedet i Mo i Rana."
+  points={[
+    { title: "Mo Industripark", description: "En av Norges største industriparker gir kontinuerlig etterspørsel etter industri-, lager- og kombinasjonsbygg." },
+    { title: "Grønn industri", description: "Betydelige investeringer i grønn industri skaper ringvirkninger for næringseiendom i regionen." },
+    { title: "Transport og logistikk", description: "Nordlandsbanen og E6 gjør Mo i Rana til et logistikknutepunkt på Helgeland." },
+    { title: "Offentlig sektor", description: "Rana som regionsenter gir et stabilt grunnlag for kontor- og handelseiendom." },
+  ]}
+/>
+
+## Hva betyr dette for deg som eier eller investor
+
+For eiere av industri- og logistikkeiendom er markedet gunstig: lav ledighet og stabil etterspørsel støtter både verdi og leieinntekter. For kontor- og handelseiendom er bildet mer nyansert — beliggenhet, standard og leietakerkvalitet avgjør prisingen.
+
+Skal du selge, leie ut eller få en verdivurdering, anbefaler vi en konkret vurdering basert på eiendommens segment og beliggenhet. Se hvordan vi jobber lokalt på [næringsmegler i Mo i Rana](/naringsmegler/mo-i-rana), eller direkte på [salg av næringseiendom i Mo i Rana](/tjenester/salg/mo-i-rana) og [verdivurdering i Mo i Rana](/tjenester/verdivurdering/mo-i-rana).
+
+For det fulle bildet på tvers av landsdelen, se [markedsinnsikt](/markedsinnsikt) og den kvartalsvise [markedsrapporten](/markedsrapport).
+
+## Kontakt
+
+Trenger du en oppdatert verdivurdering av næringseiendommen din i Mo i Rana, eller ønsker du rådgivning rundt kjøp, salg eller utleie?
+
+**Christer Hagen**  
+Eiendomsmegler MNEF / Næringsmegler / Partner  
+Advanti Estate  
+Dronningens gate 18, 8006 Bodø  
+Telefon: +47 984 53 571  
+E‑post: Christer@advanti.no
+
+---
+
+*Denne artikkelen er utarbeidet av Advanti Estate og er kun ment som veiledende informasjon. Tallene er estimater basert på tilgjengelig markedsdata per Q4 2025 og egne analyser. Artikkelen utgjør ikke en verdivurdering av spesifikke eiendommer.*


### PR DESCRIPTION
## Hva — fullfører innholds-delen av SEO-anbefalingen (punkt 2)

### `/markedsrapport` → crawlbar HTML
Siden var en ren lead-gen-gate: all data lå låst i PDF bak et skjema, ingenting crawlbart for Google/AI. Lagt til et **ungated «Sammendrag Q4 2025»** med original analyse + per-by-tabell (prime yield, markedsleie, kontorledighet) fra delt `marketData.ts` (DRY, ingen drift). PDF-gaten beholdt for full versjon; full segmentert databredde lenkes til `/markedsinnsikt`.

### Ny lokal markedsartikkel
`naringseiendomsmarkedet-mo-i-rana-2026` — grunnet i de indikative Q4 2025-dataene fra `mo-i-rana.mdx` + ledighetsdata. Bruker de redaksjonelle komponentene (StatStrip, Summary, Note) og lenker internt til de nye by-/tjeneste×by-sidene. Frøet til den månedlige markedsartikkel-kadensen.

## Verifisering
- `pnpm build` rent — 123 → **124 sider**.
- `/markedsrapport` har nå datatabellen med ekte per-by-yields (verifisert).
- Artikkelen kompilerer + prerendres.

🤖 Generated with [Claude Code](https://claude.com/claude-code)