### PR TITLE
feat(presserom): markedstall-for-media-side (lenkeagn for digital PR)

### DIFF
--- a/src/app/presserom/page.tsx
+++ b/src/app/presserom/page.tsx
@@ -1,0 +1,228 @@
+import Link from "next/link"
+
+import { constructMetadata } from "@/lib/utils"
+import { SubHero } from "@/components/site/SubHero"
+import { CtaStrip } from "@/components/site/CtaStrip"
+import { BreadcrumbStructuredData } from "@/components/StructuredData"
+import { CITIES, LATEST_QUARTER } from "@/components/markedsinnsikt/marketData"
+import { siteConfig } from "@/app/siteConfig"
+
+export const metadata = constructMetadata({
+  path: "/presserom",
+  title: "Presserom — markedstall for media | Advanti",
+  description:
+    "Markedstall for næringseiendom i Nord-Norge, fritt til bruk for media med kildehenvisning til Advanti. Yield, leie og ledighet per by, sitat og pressekontakt.",
+})
+
+export default function PresseromPage() {
+  const phone = siteConfig.contact.phone
+  const email = siteConfig.contact.email
+
+  return (
+    <>
+      <BreadcrumbStructuredData
+        items={[
+          { name: "Hjem", url: "/" },
+          { name: "Presserom", url: "/presserom" },
+        ]}
+      />
+
+      <SubHero
+        crumb={[{ label: "Hjem", href: "/" }, { label: "Presserom" }]}
+        eyebrow="Presserom · For media"
+        title={
+          <>
+            Markedstall <span className="italic">til fri bruk.</span>
+          </>
+        }
+        lede="Skriver du om næringseiendom i Nord-Norge? Tallene under kan gjengis fritt med kildehenvisning til Advanti Estate. Oppdatert kvartalsvis — og vi stiller gjerne til kommentar eller intervju."
+        actions={[
+          { label: "Pressekontakt", href: "#kontakt" },
+          { label: "Full markedsinnsikt", href: "/markedsinnsikt", variant: "outline" },
+        ]}
+        metaRow={[
+          { value: String(CITIES.length), label: "Byer dekket" },
+          { value: LATEST_QUARTER, label: "Sist oppdatert" },
+          { value: "Kvartalsvis", label: "Oppdatering" },
+        ]}
+      />
+
+      {/* 01 — NØKKELTALL */}
+      <section className="section section-divider" id="tall">
+        <div className="wrap">
+          <div className="head-compact">
+            <span className="eyebrow">01 — Nøkkeltall · {LATEST_QUARTER}</span>
+            <div>
+              <h2>
+                Tallene, <span className="italic">klare til sitering.</span>
+              </h2>
+              <p>
+                Prime yield (kontor), markedsleie og kontorledighet per by i
+                Nord-Norge. Indikative tall for prime kvalitet. Full segmentert
+                databredde — kontor, handel og logistikk — ligger på{" "}
+                <Link href="/markedsinnsikt">markedsinnsikt</Link>.
+              </p>
+            </div>
+          </div>
+
+          <div className="mi-kpis" style={{ marginBottom: 40 }}>
+            <div className="mi-kpi">
+              <div className="label">Byer dekket</div>
+              <div className="val">{CITIES.length}</div>
+              <div className="delta">Bodø til Hammerfest</div>
+            </div>
+            <div className="mi-kpi">
+              <div className="label">Lavest ledighet</div>
+              <div className="val">
+                3,4<span className="unit">%</span>
+              </div>
+              <div className="delta">Tromsø — stramt marked</div>
+            </div>
+            <div className="mi-kpi">
+              <div className="label">Transaksjonsvolum</div>
+              <div className="val">
+                4,8<span className="unit">mrd</span>
+              </div>
+              <div className="delta">Nord-Norge · 2025</div>
+            </div>
+            <div className="mi-kpi">
+              <div className="label">Sist oppdatert</div>
+              <div className="val">{LATEST_QUARTER}</div>
+              <div className="delta">Kvartalsvis</div>
+            </div>
+          </div>
+
+          <table className="mi-table">
+            <caption className="sr-only">
+              Prime yield, markedsleie og kontorledighet per by, {LATEST_QUARTER}
+            </caption>
+            <thead>
+              <tr>
+                <th>By</th>
+                <th className="r">Prime yield (kontor)</th>
+                <th className="r">Markedsleie kontor</th>
+                <th className="r">Kontorledighet</th>
+              </tr>
+            </thead>
+            <tbody>
+              {CITIES.map((c) => (
+                <tr key={c.id}>
+                  <td>{c.name}</td>
+                  <td className="r">{c.yield}</td>
+                  <td className="r">{c.leie}</td>
+                  <td className="r">{c.vac}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+
+          <div className="mi-footnote" style={{ marginTop: 24 }}>
+            <span className="source">
+              Tall er indikative og reflekterer prime kvalitet.
+            </span>
+            <span>Kilde: Advanti Estate · {LATEST_QUARTER}</span>
+          </div>
+        </div>
+      </section>
+
+      {/* 02 — SLIK SITERER DU */}
+      <section
+        className="section"
+        style={{
+          background: "var(--accent-faint)",
+          borderTop: "var(--hairline)",
+          borderBottom: "var(--hairline)",
+        }}
+      >
+        <div className="wrap">
+          <div className="head-compact">
+            <span className="eyebrow">02 — Bruk av tallene</span>
+            <div>
+              <h2>
+                Slik <span className="italic">siterer du.</span>
+              </h2>
+              <p>
+                Tallene kan gjengis fritt i redaksjonell sammenheng. Vi ber kun
+                om kildehenvisning til «Advanti Estate» med lenke til
+                advantiestate.no. Trenger du tall for en spesifikk by, segment
+                eller periode — eller et sitat på sak — ta kontakt, så leverer vi
+                raskt.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* 03 — SITAT */}
+      <section className="section">
+        <div className="wrap">
+          <div className="head-compact">
+            <span className="eyebrow">03 — Sitat fra senior partner</span>
+            <div>
+              <h2>
+                Til <span className="italic">fri gjengivelse.</span>
+              </h2>
+            </div>
+          </div>
+          <blockquote className="press-quote">
+            «Nord-Norge går inn i 2026 med rekordlav ledighet — Tromsø nede på
+            3,4 % — og et yield-gap mot storbyene som gjør landsdelen attraktiv
+            for investorer. Med forventede rentekutt tror vi på moderat
+            yield-kompresjon og økt transaksjonsvolum gjennom året.»
+            <span className="by">
+              Christer Hagen
+              <span>Partner / Næringsmegler MNEF · Advanti Estate</span>
+            </span>
+          </blockquote>
+        </div>
+      </section>
+
+      {/* 04 — PRESSEKONTAKT */}
+      <section className="section section-divider" id="kontakt">
+        <div className="wrap">
+          <div className="head-compact">
+            <span className="eyebrow">04 — Pressekontakt</span>
+            <div>
+              <h2>
+                For kommentar <span className="italic">og intervju.</span>
+              </h2>
+              <p>
+                Vi stiller gjerne til kommentar om næringseiendomsmarkedet i
+                Nord-Norge, og leverer tall eller en full datapakke på
+                forespørsel.
+              </p>
+            </div>
+          </div>
+          <div className="press-contact">
+            <div>
+              <div className="label">Kontakt</div>
+              Christer Hagen
+              <br />
+              Partner / Næringsmegler MNEF
+            </div>
+            <div>
+              <div className="label">Telefon</div>
+              <a href={`tel:${phone.replace(/\s/g, "")}`}>{phone}</a>
+            </div>
+            <div>
+              <div className="label">E-post</div>
+              <a href={`mailto:${email}`}>{email}</a>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <CtaStrip
+        eyebrow="Trenger du tall eller et sitat?"
+        title={
+          <>
+            Vi svarer <span className="italic">raskt.</span>
+          </>
+        }
+        sub="Send en henvendelse, så får du tall, kommentar eller en full datapakke tilpasset saken din."
+        primary={{ label: "Ta kontakt", href: "/kontakt" }}
+        secondary={{ label: "Se markedsinnsikt", href: "/markedsinnsikt" }}
+      />
+    </>
+  )
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -41,6 +41,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     "/markedsinnsikt",
     "/markedsinnsikt/kart",
     "/markedsrapport",
+    "/presserom",
     "/karriere",
     "/kontakt",
     "/help",

--- a/src/components/site/Footer.tsx
+++ b/src/components/site/Footer.tsx
@@ -14,6 +14,7 @@ const ADVANTI = [
   { href: "/kunder", label: "Utvalgte oppdrag" },
   { href: "/markedsinnsikt", label: "Markedsinnsikt" },
   { href: "/blog", label: "Artikler" },
+  { href: "/presserom", label: "Presserom" },
   { href: "/karriere", label: "Karriere" },
   { href: "/kontakt", label: "Kontakt" },
 ];

--- a/src/styles/advanti-design.css
+++ b/src/styles/advanti-design.css
@@ -3233,6 +3233,55 @@ h1, h2, h3 {
   border-top: var(--hairline);
 }
 
+/* PRESSEROM — quote + contact (inner page, reuses tokens) */
+.press-quote {
+  max-width: 900px;
+  margin: 8px 0 0;
+  font-family: var(--font-display);
+  font-size: clamp(22px, 3vw, 34px);
+  font-weight: 400;
+  line-height: 1.3;
+  letter-spacing: -0.015em;
+  color: var(--warm-grey);
+  text-wrap: balance;
+}
+.press-quote .by {
+  display: block;
+  margin-top: 28px;
+  font-family: var(--font-body);
+  font-size: 14px;
+  font-weight: 500;
+  letter-spacing: 0;
+  color: var(--warm-grey);
+}
+.press-quote .by span {
+  display: block;
+  font-weight: 400;
+  color: var(--warm-grey-85);
+}
+.press-contact {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 48px;
+  margin-top: 8px;
+  font-size: 15px;
+  line-height: 1.6;
+  color: var(--warm-grey);
+}
+.press-contact .label {
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--warm-grey-85);
+  margin-bottom: 8px;
+}
+.press-contact a {
+  border-bottom: 1px solid var(--warm-grey-75);
+}
+.press-contact a:hover {
+  color: var(--warm-grey);
+}
+
 /* Feedback widget */
 .ks-feedback {
   margin: 64px 0 0;


### PR DESCRIPTION
Ny `/presserom` — et presserom journalister kan sitere og lenke til, som støtter den lokale lenkebyggingen.

- Siterbare markedstall (KPI-strip + per-by-tabell fra `marketData.ts`, DRY)
- «Slik siterer du»-note med kildehenvisning + lenke (selve lenke-mekanismen)
- Sitat fra senior partner + pressekontakt
- Bygget 100% fra designsystemet (SubHero/mi-kpis/mi-table/CtaStrip, kun var()-tokens, italic-span-overskrifter). Lenket fra footer + sitemap.

Build rent — 124 → 125 sider.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Press Room page featuring market figures, contact information, and data citation guidelines for media use.
  * Added Press Room link to site footer navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->