### PR TITLE
fix(seo): intern autoritets-lenking fra fag-sider + åpne /api/og

### DIFF
--- a/src/app/(help)/help/article/[slug]/page.tsx
+++ b/src/app/(help)/help/article/[slug]/page.tsx
@@ -288,6 +288,17 @@ export default async function HelpArticle({
                 </Link>
               ))}
 
+              <div className="toc-related">
+                <div className="toc-label">Relaterte tjenester</div>
+                <Link href="/tjenester/verdivurdering">
+                  Verdivurdering av næringseiendom
+                </Link>
+                <Link href="/tjenester/salg">Salg av næringseiendom</Link>
+                <Link href="/tjenester/utleie">Utleie av næringseiendom</Link>
+                <Link href="/naringsmegler/bodo">Næringsmegler i Bodø</Link>
+                <Link href="/naringsmegler">Alle markeder i Nord-Norge</Link>
+              </div>
+
               <div className="toc-meta">
                 Skrevet av {authorName}.
                 <br />

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -10,6 +10,12 @@ export default function robots(): MetadataRoute.Robots {
   // /admin/ when granting AI crawl access.
   const SHARED_DISALLOW = ["/advanti/", "/api/", "/admin/"];
 
+  // Allow the OG image-generation endpoint even though /api/ is otherwise
+  // disallowed — so Google and social/AI crawlers (LinkedIn, Slack, …) can
+  // fetch the dynamic og:image previews for listings and blog posts. Longest
+  // path match wins in compliant parsers, so this opens /api/og/ only.
+  const SHARED_ALLOW = ["/", "/api/og/"];
+
   // Explicit allow rules for the AI search/citation crawlers. Functionally
   // equivalent to the wildcard today, but documents intent — a future tightening
   // of the wildcard rule would not silently block these engines.
@@ -27,7 +33,7 @@ export default function robots(): MetadataRoute.Robots {
     rules: [
       ...AI_SEARCH_BOTS.map((userAgent) => ({
         userAgent,
-        allow: "/",
+        allow: SHARED_ALLOW,
         disallow: SHARED_DISALLOW,
       })),
       // Common Crawl powers many AI training datasets; block it to opt out of
@@ -38,7 +44,7 @@ export default function robots(): MetadataRoute.Robots {
       },
       {
         userAgent: "*",
-        allow: "/",
+        allow: SHARED_ALLOW,
         // `/_next/` is intentionally NOT disallowed — it holds render-critical
         // JS/CSS and the next/image endpoint that Googlebot must fetch to
         // render and index pages.

--- a/src/styles/advanti-design.css
+++ b/src/styles/advanti-design.css
@@ -3225,6 +3225,13 @@ h1, h2, h3 {
   color: var(--warm-grey-85);
   line-height: 1.55;
 }
+/* Related-services links under the article TOC — passes authority from the
+   high-traffic help articles to the commercial pages. */
+.ks-toc .toc-related {
+  margin-top: 32px;
+  padding-top: 20px;
+  border-top: var(--hairline);
+}
 
 /* Feedback widget */
 .ks-feedback {


### PR DESCRIPTION
## Hvorfor
Search Console (siste 3 mnd) viser:
- 46 % av trafikken kommer fra **én** side (yield-kalkulatoren); pengesidene (næringsmegler/by + tjenester) henger på **pos 6–10**.
- **13 sider «Crawled – currently not indexed»** — Google ser dem som for lav autoritet til å indeksere.

Begge peker på **autoritet** som flaskehals. (Coverage-funnet «119 blocked» var ufarlig — kun stale build-chunks + /api/og, null innholdssider.)

## Hva
- **Intern autoritets-lenking:** hjelpeartiklene (tusenvis av visninger hver, f.eks. `diskontert-kontantstrom` 4 210, `hva-er-yield` 3 838) lenket før kun til verdivurdering. Ny **«Relaterte tjenester»-blokk** i artikkel-sidebaren → verdivurdering, salg, utleie, næringsmegler i Bodø + by-hub. Sender PageRank til pengesidene → hjelper både **indeksering** og **rangering**.
- **robots:** åpnet `/api/og/` (`Allow` før `/api/`-disallow) så Google og sosiale/AI-crawlere (LinkedIn, Slack) kan hente de genererte `og:image`-previewene.

## Verifisering
- `pnpm build` rent — 124 sider.
- 13/14 hjelpeartikler har blokken (den 14. er en alias-URL; kanonisk har den).

🤖 Generated with [Claude Code](https://claude.com/claude-code)