### PR TITLE
fix(seo): redirect legacy numeric blog pagination → /blog

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -83,6 +83,13 @@ const nextConfig = {
         permanent: true,
       },
       {
+        // Legacy numeric blog pagination (/blog/2, /blog/3, …) → blog index.
+        // Real posts use non-numeric slugs, so this never catches an article.
+        source: "/blog/:page(\\d+)",
+        destination: "/blog",
+        permanent: true,
+      },
+      {
         source:
           "/kunder/hvordan-vi-hjalp-en-investor-realisere-25-høyere-avkastning",
         destination: "/kunder/investor-avkastning",


### PR DESCRIPTION
GSC «Not found (404)»-drilldown viste `/blog/3` som død (gammel paginering). Lagt til `/blog/:page(\d+)` → `/blog`. Øvrige coverage-funn er allerede håndtert eller støy (se commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)