### PR TITLE
feat(help): SEO-løft for kunnskapssenteret — 15 nye artikler, schema-infrastruktur og avkannibalisering (planer 009–012)

### DIFF
--- a/content-collections.ts
+++ b/content-collections.ts
@@ -222,6 +222,9 @@ export const HelpPost = defineCollection({
         ]),
       )
       .default(["overview"]),
+    // Optional original publish date. When absent, the article page falls
+    // back to updatedAt for schema.org datePublished.
+    publishedAt: z.string().optional(),
     related: z.array(z.string()).optional(),
     excludeHeadingsFromSearch: z.boolean().optional(),
     // Opt-in HowTo schema. Only set on genuine step-by-step procedural
@@ -232,6 +235,13 @@ export const HelpPost = defineCollection({
     howto: z.boolean().optional(),
     step: z
       .array(z.object({ name: z.string(), text: z.string() }))
+      .min(2)
+      .optional(),
+    // Opt-in FAQ. Same policy as `howto`/`step` above: the emitted FAQPage
+    // JSON-LD MUST mirror a visible FAQ section on the page, so the article
+    // page renders this exact array as visible content AND as schema.
+    faq: z
+      .array(z.object({ question: z.string(), answer: z.string() }))
       .min(2)
       .optional(),
     slug: z.string().optional(),

--- a/src/app/(help)/help/article/[slug]/page.tsx
+++ b/src/app/(help)/help/article/[slug]/page.tsx
@@ -150,10 +150,12 @@ export default async function HelpArticle({
         data={{
           title: data.title,
           summary: data.summary,
-          publishedAt: data.updatedAt,
+          publishedAt: data.publishedAt ?? data.updatedAt,
           updatedAt: data.updatedAt,
           author: data.author,
           url: `/help/article/${data.slug}`,
+          timeRequired: readingTime ?? undefined,
+          articleSection: category.title,
         }}
       />
       {data.howto && data.step && data.step.length >= 2 && (
@@ -165,6 +167,9 @@ export default async function HelpArticle({
             step: data.step,
           }}
         />
+      )}
+      {data.faq && data.faq.length >= 2 && (
+        <StructuredData type="faq" data={{ faqs: data.faq }} />
       )}
 
       <div className="page-pad" />
@@ -227,6 +232,18 @@ export default async function HelpArticle({
               )}
 
               <MDX code={data.mdx} images={images} />
+
+              {data.faq && data.faq.length >= 2 && (
+                <div className="ks-faq">
+                  <h2 id="ofte-stilte-sporsmal">Ofte stilte spørsmål</h2>
+                  {data.faq.map((item) => (
+                    <div className="ks-faq-item" key={item.question}>
+                      <h3>{item.question}</h3>
+                      <p>{item.answer}</p>
+                    </div>
+                  ))}
+                </div>
+              )}
 
               {/* Feedback */}
               <div className="ks-feedback">

--- a/src/app/(help)/help/category/[slug]/page.tsx
+++ b/src/app/(help)/help/category/[slug]/page.tsx
@@ -60,6 +60,10 @@ export async function generateMetadata({
 
   const { title, description } = category
 
+  const hasArticles = allHelpPosts.some((post) =>
+    (post.categories as string[]).includes(slug),
+  )
+
   return constructMetadata({
     path: `/help/category/${slug}`,
     title: `${title} – Advanti Hjelpesenter`,
@@ -67,6 +71,7 @@ export async function generateMetadata({
     image: `/api/og/help?title=${encodeURIComponent(
       title,
     )}&summary=${encodeURIComponent(description)}`,
+    noIndex: !hasArticles,
   })
 }
 

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -71,7 +71,13 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   }));
 
   // Help category pages — `lastModified` omitted (no true modified date).
-  const helpCategories = HELP_CATEGORIES.map((category) => ({
+  // Categories with zero articles are excluded until they have content —
+  // they render an empty state and would be thin pages in the index.
+  const helpCategories = HELP_CATEGORIES.filter((category) =>
+    allHelpPosts.some((post) =>
+      (post.categories as string[]).includes(category.slug),
+    ),
+  ).map((category) => ({
     url: `${baseUrl}/help/category/${category.slug}`,
     changeFrequency: "weekly" as const,
     priority: 0.7,

--- a/src/content/blog/dcf-analyse-naringseiendom.mdx
+++ b/src/content/blog/dcf-analyse-naringseiendom.mdx
@@ -12,9 +12,9 @@ related:
 slug: dcf-analyse-naringseiendom
 ---
 
-DCF-analyse (diskontert kontantstrøm) er en av de mest nøyaktige metodene for verdivurdering av næringseiendom. Den beregner nåverdien av fremtidige kontantstrømmer og gir deg et objektivt grunnlag for investeringsbeslutninger.
+DCF-analyse, eller [diskontert kontantstrøm](/help/article/diskontert-kontantstrom), er en av de mest nøyaktige metodene for verdivurdering av næringseiendom. Den beregner nåverdien av fremtidige kontantstrømmer og gir deg et objektivt grunnlag for investeringsbeslutninger.
 
-Denne guiden forklarer hvordan du utfører DCF-analyse steg for steg, med eksempler og praktiske tips.
+Denne guiden viser deg steg for steg hvordan du gjennomfører en DCF-beregning i praksis — med eksempler og konkrete tall.
 
 <Figure n="Fig. 01" caption="Næringsbygg med stabil leieinntekt egner seg godt for DCF-analyse, der nåverdien av fremtidige kontantstrømmer avgjør verdsettelsen.">
   <Image src="/building/pexels-glass-panels-10156132.jpg" alt="Fasade på moderne næringsbygg med glasspaneler" width={1200} height={675} />

--- a/src/content/blog/sensitivitetsanalyse-naringseiendom.mdx
+++ b/src/content/blog/sensitivitetsanalyse-naringseiendom.mdx
@@ -1,7 +1,7 @@
 ---
-title: "Sensitivitetsanalyse: Hvorfor Det Er Kritisk for Eiendomsinvesteringer"
+title: "Slik stressetester du en eiendomsinvestering med sensitivitetsanalyse"
 publishedAt: 2025-11-05
-summary: Lær hvordan sensitivitetsanalyse hjelper deg forstå risiko og usikkerhet i eiendomsinvesteringer. Praktisk guide med eksempler og tips.
+summary: "Hva skjer med verdien hvis yield stiger eller leien faller? Slik bruker du sensitivitetsanalyse til å stressteste en eiendomsinvestering før du kjøper."
 image: /building/pexels-high-rises-low-10156174.jpg
 author: codehagen
 categories:
@@ -26,17 +26,7 @@ En verdivurdering gir deg et tall, men forteller ikke hele historien. Sensitivit
 
 ## Hva er sensitivitetsanalyse?
 
-Sensitivitetsanalyse tester hvordan endringer i antagelsene påvirker resultatet av en verdivurdering eller investeringsanalyse. Den viser deg hvilke faktorer som har størst innvirkning på verdien og hvor sårbar investeringen er for endringer.
-
-<Summary
-  title="Formål med en sensitivitetsanalyse"
-  points={[
-    { title: "Identifisere verdidrivere", description: "Avdekk hvilke faktorer som har størst innvirkning på verdien." },
-    { title: "Forstå risiko og usikkerhet", description: "Se hvor sårbar investeringen er for endringer i antagelsene." },
-    { title: "Teste ulike scenarioer", description: "Sammenlign best case, base case og worst case." },
-    { title: "Ta informerte beslutninger", description: "Bygg beslutningen på et spenn av mulige utfall, ikke ett enkelt tall." },
-  ]}
-/>
+[Sensitivitetsanalyse](/help/article/sensitivitetsanalyse) tester, kort sagt, hva som skjer med eiendomsverdien når enkeltforutsetninger endrer seg — yield, leie, driftskostnader eller terminalverdi. Metodebeskrivelsen finner du i kunnskapssenteret; her fokuserer vi på det praktiske: hvilke variabler du bør stressteste, og hva svarene faktisk betyr for kjøpsbeslutningen.
 
 ## Hvorfor er det kritisk?
 

--- a/src/content/help/aksjekjop-vs-innmatskjop.mdx
+++ b/src/content/help/aksjekjop-vs-innmatskjop.mdx
@@ -42,7 +42,7 @@ Ingen hjemmelsoverføring skjer ved aksjekjøp — eiendommen skifte ikke juridi
 
 ### Innmatskjøp (asset deal)
 
-Ved et innmatskjøp kjøper du selve eiendommen ut av selskapet. Hjemmelen overføres til kjøper eller kjøpers selskap, noe som utløser **dokumentavgift på 2,5 prosent av hjemmelsverdien** (tinglysningsvederlaget).
+Ved et innmatskjøp kjøper du selve eiendommen ut av selskapet. Hjemmelen overføres til kjøper eller kjøpers selskap, noe som utløser **dokumentavgift på 2,5 prosent av eiendommens markedsverdi** ved tinglysing av hjemmelsovergangen.
 
 <Note variant="info">
   Dokumentavgiften på 2,5 prosent er en offentlig avgift til staten og er fastsatt ved lov. For en eiendom med hjemmelsverdi på 100 millioner kroner utgjør dette 2,5 millioner kroner i avgift. Dokumentavgiften er en av de viktigste strukturelle årsakene til at aksjesalg dominerer i profesjonell næringseiendom.
@@ -50,7 +50,7 @@ Ved et innmatskjøp kjøper du selve eiendommen ut av selskapet. Hjemmelen overf
 
 **Hva kjøper oppnår ved innmatkjøp:**
 - Ren skattemessig posisjon — avskrivningsgrunnlaget settes til kjøpesummen (skattemessig trappesteg)
-- Ingen overtagelse av selskapets historikk, gjeld eller latente skattforpliktelser
+- Ingen overtagelse av selskapets historikk, gjeld eller latente skatteforpliktelser
 - Frihet til å organisere eierskap i eget selskap fra dag én
 
 ## Hvorfor aksjesalg dominerer

--- a/src/content/help/aksjekjop-vs-innmatskjop.mdx
+++ b/src/content/help/aksjekjop-vs-innmatskjop.mdx
@@ -1,0 +1,143 @@
+---
+title: "Aksjekjøp eller innmatskjøp?"
+publishedAt: 2026-06-12
+updatedAt: 2026-06-12
+summary: "De fleste norske eiendomstransaksjoner er aksjesalg, ikke innmatkjøp. Her er de to strukturene, dokumentavgiften som avgjør mye, og hva som avtales i praksis."
+author: codehagen
+categories:
+  - for-investors
+related:
+  - kjope-naringseiendom
+  - due-diligence-naringseiendom
+  - skatt-avskrivninger-naringseiendom
+slug: aksjekjop-vs-innmatskjop
+faq:
+  - question: "Hva er forskjellen på aksjekjøp og innmatskjøp?"
+    answer: "Ved aksjekjøp kjøper du aksjene i selskapet som eier eiendommen — du overtar selskapet med alle dets rettigheter, forpliktelser og skattemessige posisjoner. Ved innmatskjøp kjøper du selve eiendommen ut av selskapet — du får en ny, ren skattemessig posisjon men må betale dokumentavgift på 2,5 prosent av hjemmelsverdien."
+  - question: "Hvorfor er aksjesalg dominerende i norsk næringseiendom?"
+    answer: "Det viktigste strukturelle poenget er dokumentavgiften på 2,5 prosent av kjøpesummen ved overføring av hjemmel til fast eiendom. For en eiendom til 100 millioner kroner utgjør dette 2,5 millioner kroner — en kostnad som unngås ved aksjesalg der ingen hjemmelsoverføring skjer. I tillegg kan selger oppnå skattefritak under fritaksmetoden ved aksjesalg."
+  - question: "Hva er latent skatt og hvordan påvirker det prisen?"
+    answer: "Latent skatt er den fremtidige skatteforpliktelsen som hviler på merverdier i et selskap — typisk differansen mellom eiendommens markedsverdi og den skattemessige bokførte verdien (saldoverdien). Kjøper overtar denne forpliktelsen ved et aksjesalg og vil normalt kreve et prisavslag (latent skatteoffset) for å kompensere for skatteforpliktelsen de overtar. Beregningen av korrekt offset er et sentralt forhandlingspunkt."
+---
+
+<Note variant="warning">
+  Denne artikkelen er generell informasjon om transaksjonsstrukturer i næringseiendom — ikke skatterådgivning eller juridisk rådgivning. Valg av transaksjonsstruktur har vesentlige skattemessige og juridiske konsekvenser. Involver alltid kvalifisert advokat og skatterådgiver i konkrete transaksjoner.
+</Note>
+
+De fleste transaksjoner over et visst volum i det norske næringseiendomsmarkedet gjennomføres som aksjesalg — ikke som direktekjøp av eiendommen. Årsaken er primært dokumentavgiften, men også skattemessige hensyn på selgersiden. Å forstå de to strukturene og hva som faktisk forhandles, er grunnleggende kompetanse for enhver eiendomsinvestor.
+
+## De to strukturene
+
+### Aksjekjøp (share deal)
+
+Ved et aksjekjøp kjøper du aksjene i selskapet som eier eiendommen — typisk et aksjeselskap (AS) eller et kommandittselskap (KS). Du overtar selskapet som det er, med alle dets rettigheter, forpliktelser, historikk og skattemessige posisjoner.
+
+**Hva du overtar:**
+- Eiendommen, som forblir i selskapet uendret
+- Alle eksisterende leiekontrakter — ingen endring for leietakerne
+- Selskapets historiske skattemessige posisjoner, herunder avskrivningsgrunnlag og eventuell latent skatt
+- Selskapets eventuelle gjeld og andre forpliktelser
+
+Ingen hjemmelsoverføring skjer ved aksjekjøp — eiendommen skifte ikke juridisk eier, selskapet gjør det. Dette er den direkte årsaken til at dokumentavgiften unngås.
+
+### Innmatskjøp (asset deal)
+
+Ved et innmatskjøp kjøper du selve eiendommen ut av selskapet. Hjemmelen overføres til kjøper eller kjøpers selskap, noe som utløser **dokumentavgift på 2,5 prosent av hjemmelsverdien** (tinglysningsvederlaget).
+
+<Note variant="info">
+  Dokumentavgiften på 2,5 prosent er en offentlig avgift til staten og er fastsatt ved lov. For en eiendom med hjemmelsverdi på 100 millioner kroner utgjør dette 2,5 millioner kroner i avgift. Dokumentavgiften er en av de viktigste strukturelle årsakene til at aksjesalg dominerer i profesjonell næringseiendom.
+</Note>
+
+**Hva kjøper oppnår ved innmatkjøp:**
+- Ren skattemessig posisjon — avskrivningsgrunnlaget settes til kjøpesummen (skattemessig trappesteg)
+- Ingen overtagelse av selskapets historikk, gjeld eller latente skattforpliktelser
+- Frihet til å organisere eierskap i eget selskap fra dag én
+
+## Hvorfor aksjesalg dominerer
+
+Tre faktorer forklarer aksjesalgets dominans i det norske markedet:
+
+**Dokumentavgiften.** 2,5 prosent av kjøpesummen er en betydelig kostnadspost som begge parter har interesse av å unngå. Ingen av partene sparer noe på å la kjøper betale dokumentavgiften — det er ren sløsing sett fra et samlet transaksjonsperspektiv.
+
+**Fritaksmetoden for selger.** Et aksjeselskap som selger aksjer i et annet aksjeselskap kan — avhengig av eierstruktur og andre betingelser — benytte fritaksmetoden og dermed unngå beskatning av gevinsten. Denne skattefordelen for selger er en sterk driver for at eiendommer holdes i egne aksjeselskaper og selges som aksjer.
+
+**Kontinuitet for leietakere.** Ved aksjesalg endres ingenting for leietakerne — de har fortsatt kontrakt med det samme selskapet. Ved innmatkjøp må leiekontrakter i prinsippet reforhandles eller formelt overdras.
+
+## Skattemessige hovedforskjeller
+
+### Avskrivningsgrunnlag
+
+Ved innmatkjøp settes avskrivningsgrunnlaget til kjøpesummen. Kjøper kan dermed avskrive fra en høy verdi, noe som gir bedre skattemessige avskrivninger fremover. Dette kalles et «skattemessig trappesteg» (step-up).
+
+Ved aksjekjøp beholder eiendommen sine eksisterende skattemessige verdier. Kjøper overtar saldoverdiene slik de er i selskapet — typisk lavere enn markedsverdi etter mange år med avskrivninger. Fremtidige avskrivninger beregnes på den lavere saldoverdien, noe som gir lavere skattemessig fradrag enn ved et innmatkjøp. Les mer om avskrivningssystemet i artikkelen om [skatt og avskrivninger på næringseiendom](/help/article/skatt-avskrivninger-naringseiendom).
+
+### Latent skatt
+
+I et selskap som har eid en eiendom lenge, er det normalt en vesentlig merverdi mellom eiendommens markedsverdi og dens skattemessige bokverdi. Denne merverdien representerer en latent skatteforpliktelse: dersom eiendommen selges som innmat, realiseres gevinsten og det betales selskapsskatt av den.
+
+Når kjøper overtar aksjer, overtar kjøper også denne latente skatteforpliktelsen. Kjøper vet at en fremtidig realisering — enten ved salg av eiendommen eller ved oppløsning av selskapet — vil utløse skatt. For å kompensere for dette krever kjøper typisk et prisavslag, et «latent skatteoffset». Beregningen av korrekt offset er en av de mest tekniske forhandlingspunktene i en transaksjon og involverer skatterådgivere fra begge parter.
+
+## Hva som avtales i praksis
+
+I aksjetransaksjoner forhandles følgende nøkkelvilkår:
+
+**Kjøpesum og mekanisme.** Prisen fastsettes gjerne som en enterprise value (verdi av selskapet inkludert gjeld) minus netto gjeld, eller som en egenkapitalverdi justert for arbeidskapital. Eventuelle justeringer avtales.
+
+**Latent skatteoffset.** Partene forhandler om størrelse og beregningsmåte for fradraget som kompenserer for latent skatt. Valg av diskonteringsrente og forventet holdeperiode er sentrale forutsetninger.
+
+**Representasjoner og garantier.** Selger gir garantier om at leiekontrakter er gyldige, at det ikke er vesentlige mangler ved eiendommen, at selskapet ikke har ukjent gjeld, og at skattemessige posisjoner er korrekt presentert.
+
+**W&I-forsikring.** I større transaksjoner tegner partene gjerne en forsikring (Warranty & Indemnity insurance) som dekker brudd på selgers garantier. Dette gir kjøper trygghet og reduserer selgers eksponering etter transaksjonslukking.
+
+**Skattemessig frihet.** Dersom selger benytter fritaksmetoden, avtales det gjerne at kjøper ikke kan gjøre tiltak som trigger en skattemessig realisering i en viss periode etter overtakelse.
+
+## Innmatkjøp — når kan det gi mening?
+
+Til tross for dokumentavgiften kan innmatkjøp være aktuelt i noen situasjoner:
+
+- Selskapet som eier eiendommen har uønsket historikk (kjente tvister, ukjente forpliktelser) som kjøper ikke ønsker å overta
+- Kjøper har stor nytte av det skattemessige trappesteget og prisjusteringen for merverdi er liten
+- Eiendommen er i et selskap som ikke vil selge aksjer av strukturelle årsaker
+
+I slike tilfeller kan partene forhandle om hvem som bærer dokumentavgiften, og kompensere for dette i prisen.
+
+<Summary
+  title="Nøkkelpunkter om transaksjonsstruktur"
+  points={[
+    {
+      title: "Aksjesalg er normen",
+      description: "Dokumentavgiften på 2,5 prosent og fritaksmetoden for selger gjør aksjesalg til klart foretrukket struktur i profesjonell næringseiendom.",
+      iconName: "barChart"
+    },
+    {
+      title: "Latent skatt er et forhandlingspunkt",
+      description: "Kjøper overtar latent skatteforpliktelse ved aksjesalg og krever normalt et prisavslag (offset). Beregningen er teknisk og krever skatterådgiver.",
+      iconName: "scales"
+    },
+    {
+      title: "Avskrivninger er bedre ved innmatkjøp",
+      description: "Innmatkjøp gir skattemessig trappesteg og høyere avskrivningsgrunnlag, men koster dokumentavgift. En helhetlig skattemessig analyse avgjør hva som lønner seg.",
+      iconName: "lineChart"
+    },
+    {
+      title: "Bruk spesialiserte rådgivere",
+      description: "Transaksjonsstruktur har vesentlige skattemessige konsekvenser. Involver advokat og skatterådgiver med erfaring fra næringseiendomstransaksjoner.",
+      iconName: "lightbulb"
+    }
+  ]}
+/>
+
+<CTA
+  badge="Strukturer klokt"
+  title="Advanti bistår i hele transaksjonsprosessen"
+  description="Fra verdivurdering og rådgivning om transaksjonsstruktur til koordinering av rådgivere — Advanti er med deg gjennom hele prosessen."
+  primaryAction={{
+    label: "Ta kontakt",
+    href: "/kontakt"
+  }}
+  secondaryAction={{
+    label: "Les om kjøpsprosessen",
+    href: "/help/article/kjope-naringseiendom"
+  }}
+  size="default"
+/>

--- a/src/content/help/arealbegreper-bta-bra.mdx
+++ b/src/content/help/arealbegreper-bta-bra.mdx
@@ -1,0 +1,120 @@
+---
+title: "Arealbegreper: BTA, BRA og utleibart areal"
+publishedAt: 2026-06-12
+updatedAt: 2026-06-12
+summary: "BTA, BRA og utleibart areal er tre ulike måter å telle kvadratmeter på — og de gir ulike tall for samme bygg. Lær forskjellene, fellesarealpåslaget og hvorfor arealbegrepet er avgjørende for leieanalysen."
+author: codehagen
+categories:
+  - terms
+related:
+  - markedsleie-og-leieniva
+  - felleskostnader
+slug: arealbegreper-bta-bra
+faq:
+  - question: "Hva er forskjellen mellom BTA og BRA?"
+    answer: "BTA (bruttoareal) er byggets totale areal målt til ytterveggenes utside og inkluderer alle konstruksjoner, sjakter og bygningsdeler. BRA (bruksareal) er det arealet som faktisk kan brukes — målt innenfor omsluttende vegger. BRA er alltid lavere enn BTA fordi yttervegger og konstruksjoner ikke telles med."
+  - question: "Hva er utleibart areal og fellesarealpåslag?"
+    answer: "Utleibart areal (eksklusivt) er det arealet leietaker disponerer alene. Fellesarealpåslag (load factor) er et prosentvis tillegg for leietakers andel av fellesarealene — korridor, toaletter, tekniske rom osv. Effektivt utleibart areal inkluderer fellesarealpåslaget og er grunnlaget for leieberegningen."
+  - question: "Hvorfor kan samme bygg ha ulike kvm-priser?"
+    answer: "Fordi ulike arealbegreper gir ulike arealstørrelser. En leie oppgitt per kvm BRA gir et høyere kvm-tall enn den samme leien oppgitt per kvm BTA. Sammenligninger på tvers av eiendommer er meningsløse uten å vite hvilket arealbegrep som er brukt — og to tilsynelatende like kvm-priser kan gjelde svært ulikt bruksareal."
+---
+
+## Hva er arealbegreper?
+
+[Arealbegreper](/help/article/arealbegreper-bta-bra) i næringseiendom beskriver ulike måter å måle og oppgi kvadratmeter på. Samme bygg kan ha svært ulike arealtall avhengig av hvilket begrep man bruker — og det betyr at leie per kvm er meningsløst uten å vite hvilket arealbegrep som ligger til grunn.
+
+De tre viktigste begrepene i norsk næringseiendom er **BTA** (bruttoareal), **BRA** (bruksareal) og **utleibart areal**. Alle er definert i Norsk Standard (NS 3940).
+
+## BTA: bruttoareal
+
+BTA er byggets totale areal, målt til ytterveggenes utside. BTA inkluderer:
+
+- Alle etasjer, inkludert kjeller og loft
+- Bærevegger, søyler og sjakter
+- Yttervegger i full tykkelse
+
+BTA er det «største» arealtallet og brukes gjerne i reguleringsplaner, byggekostnadskalkyler og sammenligning av bygningers totale størrelse. I utleiesammenheng er BTA sjelden det relevante grunnlaget for leieberegning.
+
+## BRA: bruksareal
+
+BRA er arealet innenfor de omsluttende veggene — det vil si innsiden av yttervegger og mellom bærevegger. BRA er lavere enn BTA fordi ytterveggers tykkelse og konstruksjoner ikke inngår.
+
+I næringsleie brukes BRA typisk som grunnlag for leieavtalen — det er arealet inne i bruksenheten, eksklusive yttervegger og bærekonstruksjoner mot andre enheter.
+
+## Utleibart areal og fellesarealpåslag
+
+**Utleibart areal** kan defineres eksklusivt (det arealet leietaker alene disponerer) eller inklusivt fellesareal.
+
+**Fellesarealpåslaget** — også kalt «load factor» på engelsk — er et prosentvis tillegg for leietakers andel av byggets fellesarealer: korridor, resepsjon, toaletter, trappeoppganger og tekniske rom. Leietaker disponerer ikke disse arealene alene, men bidrar til kostnader og leie for dem.
+
+<Math
+  formula="\text{Leieareal inkl. fellesareal} = \text{Eksklusivt areal} \times (1 + \text{Fellesarealpåslag})"
+  description="Et fellesarealpåslag på 10 % betyr at leietaker betaler for 10 % mer areal enn det de disponerer eksklusivt"
+/>
+
+Et generisk eksempel: leietaker har 500 kvm eksklusivt kontorareal, og fellesarealpåslaget i bygget er 10 %. Da betaler leietaker for 550 kvm. Dersom leien er avtalt per kvm inkludert fellesareal, gir dette en høyere nominell kvm-pris enn om leien var oppgitt eksklusivt.
+
+## Hvorfor arealbegrepet er avgjørende for leieanalysen
+
+Å sammenligne [leienivåer](/help/article/markedsleie-og-leieniva) på tvers av eiendommer uten å vite arealbegrepet er meningsløst. To eiendommer med tilsynelatende lik «leie per kvm» kan ha svært ulik faktisk kostnad for leietaker og ulik inntekt for utleier dersom:
+
+- Den ene oppgir BTA og den andre BRA
+- Fellesarealpåslaget er inkludert i den ene men ikke den andre
+- En eiendom har høyt fellesarealpåslag og den andre lavt
+
+<Note variant="info">
+  I profesjonell næringseiendom angis leien normalt per kvm BRA inklusive leietakers andel av fellesarealer. Men dette er ikke universelt — ved sammenligning av eiendommer bør man alltid avklare arealbegrepet eksplisitt.
+</Note>
+
+## Vanlige tvister
+
+Arealbegreper er en hyppig kilde til tvister i næringsleieforhold. De vanligste situasjonene er:
+
+**Uenighet om arealoppgave.** Leietaker baserte leienivå og budsjett på oppgitt areal; ettermåling viser avvik. Dersom leieavtalen er knyttet til kvm-pris og faktisk areal avviker vesentlig, kan det gi grunnlag for justering.
+
+**Endringer i fellesarealene.** Dersom utleier gjør om arealer fra fellesbruk til eksklusivt (eller omvendt), endres fellesarealpåslaget og dermed leietakers effektive kostnad.
+
+<Note variant="info">
+  I forbindelse med leieforhandlinger og ved kjøp av næringseiendom bør areal alltid verifiseres mot tegninger og eventuelt ved ettermåling. Arealet som er oppgitt i prospektet er ikke nødvendigvis riktig.
+</Note>
+
+<Summary
+  title="Nøkkelpunkter om arealbegreper"
+  points={[
+    {
+      title: "Tre begreper — tre tall",
+      description: "BTA, BRA og utleibart areal gir ulike arealstørrelser for samme bygg. Alltid avklar hvilket begrep som brukes.",
+      iconName: "barChart"
+    },
+    {
+      title: "Fellesarealpåslaget",
+      description: "Leietaker betaler for sin andel av fellesarealene gjennom et prosentvis påslag. Høyt påslag betyr høyere effektiv leiekostnad.",
+      iconName: "scales"
+    },
+    {
+      title: "Kvm-pris uten arealbegrep er meningsløs",
+      description: "Sammenligning av leienivåer på tvers av eiendommer krever at man vet nøyaktig hvilket arealbegrep som er lagt til grunn.",
+      iconName: "lineChart"
+    },
+    {
+      title: "Verifiser alltid arealet",
+      description: "Arealtall i prospekter kan avvike fra faktisk areal. Viktige transaksjoner og lange kontrakter bør underbygges med ettermåling.",
+      iconName: "lightbulb"
+    }
+  ]}
+/>
+
+<CTA
+  badge="Forstå arealet"
+  title="Analyser leiebildet med korrekt arealgrunnlag i Advanti"
+  description="Advanti hjelper deg å strukturere leieanalyser med riktig arealbegrep, slik at sammenligninger og verdivurderinger er korrekte."
+  primaryAction={{
+    label: "Prøv Advanti",
+    href: "/kontakt"
+  }}
+  secondaryAction={{
+    label: "Se alle funksjoner",
+    href: "/tjenester"
+  }}
+  size="default"
+/>

--- a/src/content/help/arealbegreper-bta-bra.mdx
+++ b/src/content/help/arealbegreper-bta-bra.mdx
@@ -2,7 +2,7 @@
 title: "Arealbegreper: BTA, BRA og utleibart areal"
 publishedAt: 2026-06-12
 updatedAt: 2026-06-12
-summary: "BTA, BRA og utleibart areal er tre ulike måter å telle kvadratmeter på — og de gir ulike tall for samme bygg. Lær forskjellene, fellesarealpåslaget og hvorfor arealbegrepet er avgjørende for leieanalysen."
+summary: "BTA, BRA og utleibart areal er tre måter å telle kvadratmeter på — og gir ulike tall for samme bygg. Lær forskjellene og hvorfor arealbegrepet er avgjørende."
 author: codehagen
 categories:
   - terms

--- a/src/content/help/brutto-leieinntekter.mdx
+++ b/src/content/help/brutto-leieinntekter.mdx
@@ -74,7 +74,7 @@ Analysen av brutto leieinntekter er tilsynelatende rett fram, men det er noen ty
 
 **Å ta med merverdiavgift** gir et for høyt tall. Mva er ikke eiers inntekt, men en gjennomgangspost til staten. Brutto leieinntekter oppgis alltid eksklusiv mva.
 
-**Å overse leierabatter og insentiver** er en annen feil. Ny-utleie med leiefrie perioder eller bidrag til innredning betyr at den nominelle kontraktsleien er høyere enn det utleier faktisk mottar i en periode. Dette påvirker den effektive nettoinntekten.
+**Å overse leierabatter og insentiver** er en annen feil. Nyutleie med leiefrie perioder eller bidrag til innredning betyr at den nominelle kontraktsleien er høyere enn det utleier faktisk mottar i en periode. Dette påvirker den effektive nettoinntekten.
 
 **Å blande kontraktsleie og felleskostnadsbidrag** uten tydelig skille gjør det vanskelig å analysere hva som er faktisk leieinntekt og hva som er gjennomgangsposter knyttet til kostnadsdeling.
 

--- a/src/content/help/brutto-leieinntekter.mdx
+++ b/src/content/help/brutto-leieinntekter.mdx
@@ -1,0 +1,128 @@
+---
+title: Brutto leieinntekter i næringseiendom
+publishedAt: 2026-06-12
+updatedAt: 2026-06-12
+summary: "Brutto leieinntekter er summen av alle leieinntekter før kostnadsfradrag. Lær hva som inngår, forskjellen fra netto, og hvorfor skillet er avgjørende for yield."
+author: codehagen
+categories:
+  - terms
+related:
+  - netto-leieinntekter
+  - driftskostnader
+  - hva-er-yield
+slug: brutto-leieinntekter
+faq:
+  - question: "Hva er forskjellen mellom brutto og netto leieinntekter?"
+    answer: "Brutto leieinntekter er summen av alle inntekter fra eiendommen før noen kostnader er trukket fra. Netto leieinntekter fremkommer ved å trekke eierkostnadene fra bruttoleien. Det er netto leieinntekter som brukes som grunnlag for yield-beregning og verdivurdering av næringseiendom."
+  - question: "Inngår merverdiavgift i brutto leieinntekter?"
+    answer: "Nei. Brutto leieinntekter oppgis alltid eksklusiv merverdiavgift. Dersom utleier er frivillig registrert i mva-registeret for utleie av næringslokaler, beregnes mva i tillegg til leien, men mva er ikke en inntekt for utleier og holdes utenfor leieinntektene."
+  - question: "Hvorfor er vakans viktig for brutto leieinntekter?"
+    answer: "Ledige arealer genererer ingen leieinntekt, men kostnadene løper likevel. I en verdivurdering justeres brutto leieinntekter for forventet fremtidig vakansgrad, slik at analysen reflekterer et realistisk inntektspotensial snarere enn en midlertidig fullt-utleid-situasjon."
+---
+
+## Hva er brutto leieinntekter?
+
+[Brutto leieinntekter](/help/article/brutto-leieinntekter) er den totale summen av alle leieinntekter en næringseiendom genererer over et år, målt før noen kostnader er trukket fra. Det er startpunktet for all inntektsanalyse og verdivurdering — og skiller seg fra [netto leieinntekter](/help/article/netto-leieinntekter), som viser hva eier faktisk sitter igjen med etter at kostnadene er dekket.
+
+<Math
+  formula="\text{Netto leieinntekter} = \text{Brutto leieinntekter} - \text{Eierkostnader}"
+  description="Overgangen fra brutto til netto: trekk alle eierkostnader fra for å finne det som brukes i yield-beregningen"
+/>
+
+## Hva inngår i brutto leieinntekter?
+
+Brutto leieinntekter er ikke bare den avtalte kontraktsleien. I en fullstendig analyse inngår alle inntekter som er knyttet til eiendommen og leieforholdene.
+
+<Stepper
+  items={[
+    {
+      title: "Kontraktsleie",
+      content: "Den avtalte leien i gjeldende leiekontrakter. Dette er normalt den dominerende inntektsposten. Kontraktsleien kan avvike fra markedsleien dersom kontraktene er inngått i en annen markedssituasjon.",
+    },
+    {
+      title: "Felleskostnadsbidrag",
+      content: "Mange kontrakter inkluderer et separat bidrag til felleskostnader — enten som et fast beløp eller som et à-konto-tilskudd som avregnes mot faktiske kostnader. Dette er en gjennomgangspost, men teller med i bruttoinntektene.",
+    },
+    {
+      title: "Parkering og skiltleie",
+      content: "Inntekter fra parkeringsplasser, skiltvegger og annen utnyttelse av eiendommens areal inngår. Disse postene er ofte beskjedne, men skal inkluderes for et fullstendig bilde.",
+    },
+    {
+      title: "Øvrige inntekter",
+      content: "Antenneplasser, tekniske installasjoner utleid til tredjepart og andre inntekter knyttet til eiendommens bruk skal med i bruttoinntektene.",
+    }
+  ]}
+/>
+
+## Brutto yield versus netto yield
+
+Skillet mellom brutto og netto leieinntekter er direkte avgjørende for hvilken type [yield](/help/article/hva-er-yield) man beregner.
+
+**Brutto yield** bruker brutto leieinntekter som teller. Det gir et tall som ikke reflekterer eierkostnadene, og som derfor alltid vil være høyere enn netto yield for samme eiendom. Brutto yield brukes sjelden i seriøs analyse, men dukker opp i uformelle sammenligninger og markedsføring.
+
+**Netto yield** bruker netto leieinntekter — altså brutto minus eierkostnader. Dette er markedsstandarden for verdivurdering og sammenligning av næringseiendom i Norge.
+
+<Note variant="info">
+  Sammenlign alltid eiendommer på netto yield. Å bruke brutto yield er som å sammenligne omsetning uten å se på kostnader — tallene sier lite om faktisk avkastning.
+</Note>
+
+## Vanlige feil i inntektsanalysen
+
+Analysen av brutto leieinntekter er tilsynelatende rett fram, men det er noen typiske fallgruver.
+
+**Å glemme vakansrisiko** er den hyppigste feilen. Et bygg som er fullt utleid i dag vil ikke nødvendigvis forbli det. En realistisk analyse justerer for forventet ledighet over tid fremfor å fremskrive dagens utleiegrad.
+
+**Å ta med merverdiavgift** gir et for høyt tall. Mva er ikke eiers inntekt, men en gjennomgangspost til staten. Brutto leieinntekter oppgis alltid eksklusiv mva.
+
+**Å overse leierabatter og insentiver** er en annen feil. Ny-utleie med leiefrie perioder eller bidrag til innredning betyr at den nominelle kontraktsleien er høyere enn det utleier faktisk mottar i en periode. Dette påvirker den effektive nettoinntekten.
+
+**Å blande kontraktsleie og felleskostnadsbidrag** uten tydelig skille gjør det vanskelig å analysere hva som er faktisk leieinntekt og hva som er gjennomgangsposter knyttet til kostnadsdeling.
+
+## Sammenheng med driftskostnader og verdivurdering
+
+Brutto leieinntekter er første linje i enhver resultatoppstilling for en næringseiendom. [Driftskostnadene](/help/article/driftskostnader) trekkes fra for å komme til netto leieinntekter, som igjen er inngangsverdien i yield-beregningen og i mer avanserte analyser.
+
+<Note variant="success">
+  God regnskapsmessig disiplin rundt bruttoleieinntektene — klart skille mellom kontraktsleie, felleskostnadsbidrag og øvrige inntekter — gjør det vesentlig enklere å gjennomføre nøyaktige analyser og oppdage endringer i eiendomsøkonomien over tid.
+</Note>
+
+<Summary
+  title="Nøkkelpunkter om brutto leieinntekter"
+  points={[
+    {
+      title: "Startpunktet",
+      description: "Brutto leieinntekter er summen av all inntekt fra eiendommen før kostnader — kontraktsleie, felleskostnadsbidrag, parkering og øvrig arealnyttelse.",
+      iconName: "barChart"
+    },
+    {
+      title: "Ikke det samme som netto",
+      description: "Netto leieinntekter fremkommer etter at eierkostnader er trukket fra. Det er netto-tallene som brukes i yield-beregning og verdivurdering.",
+      iconName: "scales"
+    },
+    {
+      title: "Vakans teller",
+      description: "Ledige arealer genererer ingen inntekt. En realistisk analyse justerer for forventet fremtidig vakansgrad.",
+      iconName: "lineChart"
+    },
+    {
+      title: "Mva er ikke inntekt",
+      description: "Merverdiavgift holdes utenfor. Brutto leieinntekter oppgis alltid eksklusiv mva.",
+      iconName: "lightbulb"
+    }
+  ]}
+/>
+
+<CTA
+  badge="Analyser inntektene"
+  title="Forstå inntektsbildet med Advanti"
+  description="Advanti hjelper deg å strukturere og analysere leieinntekter slik at yield-beregninger og verdivurderinger blir presise."
+  primaryAction={{
+    label: "Prøv Advanti",
+    href: "/kontakt"
+  }}
+  secondaryAction={{
+    label: "Se alle funksjoner",
+    href: "/tjenester"
+  }}
+  size="default"
+/>

--- a/src/content/help/diskontert-kontantstrom.mdx
+++ b/src/content/help/diskontert-kontantstrom.mdx
@@ -253,6 +253,8 @@ For å bedre forstå hvordan ulike faktorer påvirker DCF-analysen, kan du bruke
   ]}
 />
 
+Vil du se disse prinsippene i praksis på en konkret eiendom? Les [steg-for-steg-guiden til DCF-beregning](/blog/dcf-analyse-naringseiendom) for en fullstendig gjennomgang med regnestykker, diskontosatser og terminalverdiberegning.
+
 <CTA
   badge="Prøv nå"
   title="Lag profesjonelle DCF-analyser med Advanti"

--- a/src/content/help/diskontert-kontantstrom.mdx
+++ b/src/content/help/diskontert-kontantstrom.mdx
@@ -1,7 +1,7 @@
 ---
 title: Diskontert kontantstrøm (DCF) i næringseiendom
 updatedAt: 2025-02-18
-summary: En dyptgående guide til diskontert kontantstrøm-analyse (DCF) i næringseiendom - fra grunnleggende prinsipper til avanserte beregninger.
+summary: "DCF-analyse verdsetter næringseiendom ut fra fremtidige kontantstrømmer. Steg for steg: kontantstrøm, diskonteringsrente, terminalverdi og nåverdi."
 author: codehagen
 categories:
   - valuation

--- a/src/content/help/diskontert-kontantstrom.mdx
+++ b/src/content/help/diskontert-kontantstrom.mdx
@@ -253,7 +253,7 @@ For å bedre forstå hvordan ulike faktorer påvirker DCF-analysen, kan du bruke
   ]}
 />
 
-Vil du se disse prinsippene i praksis på en konkret eiendom? Les [steg-for-steg-guiden til DCF-beregning](/blog/dcf-analyse-naringseiendom) for en fullstendig gjennomgang med regnestykker, diskontosatser og terminalverdiberegning.
+Vil du se disse prinsippene i praksis på en konkret eiendom? Les [steg-for-steg-guiden til DCF-beregning](/blog/dcf-analyse-naringseiendom) for en fullstendig gjennomgang med regnestykker, diskonteringsrenter og terminalverdiberegning.
 
 <CTA
   badge="Prøv nå"

--- a/src/content/help/diskontert-kontantstrom.mdx
+++ b/src/content/help/diskontert-kontantstrom.mdx
@@ -10,6 +10,7 @@ related:
   - hva-er-yield
   - netto-leieinntekter
   - driftskostnader
+  - exit-yield
 slug: diskontert-kontantstrom
 # HowTo schema pilot. The `step` array MUST mirror the visible <Stepper>
 # items in the "Steg-for-steg DCF-analyse" section — names and text are

--- a/src/content/help/driftskostnader.mdx
+++ b/src/content/help/driftskostnader.mdx
@@ -1,7 +1,7 @@
 ---
 title: Driftskostnader i næringseiendom
 updatedAt: 2025-02-18
-summary: En omfattende guide til å forstå driftskostnader i næringseiendom - fra faste kostnader til variable utgifter.
+summary: "Driftskostnader avgjør hva du faktisk sitter igjen med. Se hvilke kostnader som inngår, typiske nivåer, og hvordan de påvirker yield og verdi."
 author: codehagen
 categories:
   - terms

--- a/src/content/help/due-diligence-naringseiendom.mdx
+++ b/src/content/help/due-diligence-naringseiendom.mdx
@@ -55,7 +55,7 @@ I prosessen oppretter selger et datarom — en strukturert samling av dokumenter
 
 En teknisk gjennomgang bør som minimum dekke:
 
-- Takkets tilstand og alder — ett av de vanligste kildene til uventede kostnader
+- Takets tilstand og alder — ett av de vanligste kildene til uventede kostnader
 - Ventilasjon og klimaanlegg — dyre å skifte, og direkte leietakerpåvirkende
 - Elektriske anlegg og kapasitet
 - VVS og varmesystem
@@ -65,7 +65,7 @@ En teknisk gjennomgang bør som minimum dekke:
 - Universell utforming og tilgjengelighet
 - Pågående eller planlagte offentlige pålegg
 
-Det tekniske sporrapporten angir restlevetid og estimerte vedlikeholdskostnader. Dette er grunnlaget for å vurdere fremtidige capex-behov og justere eiendommens verdi eller forhandle prisreduksjon.
+Den tekniske sporrapporten angir restlevetid og estimerte vedlikeholdskostnader. Dette er grunnlaget for å vurdere fremtidige capex-behov og justere eiendommens verdi eller forhandle prisreduksjon.
 
 ### Juridisk spor — sentrale sjekkpunkter
 

--- a/src/content/help/due-diligence-naringseiendom.mdx
+++ b/src/content/help/due-diligence-naringseiendom.mdx
@@ -1,0 +1,174 @@
+---
+title: "Due diligence ved kjøp av næringseiendom"
+publishedAt: 2026-06-12
+updatedAt: 2026-06-12
+summary: "Due diligence avdekker hva du faktisk kjøper — teknisk tilstand, juridisk klarhet, finansielt grunnlag og miljøforhold. Her er de fire sporene og røde flagg."
+author: codehagen
+categories:
+  - for-investors
+related:
+  - kjope-naringseiendom
+  - verdivurdering-av-naringseiendom
+  - leiekontrakter-naringseiendom
+slug: due-diligence-naringseiendom
+faq:
+  - question: "Hva er formålet med due diligence?"
+    answer: "Due diligence skal avdekke hva kjøper faktisk kjøper — og om forutsetningene budet er basert på faktisk stemmer. Formålet er ikke å finne grunn til å trekke budet, men å skaffe seg grunnlag for å bekrefte prisen, justere vilkår eller — ved vesentlige avvik — trekke seg ut av prosessen med rimelig grunn."
+  - question: "Hvem gjennomfører due diligence?"
+    answer: "Due diligence gjennomføres av kjøpers egne rådgivere: advokat for juridisk spor, teknisk rådgiver eller takstmann for bygningsteknisk spor, revisor eller finansiell rådgiver for finansielt spor og miljørådgiver for miljøspor. Kjøper koordinerer gjennomgangen og finansierer kostnadene."
+  - question: "Hva skjer hvis due diligence avdekker avvik?"
+    answer: "Funn fra due diligence brukes aktivt i forhandlingen. Avvik kan gi grunnlag for prisreduksjon, krav om at selger utbedrer forholdet før overtakelse, endrede representasjoner og garantier i kjøpekontrakten, eller — ved vesentlige avvik som var ukjente for kjøper — å trekke budet."
+---
+
+Due diligence er den grundige gjennomgangen en kjøper gjennomfører etter at en intensjonsavtale er inngått og eksklusivitet er sikret. Formålet er enkelt: verifiser at forutsetningene budet er basert på faktisk stemmer — og avdekk det du ikke visste du ikke visste.
+
+## Hva er due diligence?
+
+Due diligence er ikke en formalitet. Det er den kritiske fasen der kjøper, gjennom sine rådgivere, gjennomgår all vesentlig dokumentasjon om eiendommen: leiekontrakter, tekniske rapporter, regnskap, skjøter, heftelser, reguleringsplaner og miljødata. Gjennomgangen gjennomføres normalt i løpet av tre til åtte uker.
+
+I prosessen oppretter selger et datarom — en strukturert samling av dokumenter som kjøper og dennes rådgivere får tilgang til. Et godt organisert datarom gjør gjennomgangen raskere og mer pålitelig. Et dårlig organisert datarom er i seg selv et signal.
+
+## De fire sporene
+
+<Stepper
+  items={[
+    {
+      title: "Teknisk due diligence",
+      content: "Teknisk gjennomgang av byggets fysiske tilstand: konstruksjon, tak, fasade, fundament, tekniske anlegg (VVS, elektro, ventilasjon, heis), brannsikring og universell utforming. Formålet er å identifisere eksisterende mangler, kommende investeringsbehov og avvik fra lovkrav.",
+    },
+    {
+      title: "Juridisk due diligence",
+      content: "Juridisk gjennomgang av hjemmel, heftelser, leiekontrakter, servitutter, reguleringsplan, byggetillatelser og pågående tvister. Formålet er å bekrefte at selger har rett til å selge, at eiendommen er fri for ukjente heftelser, og at leiekontraktene er gyldige og bindende.",
+    },
+    {
+      title: "Finansiell due diligence",
+      content: "Gjennomgang av historiske regnskaper, kontantstrøm, leiekravbøker, felleskostnadsoppgjør og budsjetter. Formålet er å verifisere at de faktiske leieinntektene og kostnadene stemmer med selgers presentasjon, og å identifisere avvik som påvirker eiendommens verdi.",
+    },
+    {
+      title: "Miljødue diligence",
+      content: "Vurdering av miljøforhold: tidligere bruk av eiendommen, forurensede masser, asbest, radon, PCB i fuger og maling. Forurensning kan gi kjøper ansvar etter forurensningsloven og innebære store utbedringskostnader.",
+    }
+  ]}
+/>
+
+### Teknisk spor — sentrale sjekkpunkter
+
+En teknisk gjennomgang bør som minimum dekke:
+
+- Takkets tilstand og alder — ett av de vanligste kildene til uventede kostnader
+- Ventilasjon og klimaanlegg — dyre å skifte, og direkte leietakerpåvirkende
+- Elektriske anlegg og kapasitet
+- VVS og varmesystem
+- Heiser — sertifikater, vedlikeholdsavtaler og alder
+- Brannanlegg og rømningsveier
+- Fasade og vinduer — spesielt relevant i norsk klima
+- Universell utforming og tilgjengelighet
+- Pågående eller planlagte offentlige pålegg
+
+Det tekniske sporrapporten angir restlevetid og estimerte vedlikeholdskostnader. Dette er grunnlaget for å vurdere fremtidige capex-behov og justere eiendommens verdi eller forhandle prisreduksjon.
+
+### Juridisk spor — sentrale sjekkpunkter
+
+- Eierforhold og hjemmel — er selger legitimert til å selge?
+- Heftelser og panterettigheter i grunnboken
+- Leiekontrakter — gyldighet, varighet, oppsigelsesvilkår, reguleringsklausuler, opsjoner, fremleieretter
+- Servitutter og naboavtaler
+- Reguleringsplan og utnyttelsesgrad
+- Byggetillatelser og ferdigattest
+- Pågående tvister eller klager
+- MVA-status — frivillig registrering og eventuelle justeringsforpliktelser
+
+[Leiekontrakter](/help/article/leiekontrakter-naringseiendom) er det juridiske sporets viktigste element. Kontrakten er inntektsgrunnlaget — og den kan inneholde klausuler som vesentlig endrer bildet: fremleieretter som gjør leietakerporteføljen uoversiktlig, opsjoner som binder eier til lave leienivåer i lang tid, eller oppsigelsesretter som selger ikke har opplyst om.
+
+### Finansielt spor — sentrale sjekkpunkter
+
+- Historisk leiekravbok — stemmer faktisk innbetalt leie med presentert leiebase?
+- Ledighetsutvikling og leieregulering siste tre til fem år
+- Felleskostnadsoppgjør — er kostnadene viderebelastet leietaker korrekt?
+- Eierkostnader — er de faktiske eierkostnadene i samsvar med presenterte tall?
+- Budsjetter og planlagte investeringer
+- Forsikringsdekning og historisk skadeshistorikk
+
+En [verdivurdering av næringseiendom](/help/article/verdivurdering-av-naringseiendom) er alltid basert på en leiebase. Det finansielle sporet verifiserer at leiebasen faktisk er korrekt — og avdekker om det er skjulte kostnader eller inntekter som ikke fremgår av selgers presentasjon.
+
+### Miljøspor — sentrale sjekkpunkter
+
+- Historisk bruk av eiendommen — spesielt relevant for industrieiendommer og tomter med ukjent historikk
+- Forurenset grunn — prøvetaking og analyse av masser
+- Asbest — særlig i bygninger fra perioden 1930–1980
+- Radon — spesielt relevant i kjeller og lavere etasjer
+- PCB i fuger og lysarmaturer
+- EL-tilkoblinger og trafostasjoner med miljøproblematikk
+
+<Note variant="warning">
+  Forurensning og miljøforhold kan gi kjøper opprydningsplikt etter forurensningsloven — uavhengig av hvem som forårsaket forurensningen. Miljøhistorikk bør alltid gjennomgås av kvalifisert rådgiver.
+</Note>
+
+## Røde flagg
+
+Noen funn i due diligence bør alltid tas på alvor som vesentlige røde flagg:
+
+**Manglende ferdigattest.** Bygg uten ferdigattest kan ha ulovlige byggearbeider og manglende godkjenning fra kommunen. Dette kan gi pålegg om utbedring eller riving.
+
+**Leiekontrakter med ukjente opsjoner eller fremleieretter.** Selger som ikke har opplyst om opsjoner som binder eier til lave leienivåer i lang tid, er et alvorlig avvik.
+
+**Vesentlig differanse mellom presentert og faktisk leiebase.** Dersom selgers presentasjon viser høyere leieinntekter enn det som faktisk er innbetalt, er dette et tegn på enten feil eller bevisst villeding.
+
+**Forurensede masser uten opprydningsplan.** Ukjent miljøforpliktelse som kjøper overtar er et av de vanskeligste scenariene — kostnadene kan overstige eiendomsverdien.
+
+**Pågående tvister.** En uavklart tvist om leie, eierforhold eller naboforhold kan hemme salg, refinansiering og drift i lang tid.
+
+**Manglende dokumentasjon i datarom.** Selger som ikke kan fremlegge dokumentasjon — leiekontrakter, byggetillatelser, servicerapporter — har enten dårlig orden eller noe å skjule.
+
+## Hvordan funn brukes i prisforhandling
+
+Due diligence er ikke bare en sjekkliste — det er forhandlingsverktøy. Funn kategoriseres normalt etter alvorlighetsgrad og håndteres på ulike måter:
+
+**Prisjustering.** Identifiserte vedlikeholdsetterslep, kommende capex-behov eller leiebase som er lavere enn antatt, kan gi grunnlag for å forhandle ned prisen.
+
+**Selgergarantier.** Kjøper kan kreve spesifikke garantier i kjøpekontrakten for forhold avdekket i due diligence — for eksempel at leiekontraktene er gyldige og uten kjente mislighold.
+
+**Utbedring før overtakelse.** For konkrete tekniske avvik kan kjøper kreve at selger utbedrer forholdet, eller at det settes av tilstrekkelig beløp på en sperret konto.
+
+**Rett til å trekke budet.** Dersom det avdekkes vesentlige avvik som var ukjent for kjøper og som endrer investeringsbeslutningen, gir intensjonsavtalen normalt rett til å trekke seg uten ansvar.
+
+<Summary
+  title="Nøkkelpunkter om due diligence"
+  points={[
+    {
+      title: "Fire spor — alle nødvendige",
+      description: "Teknisk, juridisk, finansiell og miljømessig gjennomgang dekker komplementære risikoer. Svakheter i ett spor kan ikke kompenseres av styrke i et annet.",
+      iconName: "barChart"
+    },
+    {
+      title: "Leiekontrakter er kjernen",
+      description: "Leiekontraktene er inntektsgrunnlaget. Juridisk gjennomgang av kontraktsporteføljen er det viktigste enkeltspørsmålet i due diligence.",
+      iconName: "scales"
+    },
+    {
+      title: "Funn er forhandlingsverktøy",
+      description: "Avvik fra forutsetningene gir grunnlag for prisreduksjon, garanti eller krav om utbedring — ikke nødvendigvis for å trekke seg.",
+      iconName: "lineChart"
+    },
+    {
+      title: "Miljø kan overraske",
+      description: "Forurensning og miljøhistorikk er den risikokomponenten som oftest undervurderes — og som kan ha de største konsekvensene.",
+      iconName: "lightbulb"
+    }
+  ]}
+/>
+
+<CTA
+  badge="Trygg transaksjon"
+  title="Advanti hjelper deg gjennom kjøpsprosessen"
+  description="Fra innledende analyse og verdivurdering til koordinering av due diligence og forhandling — Advanti bistår kjøpere i Nord-Norge."
+  primaryAction={{
+    label: "Ta kontakt",
+    href: "/kontakt"
+  }}
+  secondaryAction={{
+    label: "Les om kjøpsprosessen",
+    href: "/help/article/kjope-naringseiendom"
+  }}
+  size="default"
+/>

--- a/src/content/help/eierkostnader.mdx
+++ b/src/content/help/eierkostnader.mdx
@@ -1,0 +1,127 @@
+---
+title: Eierkostnader i næringseiendom
+publishedAt: 2026-06-12
+updatedAt: 2026-06-12
+summary: "Eierkostnader er kostnadene utleier bærer selv — utover det leietaker dekker. Se hvilke poster som inngår og hvordan de påvirker netto yield og eiendomsverdi."
+author: codehagen
+categories:
+  - terms
+related:
+  - driftskostnader
+  - felleskostnader
+  - netto-leieinntekter
+slug: eierkostnader
+faq:
+  - question: "Hva er eierkostnader i næringseiendom?"
+    answer: "Eierkostnader er de kostnadene som utleier bærer ved å eie en næringseiendom — typisk forsikring, eiendomsskatt, utvendig vedlikehold, forvaltningskostnader og eiers andel av felleskostnader ved eventuell ledighet. Disse trekkes fra brutto leieinntekter for å finne netto leieinntekter."
+  - question: "Hva er forskjellen mellom eierkostnader og driftskostnader?"
+    answer: "Driftskostnader er en samlebetegnelse for alle kostnader ved å eie og drive eiendommen. Eierkostnader er den delen av driftskostnadene som utleier selv bærer — i motsetning til felleskostnader som viderebelastes leietakerne. I praksis brukes begrepene ofte om hverandre, men skillet er viktig for å forstå hvem som bærer hvilken risiko."
+  - question: "Hvem betaler felleskostnadene ved tomme arealer?"
+    answer: "Når arealer står ledige, faller felleskostnadsbidraget fra den aktuelle leietakeren bort. Eier må da dekke felleskostnadsandelen for de tomme arealene selv. Dette er en vesentlig risikofaktor ved høy vakansgrad og bør inkluderes i eierkostnadene i enhver realistisk inntektsanalyse."
+---
+
+## Hva er eierkostnader?
+
+[Eierkostnader](/help/article/eierkostnader) er kostnadene utleier bærer ved å eie en næringseiendom — de kostnadene som ikke viderebelastes leietakerne. For å beregne [netto leieinntekter](/help/article/netto-leieinntekter) trekkes eierkostnadene fra brutto leieinntekter. Det er netto leieinntekter som legges til grunn for yield-beregning og verdivurdering.
+
+<Math
+  formula="\text{Netto leieinntekter} = \text{Brutto leieinntekter} - \text{Eierkostnader}"
+  description="Eierkostnadene er det som skiller brutto fra netto — og dermed det som avgjør hva eier faktisk tjener"
+/>
+
+## Grensen mot felleskostnader
+
+Det er viktig å skille mellom eierkostnader og [felleskostnader](/help/article/felleskostnader). Felleskostnader er utgifter til drift av fellesarealer som viderebelastes leietakerne — typisk strøm, renhold og vedlikehold av trappeoppganger, heiser og tekniske installasjoner. Disse er i utgangspunktet gjennomgangsposter for eier: leietakerne betaler, og eier viderefører.
+
+Eierkostnader er det eier bærer selv, uavhengig av hva som viderebelastes:
+
+- Eier betaler felleskostnadsandelen for **ledige arealer**. Når en leietaker faller fra, stopper betalingen — men kostnadene fortsetter. Eier bærer da kostnaden for de tomme kvadratmeterne.
+- Kostnader som leiekontrakten legger på eier, ikke leietaker — for eksempel utvendig vedlikehold der kontrakten er strukturert som «brutto-leie».
+
+## Typiske poster i eierkostnadene
+
+<Stepper
+  items={[
+    {
+      title: "Forsikring",
+      content: "Bygningsforsikring og ansvarsforsikring er eiers ansvar og inngår i eierkostnadene. Leietaker tegner normalt egne ansvarsforsikringer for sin virksomhet.",
+    },
+    {
+      title: "Eiendomsskatt",
+      content: "Der kommunen har innført eiendomsskatt på næringseiendom, er dette en kostnad som påhviler eier. Skatten beregnes på grunnlag av eiendomsskattverdi fastsatt av kommunen.",
+    },
+    {
+      title: "Utvendig vedlikehold",
+      content: "Vedlikehold av fasade, tak, bærende konstruksjoner og utomhusarealer er i de fleste kontrakter eiers ansvar. Dette er gjerne en av de største og mest uforutsigbare postene.",
+    },
+    {
+      title: "Forvaltning og administrasjon",
+      content: "Kostnader til eiendomsforvalter, regnskapsfører og teknisk forvaltning som ikke dekkes gjennom felleskostnadsregnskapet.",
+    },
+    {
+      title: "Eierandel av felleskostnader ved ledighet",
+      content: "Eier bærer felleskostnadsbidraget for tomme arealer. Jo høyere vakansgrad, desto større andel av felleskostnadene faller på eier.",
+    }
+  ]}
+/>
+
+## Eierkostnadenes rolle i netto yield
+
+[Yield](/help/article/hva-er-yield) beregnes av netto leieinntekter. Høye eierkostnader reduserer netto leieinntekter direkte og trekker dermed ned eiendomsverdien, gitt uendret yield-krav fra markedet.
+
+Omvendt: å redusere eierkostnadene — for eksempel gjennom bedre forsikringsavtaler, mer effektiv forvaltning eller forebyggende vedlikehold — øker netto leieinntekter krone for krone, og den positive effekten på verdien multipliseres med yield-faktoren.
+
+<Note variant="info">
+  En tommelfingerregel er at eierkostnader som andel av brutto leieinntekter varierer med eiendomstype, byggets alder og kontraktsstruktur. Eldre bygg har typisk høyere vedlikeholdskostnader; kontrakter med «bare house»-prinsipp (netto-leie) legger mer over på leietaker. Det finnes ingen universell prosent — estimer alltid konkret.
+</Note>
+
+## Forholdet til kontraktsstrukturen
+
+Kontraktsstrukturen avgjør hvem som faktisk bærer hvilke kostnader. I en **nettoleieavtale** betaler leietaker de fleste løpende driftskostnadene selv, og eiers eierkostnader er dermed lave. I en **bruttoleieavtale** dekker eier mer, og eierkostnadene er tilsvarende høyere.
+
+Denne forskjellen er avgjørende for tolkning av leieinntektene: to eiendommer med samme nominelle leie kan ha svært ulik netto yield dersom kontraktsstrukturene er ulike. En analyse som ikke tar hensyn til hvem som bærer hvilke kostnader, kan gi kraftig feilpriset eiendom.
+
+<Note variant="success">
+  I verdivurdering av næringseiendom er det god praksis å spesifisere eierkostnadene post for post fremfor å bruke en sjablongandel av bruttoleien. Konkrete tall gir bedre beslutningsgrunnlag enn tommelfingerregler.
+</Note>
+
+<Summary
+  title="Nøkkelpunkter om eierkostnader"
+  points={[
+    {
+      title: "Eiers andel av kostnadene",
+      description: "Eierkostnader er det eier bærer selv — forsikring, eiendomsskatt, utvendig vedlikehold, forvaltning og felleskostnader for ledige arealer.",
+      iconName: "barChart"
+    },
+    {
+      title: "Skillet mot felleskostnader",
+      description: "Felleskostnader viderefaktureres leietakerne. Eierkostnader er det eier bærer direkte, inkludert andelen for tomme arealer.",
+      iconName: "scales"
+    },
+    {
+      title: "Direkte effekt på yield",
+      description: "Høye eierkostnader reduserer netto leieinntekter og dermed eiendomsverdien — gitt uendret yield-krav fra markedet.",
+      iconName: "lineChart"
+    },
+    {
+      title: "Avhengig av kontraktsstruktur",
+      description: "Netto- og bruttoleieavtaler fordeler kostnadene ulikt. Kontraktsstrukturen er avgjørende for hva som faktisk inngår i eierkostnadene.",
+      iconName: "lightbulb"
+    }
+  ]}
+/>
+
+<CTA
+  badge="Få oversikt"
+  title="Analyser eierkostnadene med Advanti"
+  description="Advanti hjelper deg å kartlegge og optimalisere eierkostnadene slik at netto yield og verdivurdering blir presis."
+  primaryAction={{
+    label: "Prøv Advanti",
+    href: "/kontakt"
+  }}
+  secondaryAction={{
+    label: "Se alle funksjoner",
+    href: "/tjenester"
+  }}
+  size="default"
+/>

--- a/src/content/help/exit-yield.mdx
+++ b/src/content/help/exit-yield.mdx
@@ -23,7 +23,7 @@ faq:
 
 ## Hva er exit yield?
 
-[Exit yield](/help/article/exit-yield) er det avkastningskravet man forventer at markedet vil legge til grunn for å prise eiendommen på et fremtidig salgstidspunkt — typisk ved slutten av en [DCF-analyse](/help/article/diskontert-kontantstrom). Exit yield brukes til å beregne **terminalverdien**: det estimerte provenyets fra et hypotetisk salg etter analyseperiodens siste år.
+[Exit yield](/help/article/exit-yield) er det avkastningskravet man forventer at markedet vil legge til grunn for å prise eiendommen på et fremtidig salgstidspunkt — typisk ved slutten av en [DCF-analyse](/help/article/diskontert-kontantstrom). Exit yield brukes til å beregne **terminalverdien**: det estimerte provenyet fra et hypotetisk salg etter analyseperiodens siste år.
 
 Begrepet er uløselig knyttet til DCF-metodikken og er en av de mest verdipåvirkende forutsetningene i enhver kontantstrømsbasert verdivurdering.
 

--- a/src/content/help/exit-yield.mdx
+++ b/src/content/help/exit-yield.mdx
@@ -1,0 +1,115 @@
+---
+title: Exit yield og terminalverdi
+publishedAt: 2026-06-12
+updatedAt: 2026-06-12
+summary: "Exit yield er avkastningskravet som brukes til å beregne eiendommens terminalverdi i en DCF-analyse. Lær hva det er, hvorfor det settes høyere enn dagens yield, og hva det betyr for verdivurderingen."
+author: codehagen
+categories:
+  - terms
+  - valuation
+related:
+  - diskontert-kontantstrom
+  - hva-er-yield
+  - sensitivitetsanalyse
+slug: exit-yield
+faq:
+  - question: "Hva er exit yield?"
+    answer: "Exit yield er det avkastningskravet man forutsetter at markedet vil bruke for å prise eiendommen ved slutten av analyseperioden i en DCF-modell. Det brukes til å beregne terminalverdien — estimert salgsverdi — på slutten av DCF-horisonten."
+  - question: "Hvorfor settes exit yield ofte høyere enn dagens yield?"
+    answer: "Exit yield settes gjerne høyere enn dagens inngangs-yield for å reflektere at eiendommen vil ha eldet, at leiekontrakter vil ha kortere gjenværende tid, og at fremtiden er usikker. Det er et forsiktighetsprinsipp som hindrer at en modell systematisk overvurderer langsiktig terminalverdi."
+  - question: "Hvilken del av verdien representerer terminalverdien?"
+    answer: "I en typisk 10-års DCF-analyse for næringseiendom vil terminalverdien utgjøre en svært betydelig andel av total nåverdi — ofte mer enn halvparten. Det gjør valget av exit yield til en av de mest verdipåvirkende forutsetningene i hele analysen."
+---
+
+## Hva er exit yield?
+
+[Exit yield](/help/article/exit-yield) er det avkastningskravet man forventer at markedet vil legge til grunn for å prise eiendommen på et fremtidig salgstidspunkt — typisk ved slutten av en [DCF-analyse](/help/article/diskontert-kontantstrom). Exit yield brukes til å beregne **terminalverdien**: det estimerte provenyets fra et hypotetisk salg etter analyseperiodens siste år.
+
+Begrepet er uløselig knyttet til DCF-metodikken og er en av de mest verdipåvirkende forutsetningene i enhver kontantstrømsbasert verdivurdering.
+
+## Terminalverdien i DCF-modellen
+
+I en [DCF-analyse](/help/article/diskontert-kontantstrom) modelleres kontantstrømmene år for år gjennom en analyseperiode — vanligvis fem til ti år. På slutten av perioden trenger man et estimat på hva eiendommen kan selges for. Det er terminalverdien.
+
+Terminalverdien beregnes ved å dele netto driftsinntekt (NOI) for det første året etter analyseperioden på exit yield:
+
+<Math
+  formula="\text{Terminalverdi} = \frac{\text{NOI}_{n+1}}{\text{Exit yield}}"
+  description="NOI n+1 er netto driftsinntekt i det første året etter analyseperioden; exit yield er det forventede avkastningskravet ved salg"
+/>
+
+Terminalverdien neddiskonteres deretter tilbake til analysetidspunktet med diskonteringsrenten, og legges til summen av de diskonterte årlige kontantstrømmene for å finne total nåverdi.
+
+## Exit yield versus dagens yield
+
+Et naturlig spørsmål er om man ikke bare kan bruke dagens [yield](/help/article/hva-er-yield) som exit yield. Svaret er at det kan man teknisk sett gjøre, men det er ofte for optimistisk — og det er to viktige grunner til det.
+
+**Eiendommen eldes.** Etter en analyseperiode på for eksempel ti år vil bygget ha eldet teknisk og funksjonelt. Vedlikeholdsbehov øker, og standarden relativt til nyere bygg i markedet svekkes. Markedet vil typisk kreve høyere avkastning for å kompensere for økt risiko.
+
+**Leiekontrakter har kortere gjenværende tid.** Verdien av sikre, langsiktige kontrakter — som kanskje var en av verdigrunnlagene ved kjøpet — er redusert ved re-salg fordi kontraktene nå er nærmere forfall.
+
+<Note variant="info">
+  En vanlig tilnærming er å sette exit yield noe høyere enn inngangs-yield — for eksempel ett kvart til ett halvt prosentpoeng — for å reflektere usikkerhet og aldring. Men det finnes ingen fast regel; valget må begrunnes konkret ut fra eiendomstype, beliggenhet og kontraktsstruktur.
+</Note>
+
+## Sensitiviteten for exit yield
+
+Fordi terminalverdien typisk utgjør en svært betydelig andel av total nåverdi i en DCF-modell, er verdivurderingen særlig følsom for valget av exit yield. En liten endring i exit yield kan gi store utslag på konklusjonen.
+
+Dette er årsaken til at [sensitivitetsanalyse](/help/article/sensitivitetsanalyse) er uunnværlig i enhver seriøs DCF-modell: man bør alltid beregne hvordan nåverdien endres dersom exit yield settes høyere eller lavere enn basisantagelsen.
+
+Et typisk sensitivitetsdisplay viser nåverdi for ulike kombinasjoner av diskonteringsrente og exit yield i en matrise — slik at leseren ser hvilke forutsetninger som er kritiske og hvilke scenarier som er rimelige.
+
+## Praktisk anvendelse
+
+Valg av exit yield krever vurdering av:
+
+1. **Eiendomstype og segment** — Noen segmenter er mer konjunkturfølsomme enn andre, noe som taler for konservative exit-antagelser.
+2. **Leietakerkvalitet og gjenværende kontraktstid** — Jo kortere gjenværende kontraktstid ved exit-tidspunktet, desto høyere risiko og typisk høyere exit yield.
+3. **Bygg- og beliggenhetskvalitet** — Sentral beliggenhet og høy teknisk standard gir grunnlag for lavere exit yield enn periferi og vedlikeholdskrevende bygg.
+4. **Markedsutvikling** — Forventninger om renteutviklingen og generell markedsprisingstrend er sentrale innspill.
+
+<Note variant="success">
+  Dokumenter alltid begrunnelsen for valg av exit yield. En ubegrunnet exit yield er en svakhet som gjør verdivurderingen vanskelig å etterprøve og kritisere konstruktivt.
+</Note>
+
+<Summary
+  title="Nøkkelpunkter om exit yield og terminalverdi"
+  points={[
+    {
+      title: "Hva det er",
+      description: "Exit yield er det forventede avkastningskravet ved et fremtidig salg, og brukes til å beregne terminalverdien i en DCF-analyse.",
+      iconName: "barChart"
+    },
+    {
+      title: "Typisk satt høyere",
+      description: "Exit yield settes gjerne høyere enn inngangs-yield for å reflektere aldring, kortere kontrakter og fremtidig usikkerhet.",
+      iconName: "scales"
+    },
+    {
+      title: "Stor verdipåvirkning",
+      description: "Terminalverdien utgjør en svært stor andel av total nåverdi. Valg av exit yield er en av de mest verdipåvirkende forutsetningene i analysen.",
+      iconName: "lineChart"
+    },
+    {
+      title: "Alltid sensitivitetstest",
+      description: "Fordi exit yield er så verdisensitiv, bør sensitivitetsanalyse alltid vise verdien under ulike exit yield-scenarier.",
+      iconName: "lightbulb"
+    }
+  ]}
+/>
+
+<CTA
+  badge="Verdsett riktig"
+  title="Bygg presise DCF-modeller med Advanti"
+  description="Advanti gir deg verktøy for DCF-analyse med sensitivitetstesting på exit yield, diskonteringsrente og leievekst."
+  primaryAction={{
+    label: "Prøv Advanti",
+    href: "/kontakt"
+  }}
+  secondaryAction={{
+    label: "Se alle funksjoner",
+    href: "/tjenester"
+  }}
+  size="default"
+/>

--- a/src/content/help/exit-yield.mdx
+++ b/src/content/help/exit-yield.mdx
@@ -2,7 +2,7 @@
 title: Exit yield og terminalverdi
 publishedAt: 2026-06-12
 updatedAt: 2026-06-12
-summary: "Exit yield er avkastningskravet som brukes til å beregne eiendommens terminalverdi i en DCF-analyse. Lær hva det er, hvorfor det settes høyere enn dagens yield, og hva det betyr for verdivurderingen."
+summary: "Exit yield er avkastningskravet for terminalverdien i DCF. Lær hva det er, hvorfor det settes høyere enn inngangs-yield, og hva det betyr for verdivurderingen."
 author: codehagen
 categories:
   - terms

--- a/src/content/help/felleskostnader.mdx
+++ b/src/content/help/felleskostnader.mdx
@@ -1,7 +1,7 @@
 ---
 title: Felleskostnader i næringseiendom
 updatedAt: 2025-02-20
-summary: En detaljert guide om felleskostnader i næringseiendom - fra kostnadstyper og fordeling til optimalisering og energieffektivisering.
+summary: "Felleskostnader fordeles mellom leietakerne og påvirker totalprisen på leieforholdet. Slik beregnes, fordeles og optimaliseres de i næringsbygg."
 author: codehagen
 categories:
   - getting-started

--- a/src/content/help/finansiering-av-naringseiendom.mdx
+++ b/src/content/help/finansiering-av-naringseiendom.mdx
@@ -33,7 +33,7 @@ Det sentrale begrepet er **LTV — Loan-to-Value**, som angir lånet som andel a
   description="LTV angir lånebelastningen som prosent av eiendomsverdi"
 />
 
-En eiendom verdsatt til 100 millioner kroner med et lån på 65 millioner har en LTV på 65 prosent — og kjøper må dermed stille 35 millioner i egenkapital (pluss transaksjonskostnader). Bankens krav til maksimal LTV varierer med eiendomstype, beliggenhet, leietakerkvalitet og markedskonjunktur. Stabilt beliggende eiendommer med lange kontrakter og solide leietakere gir normalt bedre lånebetingelser enn kortidsscontrakterte eiendommer i tynnere markeder.
+En eiendom verdsatt til 100 millioner kroner med et lån på 65 millioner har en LTV på 65 prosent — og kjøper må dermed stille 35 millioner i egenkapital (pluss transaksjonskostnader). Bankens krav til maksimal LTV varierer med eiendomstype, beliggenhet, leietakerkvalitet og markedskonjunktur. Stabilt beliggende eiendommer med lange kontrakter og solide leietakere gir normalt bedre lånebetingelser enn korttidskontrakterte eiendommer i tynnere markeder.
 
 <Note variant="info">
   LTV er ikke den eneste risikovariabelen banken måler. Kontantstrømsdekning — evnen til å betjene renter og avdrag fra leieinntektene — er minst like viktig i bankens kredittvurdering.

--- a/src/content/help/finansiering-av-naringseiendom.mdx
+++ b/src/content/help/finansiering-av-naringseiendom.mdx
@@ -2,7 +2,7 @@
 title: "Finansiering av næringseiendom"
 publishedAt: 2026-06-12
 updatedAt: 2026-06-12
-summary: "Bankfinansiering, LTV, rentebinding og gearing — lær hva banken vurderer, hvordan finansieringsstrukturen påvirker avkastning og risiko, og hvilke alternativer som finnes."
+summary: "LTV, rentebinding og gearing — hva banken krever, strukturens effekt på avkastning og risiko, og alternative finansieringskilder ved kjøp av næringseiendom."
 author: codehagen
 categories:
   - for-investors

--- a/src/content/help/finansiering-av-naringseiendom.mdx
+++ b/src/content/help/finansiering-av-naringseiendom.mdx
@@ -1,0 +1,141 @@
+---
+title: "Finansiering av næringseiendom"
+publishedAt: 2026-06-12
+updatedAt: 2026-06-12
+summary: "Bankfinansiering, LTV, rentebinding og gearing — lær hva banken vurderer, hvordan finansieringsstrukturen påvirker avkastning og risiko, og hvilke alternativer som finnes."
+author: codehagen
+categories:
+  - for-investors
+related:
+  - kjope-naringseiendom
+  - hva-er-yield
+  - kontantstromsanalyse
+slug: finansiering-av-naringseiendom
+faq:
+  - question: "Hva er LTV og hva er et typisk krav fra bank?"
+    answer: "LTV (Loan-to-Value) er lånet som andel av eiendommens verdi. Banker i det norske næringseiendomsmarkedet stiller vanligvis krav til maksimal LTV — nivået varierer med eiendomstype, beliggenhet, leietakerkvalitet og markedsforhold. Jo lavere LTV, desto lavere finansieringsrisiko for begge parter."
+  - question: "Hva er WAULT og hvorfor er det viktig for banken?"
+    answer: "WAULT (Weighted Average Unexpired Lease Term) er den vektede gjennomsnittlige gjenværende kontraktstiden i en eiendomsportefølje. Lang WAULT betyr at leieinntektene er sikret over en lengre periode, noe som reduserer re-utleierisiko. Banker vektlegger WAULT tungt i sin kredittvurdering og en kort WAULT kan begrense belåningsgrad eller øke marginen."
+  - question: "Hva er forskjellen på rentebinding og flytende rente ved næringseiendomslån?"
+    answer: "Med flytende rente følger lånerenten markedsrentene løpende og gir laveste rente dersom rentene faller, men eksponerer deg for økte kostnader dersom rentene stiger. Rentebinding — fast rente over en avtalt periode — gir forutsigbar finansieringskostnad og beskytter mot renteoppgang, men innebærer at du ikke drar nytte av rentefall i bindingsperioden."
+---
+
+Finansiering er en forutsetning for de fleste kjøp av næringseiendom. Forståelse av bankens krav, finansieringsstrukturens effekt på avkastning og tilgjengelige alternativer er grunnleggende kompetanse for enhver investor i næringseiendom.
+
+## Bankfinansiering og LTV-begrepet
+
+Det dominerende finansieringsinstrumentet for næringseiendom er banklån med eiendommen som sikkerhet. Lånet gis mot pant i eiendommen, og bankens risikovurdering avgjør hvor mye du kan låne.
+
+Det sentrale begrepet er **LTV — Loan-to-Value**, som angir lånet som andel av eiendommens verdi:
+
+<Math
+  formula="\text{LTV} = \frac{\text{Lån}}{\text{Eiendomsverdi}} \times 100"
+  description="LTV angir lånebelastningen som prosent av eiendomsverdi"
+/>
+
+En eiendom verdsatt til 100 millioner kroner med et lån på 65 millioner har en LTV på 65 prosent — og kjøper må dermed stille 35 millioner i egenkapital (pluss transaksjonskostnader). Bankens krav til maksimal LTV varierer med eiendomstype, beliggenhet, leietakerkvalitet og markedskonjunktur. Stabilt beliggende eiendommer med lange kontrakter og solide leietakere gir normalt bedre lånebetingelser enn kortidsscontrakterte eiendommer i tynnere markeder.
+
+<Note variant="info">
+  LTV er ikke den eneste risikovariabelen banken måler. Kontantstrømsdekning — evnen til å betjene renter og avdrag fra leieinntektene — er minst like viktig i bankens kredittvurdering.
+</Note>
+
+## Rentebinding versus flytende rente
+
+Valget mellom rentebinding og flytende rente er en av de viktigste finansieringsstrategiske beslutningene. Det finnes ikke ett riktig svar — valget avhenger av din risikoprofil, finansieringshorisont og syn på renteutviklingen.
+
+**Flytende rente** følger markedsrentene løpende (typisk knyttet til NIBOR eller en bankrente). Flytende rente gir lavere kostnad i perioder med lave eller fallende renter, men eksponerer kontantstrømmen for renteoppgang. For eiendomsinvestorer med stramme kontantstrømsmargin kan en renteøkning raskt gi negativt resultat etter finansiering.
+
+**Rentebinding** — fast rente over en avtalt periode — gir forutsigbar finansieringskostnad i hele bindingsperioden. Det gjør budsjettering enklere og beskytter mot renteoppgang, men innebærer at du ikke drar nytte av rentefall. Rentebinding er vanligst for lengre eiendomsposisjoner der forutsigbarhet i kontantstrøm er høyt prioritert.
+
+Mange investorer kombinerer de to: en del av lånet bindes for å redusere renteeksponering, mens resten holdes flytende for fleksibilitet.
+
+## Bankens krav: hva vurderes?
+
+### Kontantstrømsdekning
+
+Banken analyserer eiendommens evne til å betjene lånet fra leieinntektene. Nøkkelbegrepet er **kontantstrømsdekning** — forholdet mellom netto leieinntekt og finansieringskostnad (renter og avdrag). Høy dekning gir trygghet for banken; lav dekning er et rødt flagg.
+
+En [kontantstrømsanalyse](/help/article/kontantstromsanalyse) er et nyttig verktøy for å modellere finansieringsdekning under ulike rentescenarier — og for å identifisere hvor stramt finansieringsrommet faktisk er.
+
+### Leietakerkvalitet
+
+Banken vurderer hvem leietakerne er. En statlig eller kommunal leietaker på lang kontrakt gir bedre sikkerhet enn mange små private leietakere på korte kontrakter. Leietakers kredittverdighet, bransje og historikk er del av bankens risikovurdering.
+
+### WAULT — vektet gjenværende kontraktstid
+
+**WAULT** (Weighted Average Unexpired Lease Term) er den vektede gjennomsnittlige gjenværende leieperioden for eiendommens samlede leiekontrakter, vektet mot leieinntektenes andel av totalleien. Lang WAULT betyr at inntektene er sikret over tid og re-utleierisikoen er lav. Banker bruker WAULT aktivt for å vurdere kontantstrømmens stabilitet og priser lånebetingelsene deretter.
+
+En eiendom med WAULT på ni år og én stor statlig leietaker fremstår som vesentlig tryggere enn en tilsvarende eiendom der alle kontrakter utløper om to til tre år.
+
+### Teknisk stand og beliggenhet
+
+Bankens verdivurdering av eiendommen — som danner grunnlaget for LTV-beregningen — vektlegger teknisk stand, beliggenhet og likviditet i annenhåndsmarkedet. En eiendom i et tynt marked med lav alternativ bruk kan verdsettes konservativt og dermed gi lavere belåningsgrad enn en tilsvarende eiendom i et likvid marked.
+
+## Gearing: effekten på avkastning og risiko
+
+Finansiering med lån — gearing — er et dobbeltegget virkemiddel. Det forsterker avkastning på egenkapitalen, men det forsterker også risikoen.
+
+Tenk deg en eiendom med netto yield på fem prosent og en finansieringskostnad (rente etter skatt) som er lavere enn det. I det scenariet bidrar lånet til å løfte egenkapitalavkastningen over yielden. Men dersom renten stiger over yielden — eller dersom leieinntektene faller — snur gearingen og egenkapitalavkastningen blir lavere, eller negativ.
+
+<Note variant="warning">
+  Gearing er ikke gratis. I perioder med svak kontantstrøm eller økte renter kan høy belåning true evnen til å betjene lånet og i ytterste konsekvens tvinge et tvangssalg til dårlige priser. Tilpass belåningsgraden til din risikotoleranse og kontantstrømmens robusthet.
+</Note>
+
+Høy gearing passer best for investorer med lang horisont, sterk kontantstrøm og evne til å tåle midlertidig negativ utvikling. Lav gearing gir lavere egenkapitalavkastning, men vesentlig lavere risiko.
+
+## Alternative finansieringskilder
+
+Banklån er den vanligste finansieringsformen, men ikke den eneste.
+
+**Obligasjonsmarkedet** er tilgjengelig for større eiendomsselskaper. Obligasjoner utstedes typisk i det norske eller nordiske kapitalmarkedet og er et alternativ til — eller supplement for — bankfinansiering. Obligasjonsmarkedet kan gi bedre betingelser i perioder med sterk investorappetitt på eiendom.
+
+**Selgerkreditt** er en ordning der selger lar kjøper betale deler av kjøpesummen over tid — i praksis en form for finansiering fra selger til kjøper. Selgerkreditt brukes typisk for å tette et hull mellom hva banken finansierer og hva kjøper har tilgjengelig. Det er en forhandlingssak og koster normalt en rente.
+
+**Syndikat og medinvestorer** er vanlig i større transaksjoner der én investor ikke har tilstrekkelig egenkapital alene. Et syndikat samler flere investorer som deler egenkapitalinnskuddet og risikoen — og gir dermed tilgang til større eiendommer enn det ville vært mulig individuelt.
+
+## Refinansiering og renteeksponering over tid
+
+Finansiering av næringseiendom er ikke bare et kjøpstidspunkt-spørsmål. Gjennom eierperioden vil du sannsynligvis refinansiere én eller flere ganger — ved låneutløp, ved porteføljeendringer eller for å frigjøre kapital.
+
+Renteeksponering bør vurderes løpende. En god [kontantstrømsanalyse](/help/article/kontantstromsanalyse) inkluderer sensitivitetstest på rentescenarier — hva skjer med egenkapitalavkastningen dersom renten øker? Kjenner du svaret på det spørsmålet, kan du ta bevisste valg om rentebinding og gearingsnivå.
+
+<Summary
+  title="Nøkkelpunkter om finansiering av næringseiendom"
+  points={[
+    {
+      title: "LTV styrer egenkapitalkravet",
+      description: "Bankens krav til maksimal belåningsgrad (LTV) varierer med eiendomstype, leietakerkvalitet og markedsforhold. Kjenn bankens krav tidlig i prosessen.",
+      iconName: "barChart"
+    },
+    {
+      title: "WAULT og kontantstrøm er nøkkelen",
+      description: "Lang vektet gjenværende kontraktstid og sterk kontantstrømsdekning gir bedre lånebetingelser og mer finansieringsfleksibilitet.",
+      iconName: "scales"
+    },
+    {
+      title: "Gearing er et dobbeltegget virkemiddel",
+      description: "Lån forsterker egenkapitalavkastningen i gode tider, men forstørrer risikoen i dårlige. Tilpass belåningsgraden til kontantstrømmens robusthet.",
+      iconName: "lineChart"
+    },
+    {
+      title: "Rentebinding er risikostyring",
+      description: "Fast rente over deler av lånebindingsperioden gir forutsigbar finansieringskostnad og beskytter kontantstrømmen mot renteoppgang.",
+      iconName: "lightbulb"
+    }
+  ]}
+/>
+
+<CTA
+  badge="Forstå finansieringen"
+  title="Modeller finansieringsstrukturen med Advanti"
+  description="Advanti hjelper deg å analysere kontantstrøm, vurdere gearingseffekt og forstå hva finansieringsstrukturen betyr for avkastning og risiko."
+  primaryAction={{
+    label: "Ta kontakt",
+    href: "/kontakt"
+  }}
+  secondaryAction={{
+    label: "Les om kjøpsprosessen",
+    href: "/help/article/kjope-naringseiendom"
+  }}
+  size="default"
+/>

--- a/src/content/help/hva-er-naringseiendom.mdx
+++ b/src/content/help/hva-er-naringseiendom.mdx
@@ -1,46 +1,116 @@
 ---
 title: "Hva er næringseiendom? En komplett guide"
 slug: "hva-er-naringseiendom"
-summary: "Lær alt om hva næringseiendom er, de ulike kategoriene, og hva som skiller det fra boligeiendom. En guide for investorer og bedrifter."
+summary: "Næringseiendom er eiendom som brukes til virksomhet eller utleie — kontor, handel, lager og mer. Lær kategoriene, verdidriverne og hvordan markedet fungerer."
 categories: ["overview"]
 author: codehagen
 publishedAt: "2024-01-25"
-updatedAt: "2024-01-25"
+updatedAt: "2026-06-12"
 images: ["/building/pexels-pixabay-248877.jpg"]
+related:
+  - hva-er-yield
+  - verdivurdering-av-naringseiendom
+  - markedsleie-og-leieniva
+faq:
+  - question: "Hva regnes som næringseiendom?"
+    answer: "Eiendom som primært brukes til næringsvirksomhet eller utleie til virksomheter: kontorbygg, butikklokaler, lager- og logistikkbygg, hoteller, kombinasjonsbygg og spesialeiendom. Boligutleie i stor skala kan også drives som næring, men selve boligeiendommen kategoriseres normalt ikke som næringseiendom."
+  - question: "Er det lurt å investere i næringseiendom?"
+    answer: "Næringseiendom gir typisk lengre leiekontrakter og mer forutsigbar kontantstrøm enn bolig, men krever større kapital, mer kompetanse og innebærer høyere risiko ved ledighet. En grundig verdivurdering og forståelse av yield og kontantstrøm er forutsetninger for en god investering."
+  - question: "Hva er forskjellen på næringseiendom og boligeiendom?"
+    answer: "De viktigste forskjellene er leiekontraktens lengde og struktur, at partene er profesjonelle, at verdien beregnes ut fra leieinntektene (yield), og at utleie av næringslokaler kan registreres frivillig i MVA-registeret."
 ---
 
-Næringseiendom er en samlebetegnelse for eiendommer som primært brukes til næringsvirksomhet, i motsetning til boligeiendom som brukes til privat beboelse. Formålet med næringseiendom er enten å huse en virksomhet eller å generere inntekter gjennom utleie.
+Næringseiendom er en samlebetegnelse for eiendommer som primært brukes til næringsvirksomhet, i motsetning til boligeiendom som brukes til privat beboelse. Formålet er enten å huse en virksomhet direkte — for eksempel et kontor, en butikk eller et lager — eller å generere løpende leieinntekter fra leietakere som driver virksomhet i bygget. Verdien av en næringseiendom knyttes tett til dens evne til å produsere stabile inntekter over tid, noe som gjør kontantstrøm og leiekontrakter til de sentrale verdidriverne.
 
 ## Hovedkategorier av næringseiendom
 
-Næringseiendom deles ofte inn i flere underkategorier basert på bruksområde:
+Næringseiendom deles inn i kategorier etter byggets primære bruksmål. Kategorien har stor betydning for risikoprofilen, leienivået, leiestrukturen og hvem de typiske leietakerne er.
 
-### 1. Kontoreiendom
+### Kontoreiendom
 
-Dette inkluderer alt fra små kontorfellesskap til store kontorbygg. Dette er den mest vanlige formen for næringseiendom i bysentrum som Bodø og Tromsø.
+Kontoreiendom omfatter alt fra mindre kontorfellesskap og etasjekontor i blandingsbygg til store dedikerte kontorbygg. Leietakerne er gjerne virksomheter innenfor finans, juridiske tjenester, konsulentbransjen, offentlig forvaltning og teknologi. Beliggenhet er en avgjørende faktor: nærhet til kollektivknutepunkter, parkering og service påvirker etterspørselen og dermed leienivå og yield. Kontoreiendom er den mest vanlige kategorien i bysentrum og er godt egnet for investorer som ønsker forutsigbar kontantstrøm med profesjonelle leietakere på mellom- til langvarige kontrakter.
 
-### 2. Handelseiendom (Retail)
+### Handelseiendom (retail)
 
-Butikklokaler, kjøpesentre og serveringssteder faller inn under denne kategorien. Beliggenhet og kundestrøm er kritiske faktorer for verdien av disse eiendommene.
+Handelseiendom inkluderer butikklokaler på gateplan, kjøpesentre, dagligvarebygg og serveringssteder. Kategorien er særlig følsom for forbrukertrender, e-handelsutvikling og kundestrøm — faktorer som direkte påvirker leietakernes omsetning og dermed betalingsevne. Gode handelslokasjoner med høy fottrafikk og god synlighet oppnår sterkere etterspørsel og mer stabile leieforhold. Større handelseiendom med dagligvare som ankerleietaker betraktes gjerne som defensiv og er populær blant institusjonelle investorer.
 
-### 3. Lager og logistikk
+### Lager og logistikk
 
-Bygg som brukes til lagring, distribusjon og lett produksjon. Disse ligger ofte strategisk plassert nær transportknutepunkter.
+Lager- og logistikkeiendommer brukes til lagring, distribusjon, sortering og lett produksjon. Etterspørselen drives av e-handel, forsyningskjedebehov og industrivekst. Strategisk beliggenhet nær veiknutepunkter, havner og jernbane er sentralt for verdivurderingen. Byggets tekniske standard — fri takhøyde, bæreevne i gulv, antall laste- og losseporter — er viktige kvalitetsindikatorer. Leiekontrakter innen logistikk er ofte lange, noe som gir stabil kontantstrøm og gjør segmentet attraktivt for langsiktige investorer.
 
-### 4. Kombinasjonseiendom
+### Kombinasjonseiendom
 
-Eiendommer som kombinerer flere bruksmål, for eksempel verksted med tilhørende kontorlokaler.
+Kombinasjonseiendom samler flere funksjoner i ett bygg — typisk en kombinasjon av kontor, verksted, lager og lett produksjon. Denne fleksibiliteten gjør bygget tilgjengelig for en bred leietakermasse og gir mulighet for tilpasning etter skiftende behov. Kombinasjonseiendommer finnes særlig i næringsparker og randsonelokasjoner utenfor bykjernen. Verdien avhenger av den faktiske bruken og kvaliteten på leiekontraktene, ikke bare av den fysiske standarden.
+
+### Hotell og overnatting
+
+Hoteller og overnattingsbygg er en spesialisert del av næringseiendomsmarkedet. Her selges og leies bygget enten til en operatør som driver hotellet, eller det eies og driftes av samme aktør. Verdivurdering av hoteller er mer kompleks enn for tradisjonell næringseiendom fordi inntektene er driftsbetingede og varierer med belegg, rompris og sesong. Segmentet er mer konjunkturfølsomt enn eksempelvis logistikk, men kan by på høyere avkastning i perioder med sterk reiselivsetterspørsel.
+
+### Spesialeiendom
+
+Spesialeiendom er en restkategori som dekker bygg med svært spesifikke bruksformål: industribygg med tunge tekniske installasjoner, parkeringshus, helserelaterte bygg (klinikker, sykehjem), skolebygg og annen offentlig formålsbygg. Felles for disse er at de er bygget og tilpasset én type bruk, noe som gjør dem vanskeligere å re-utleie til andre formål hvis leietakeren faller fra. Risikoprofilen er høyere enn for generell næringseiendom, og verdivurderingen krever spesialisert kompetanse.
 
 ## Hva skiller næringseiendom fra boligeiendom?
 
-Det er flere fundamentale forskjeller mellom næringseiendom og boligeiendom:
+Det er grunnleggende strukturelle forskjeller mellom nærings- og boligmarkedet. De viktigste handler om leieforhold, verdsettelse, parter og regulatoriske rammer.
 
-- **Leiekontrakter:** Næringskontrakter er ofte langvarige (5-10 år) og reguleres av andre lover enn boligleie.
-- **Verdsettelse:** Verdien av en næringseiendom bestemmes primært av netto leieinntekter og avkastningskrav (yield), fremfor kvadratmeterpris i markedet.
-- **Finansiering:** Bankene stiller ofte strengere krav til egenkapital og kontantstrøm ved finansiering av næringseiendom.
+| Dimensjon | Næringseiendom | Boligeiendom |
+|---|---|---|
+| Leiekontraktens lengde | Typisk 5–15 år | Typisk 1–3 år |
+| Leiejustering | KPI-regulering (husleieindeks) | Begrenset av husleieloven |
+| Parter | Profesjonelle (virksomhet–eier) | Privat leietaker–eier |
+| Verdsettelsesmetode | Yield og kontantstrøm | Sammenlignbare salg (kvadratmeterpris) |
+| Finansiering | Strengere egenkapitalkrav, fokus på kontantstrøm | Standardiserte boliglånsregler |
+| MVA | Frivillig MVA-registrering mulig | Ikke MVA-pliktig |
 
-## Hvorfor investere i næringseiendom?
+Lejereguleringen for bolig er langt mer leietakervennlig enn for næring: husleieloven setter strenge begrensninger på oppsigelse og leieøkning, mens næringsleie i stor grad er avtalefrihet mellom profesjonelle parter. Det betyr at næringsleieavtaler er mer fleksible, men at forhandlingsstyrken mellom partene er avgjørende for hva kontrakten faktisk inneholder.
 
-Mange investorer velger næringseiendom på grunn av stabil kontantstrøm, inflasjonsbeskyttelse gjennom KPI-justering av leie, og potensial for verdiøkning gjennom aktiv forvaltning.
+Verdsettelse er kanskje den største strukturelle forskjellen. En bolig prises primært ut fra hva tilsvarende boliger er solgt for i samme område. En næringseiendom prises ut fra hva den kan generere av netto leieinntekter, og hvilket avkastningskrav markedet setter på den type eiendom i den type marked — det vil si yield. Disse to metodene gir helt ulike prislogikker og gjør næringseiendom mer lik finansielle instrumenter enn forbruksvarer.
 
-Trenger du hjelp med å vurdere en næringseiendom eller planlegger du å selge? Advanti har lokal ekspertise i Nord-Norge og hjelper deg gjennom hele prosessen.
+## Hvordan verdsettes næringseiendom?
+
+Den vanligste og enkleste metoden er yield-basert verdsettelse: du deler netto leieinntekter på markedets avkastningskrav (yield) og får markedsverdien.
+
+<Math formula="\text{Markedsverdi} = \frac{\text{Netto leieinntekter}}{\text{Yield}}" description="Yield-basert verdsettelse — den vanligste metoden" />
+
+For mer komplekse eiendommer — der leiekontrakter utløper, der det er ledige arealer, eller der man forventer vesentlige endringer i inntekter eller kostnader — benyttes [diskontert kontantstrøm (DCF)](/help/article/diskontert-kontantstrom). DCF-analysen modellerer kontantstrømmene år for år og neddiskonterer dem til nåverdi, noe som gir et mer presist bilde av verdien over tid.
+
+En fullstendig [verdivurdering av næringseiendom](/help/article/verdivurdering-av-naringseiendom) kombinerer yield-tilnærming og DCF med en vurdering av leietakerkvalitet, gjenværende kontraktstid, bygningsmessig standard og markedsposisjon. Resultatet er et verdiestimat som kan brukes i transaksjoner, refinansiering, og strategiske vurderinger.
+
+Lær mer om de sentrale verdsettelsesverktøyene: [yield](/help/article/hva-er-yield), [diskontert kontantstrøm](/help/article/diskontert-kontantstrom) og [verdivurdering av næringseiendom](/help/article/verdivurdering-av-naringseiendom).
+
+## Hvordan investere i næringseiendom
+
+Det finnes tre hovedveier inn i næringseiendom som investor.
+
+**Direktekjøp** innebærer at du kjøper selve eiendommen — enten som privatperson eller gjennom et eget selskap. Du får full kontroll, men også fullt ansvar for finansiering, forvaltning, leietakeroppfølging og teknisk drift. Direktekjøp passer best for investorer med tilstrekkelig kapital, kompetanse og kapasitet til aktiv forvaltning.
+
+**Kjøp av eiendomsselskap** er den dominerende transaksjonsformen i det profesjonelle markedet. Her kjøper du aksjene i selskapet som eier eiendommen (aksjer), eller du overtar eiendelen ut av selskapet (innmat). De to strukturene har ulike skattemessige konsekvenser for selger og kjøper, og de fleste større transaksjoner i Norge er organisert som aksjesalg.
+
+<Note variant="info">De fleste transaksjoner over et visst volum i det norske næringseiendomsmarkedet gjennomføres som kjøp og salg av aksjer i eiendomsselskap, ikke direktekjøp av eiendommen. Dette har skattemessige fordeler for begge parter og er markedsstandard.</Note>
+
+**Syndikat og fond** gir tilgang til næringseiendom med lavere minsteinnskudd. Et syndikat er en gruppe investorer som sammen kjøper én eller flere eiendommer gjennom et felles selskap. Eiendomsfond er regulerte investeringsvehikler som investerer i en portefølje av eiendommer. Begge gir eksponering mot næringseiendom uten at du selv trenger å forvalte eiendommen — til gjengjeld er kontrollen og informasjonstilgangen lavere enn ved direkteinvestering.
+
+## Næringseiendom i Nord-Norge
+
+Næringseiendomsmarkedet i Nord-Norge har særtrekk som skiller det fra de store bymarkedene i sør. Markedene er mindre i volum og mer konsentrerte geografisk. Det handler mer om lokalkunnskap — om hvilke leietakere som driver virksomhet i regionen, om hvilke bransjer som vokser, og om hvilke bygg som faktisk er etterspurt.
+
+Bodø og Tromsø er de to regionale tyngdepunktene og har det mest likvide markedet for næringseiendom i landsdelen. Bodø, med byutviklingsprosjektet Ny by — ny flyplass, er i en særstilling med betydelig byggeaktivitet og strukturelle endringer i byens næringseiendomsmasse. Tromsø har en sterk posisjon innen offentlig sektor, forskning, helse og reiseliv — noe som preger leietakersammensetningen og etterspørselsmønsteret.
+
+Utenfor de to byene er markedene tynnere. Det gjør likviditet, verdsettelse og exit-muligheter vanskeligere å forutsi. Lokalkunnskap og et etablert nettverk er ikke et konkurransefortrinn — det er en forutsetning for å navigere disse markedene på en forsvarlig måte.
+
+## Sentrale begreper
+
+Næringseiendom har et eget fagspråk. Her er de viktigste begrepene du trenger å kjenne, med lenker til dypere forklaringer:
+
+- [Yield](/help/article/hva-er-yield) — avkastningskravet som brukes til å prise netto leieinntekter om til verdi
+- [Netto leieinntekter](/help/article/netto-leieinntekter) — brutto leieinntekter fratrukket eierkostnader
+- [Driftskostnader](/help/article/driftskostnader) — kostnadene ved å eie og drifte eiendommen (vedlikehold, forsikring, kommunale avgifter m.m.)
+- [Felleskostnader](/help/article/felleskostnader) — fellesutgifter i et bygg som fordeles mellom leietakerne
+- [Markedsleie](/help/article/markedsleie-og-leieniva) — leienivået et areal oppnår ved ny utleie i dagens marked
+- [Kontantstrømsanalyse](/help/article/kontantstromsanalyse) — systematisk analyse av inn- og utbetalinger knyttet til eiendommen
+- [Sensitivitetsanalyse](/help/article/sensitivitetsanalyse) — beregning av hvordan endringer i yield, leie eller kostnader påvirker verdien
+
+En grundig forståelse av disse begrepene er grunnlaget for ethvert seriøst arbeid med kjøp, salg eller verdivurdering av næringseiendom.
+
+Vil du vite hva din næringseiendom faktisk er verdt? Les mer om [verdivurdering av næringseiendom](/tjenester/verdivurdering) og hvordan Advanti gjennomfører profesjonelle verdsettelser i Nord-Norge.

--- a/src/content/help/hva-er-naringseiendom.mdx
+++ b/src/content/help/hva-er-naringseiendom.mdx
@@ -3,7 +3,7 @@ title: "Hva er næringseiendom? En komplett guide"
 slug: "hva-er-naringseiendom"
 summary: "Lær alt om hva næringseiendom er, de ulike kategoriene, og hva som skiller det fra boligeiendom. En guide for investorer og bedrifter."
 categories: ["overview"]
-author: "christer"
+author: codehagen
 publishedAt: "2024-01-25"
 updatedAt: "2024-01-25"
 images: ["/building/pexels-pixabay-248877.jpg"]

--- a/src/content/help/hva-er-naringseiendom.mdx
+++ b/src/content/help/hva-er-naringseiendom.mdx
@@ -83,9 +83,9 @@ Lær mer om de sentrale verdsettelsesverktøyene: [yield](/help/article/hva-er-y
 
 Det finnes tre hovedveier inn i næringseiendom som investor.
 
-**Direktekjøp** innebærer at du kjøper selve eiendommen — enten som privatperson eller gjennom et eget selskap. Du får full kontroll, men også fullt ansvar for finansiering, forvaltning, leietakeroppfølging og teknisk drift. Direktekjøp passer best for investorer med tilstrekkelig kapital, kompetanse og kapasitet til aktiv forvaltning.
+**[Direktekjøp](/help/article/kjope-naringseiendom)** innebærer at du kjøper selve eiendommen — enten som privatperson eller gjennom et eget selskap. Du får full kontroll, men også fullt ansvar for [finansiering](/help/article/finansiering-av-naringseiendom), forvaltning, leietakeroppfølging og teknisk drift. Direktekjøp passer best for investorer med tilstrekkelig kapital, kompetanse og kapasitet til aktiv forvaltning.
 
-**Kjøp av eiendomsselskap** er den dominerende transaksjonsformen i det profesjonelle markedet. Her kjøper du aksjene i selskapet som eier eiendommen (aksjer), eller du overtar eiendelen ut av selskapet (innmat). De to strukturene har ulike skattemessige konsekvenser for selger og kjøper, og de fleste større transaksjoner i Norge er organisert som aksjesalg.
+**Kjøp av eiendomsselskap** er den dominerende transaksjonsformen i det profesjonelle markedet. Her kjøper du aksjene i selskapet som eier eiendommen, eller du overtar eiendelen ut av selskapet — de to strukturene kalles henholdsvis [aksjekjøp og innmatskjøp](/help/article/aksjekjop-vs-innmatskjop). De to strukturene har ulike skattemessige konsekvenser for selger og kjøper, og de fleste større transaksjoner i Norge er organisert som aksjesalg.
 
 <Note variant="info">De fleste transaksjoner over et visst volum i det norske næringseiendomsmarkedet gjennomføres som kjøp og salg av aksjer i eiendomsselskap, ikke direktekjøp av eiendommen. Dette har skattemessige fordeler for begge parter og er markedsstandard.</Note>
 

--- a/src/content/help/hva-er-naringseiendom.mdx
+++ b/src/content/help/hva-er-naringseiendom.mdx
@@ -110,6 +110,10 @@ Næringseiendom har et eget fagspråk. Her er de viktigste begrepene du trenger 
 - [Markedsleie](/help/article/markedsleie-og-leieniva) — leienivået et areal oppnår ved ny utleie i dagens marked
 - [Kontantstrømsanalyse](/help/article/kontantstromsanalyse) — systematisk analyse av inn- og utbetalinger knyttet til eiendommen
 - [Sensitivitetsanalyse](/help/article/sensitivitetsanalyse) — beregning av hvordan endringer i yield, leie eller kostnader påvirker verdien
+- [Brutto leieinntekter](/help/article/brutto-leieinntekter) — summen av alle leieinntekter før kostnadsfradrag
+- [Eierkostnader](/help/article/eierkostnader) — kostnadene utleier bærer selv, utover det leietaker dekker
+- [Exit yield](/help/article/exit-yield) — avkastningskravet som brukes til å beregne terminalverdien i en DCF-analyse
+- [Yield gap](/help/article/yield-gap) — differansen mellom eiendomsyield og risikofri rente; markedets risikopremie for eiendom
 
 En grundig forståelse av disse begrepene er grunnlaget for ethvert seriøst arbeid med kjøp, salg eller verdivurdering av næringseiendom.
 

--- a/src/content/help/hva-er-naringseiendom.mdx
+++ b/src/content/help/hva-er-naringseiendom.mdx
@@ -63,7 +63,7 @@ Det er grunnleggende strukturelle forskjeller mellom nærings- og boligmarkedet.
 | Finansiering | Strengere egenkapitalkrav, fokus på kontantstrøm | Standardiserte boliglånsregler |
 | MVA | Frivillig MVA-registrering mulig | Ikke MVA-pliktig |
 
-Lejereguleringen for bolig er langt mer leietakervennlig enn for næring: husleieloven setter strenge begrensninger på oppsigelse og leieøkning, mens næringsleie i stor grad er avtalefrihet mellom profesjonelle parter. Det betyr at næringsleieavtaler er mer fleksible, men at forhandlingsstyrken mellom partene er avgjørende for hva kontrakten faktisk inneholder.
+Leiereguleringen for bolig er langt mer leietakervennlig enn for næring: husleieloven setter strenge begrensninger på oppsigelse og leieøkning, mens næringsleie i stor grad er avtalefrihet mellom profesjonelle parter. Det betyr at næringsleieavtaler er mer fleksible, men at forhandlingsstyrken mellom partene er avgjørende for hva kontrakten faktisk inneholder.
 
 Verdsettelse er kanskje den største strukturelle forskjellen. En bolig prises primært ut fra hva tilsvarende boliger er solgt for i samme område. En næringseiendom prises ut fra hva den kan generere av netto leieinntekter, og hvilket avkastningskrav markedet setter på den type eiendom i den type marked — det vil si yield. Disse to metodene gir helt ulike prislogikker og gjør næringseiendom mer lik finansielle instrumenter enn forbruksvarer.
 

--- a/src/content/help/hva-er-yield.mdx
+++ b/src/content/help/hva-er-yield.mdx
@@ -11,6 +11,7 @@ related:
   - driftskostnader
   - exit-yield
   - yield-gap
+  - prime-yield
 slug: hva-er-yield
 faq:
   - question: "Hva er en god yield for næringseiendom?"

--- a/src/content/help/hva-er-yield.mdx
+++ b/src/content/help/hva-er-yield.mdx
@@ -9,6 +9,8 @@ related:
   - hva-er-advanti
   - netto-leieinntekter
   - driftskostnader
+  - exit-yield
+  - yield-gap
 slug: hva-er-yield
 faq:
   - question: "Hva er en god yield for næringseiendom?"

--- a/src/content/help/hva-er-yield.mdx
+++ b/src/content/help/hva-er-yield.mdx
@@ -10,6 +10,13 @@ related:
   - netto-leieinntekter
   - driftskostnader
 slug: hva-er-yield
+faq:
+  - question: "Hva er en god yield for næringseiendom?"
+    answer: "Det finnes ikke ett riktig svar — yield reflekterer risiko. Sentralt beliggende kontoreiendom med solide leietakere på lange kontrakter prises med lavere yield enn eldre bygg med korte kontrakter i mindre markeder. Sammenlign alltid mot tilsvarende eiendommer i samme marked."
+  - question: "Hva er forskjellen på brutto- og netto-yield?"
+    answer: "Brutto-yield beregnes av brutto leieinntekter, mens netto-yield (det vanligste i næringseiendom) beregnes av leieinntekter fratrukket eierkostnader. Netto-yield gir det mest presise bildet av faktisk avkastning."
+  - question: "Hvorfor faller verdien når yielden stiger?"
+    answer: "Verdi = netto leieinntekter delt på yield. Når markedet krever høyere avkastning (høyere yield) for samme leieinntekt, må prisen ned. En endring på ett prosentpoeng i yield kan gi store verdiutslag."
 ---
 
 ## Hva er Yield i næringseiendom?

--- a/src/content/help/hva-er-yield.mdx
+++ b/src/content/help/hva-er-yield.mdx
@@ -1,7 +1,7 @@
 ---
 title: Hva er yield i næringseiendom?
 updatedAt: 2025-02-17
-summary: En omfattende guide til å forstå yield i næringseiendom - fra grunnleggende konsepter til avanserte beregninger.
+summary: "Yield er forholdet mellom netto leieinntekter og eiendomsverdi. Lær hvordan du beregner yield, tolker nivåene og bruker den til å sammenligne eiendommer."
 author: codehagen
 categories:
   - terms

--- a/src/content/help/hvordan-lese-markedsrapport.mdx
+++ b/src/content/help/hvordan-lese-markedsrapport.mdx
@@ -28,7 +28,7 @@ En markedsrapport for næringseiendom sammenstiller fire typer nøkkeltall: [pri
 
 [Prime yield](/help/article/prime-yield) er avkastningskravet på de best kvalifiserte eiendommene i markedet: sentral beliggenhet, høy teknisk standard, lange kontrakter og solide leietakere. Det er markedets referansepunkt. Alle andre eiendommer prises med et risikopåslag — en høyere yield — relativt til prime.
 
-Prime yield forteller deg hva investorer er villige til å betale for mest mulig sikker og langsiktig kontantstrøm. Et fall i prime yield betyr at etterspørselen etter prime-eiendom er høy og risikopremien lav. En stigning betyr at markedet krever mer kompensasjon for å investere i eiendom — typisk drevet av rentemarkedet, generell usikkerhet eller et skift i kapitalilstrøm.
+Prime yield forteller deg hva investorer er villige til å betale for mest mulig sikker og langsiktig kontantstrøm. Et fall i prime yield betyr at etterspørselen etter prime-eiendom er høy og risikopremien lav. En stigning betyr at markedet krever mer kompensasjon for å investere i eiendom — typisk drevet av rentemarkedet, generell usikkerhet eller et skift i kapitaltilstrøm.
 
 ## Markedsleie — hva er oppnåelig ved ny utleie?
 

--- a/src/content/help/hvordan-lese-markedsrapport.mdx
+++ b/src/content/help/hvordan-lese-markedsrapport.mdx
@@ -1,0 +1,118 @@
+---
+title: Hvordan lese en markedsrapport for næringseiendom
+publishedAt: 2026-06-12
+updatedAt: 2026-06-12
+summary: "Markedsrapporter inneholder prime yield, markedsleie, ledighet og transaksjonsvolum. Lær hva hvert tall forteller og hvilke fallgruver du bør unngå."
+author: codehagen
+categories:
+  - analysis
+related:
+  - hva-er-yield
+  - markedsleie-og-leieniva
+  - prime-yield
+slug: hvordan-lese-markedsrapport
+faq:
+  - question: "Hva er de viktigste tallene i en markedsrapport for næringseiendom?"
+    answer: "De fire mest sentrale nøkkeltallene er prime yield, markedsleie, ledighet og transaksjonsvolum. Prime yield angir prisingsnivået i det beste markedssegmentet, markedsleie viser hva som er oppnåelig ved ny utleie, ledighet reflekterer balansen mellom tilbud og etterspørsel, og transaksjonsvolum gir bilde av markedets aktivitet og investorinteresse."
+  - question: "Hva er forskjellen på asking rent og achieved rent?"
+    answer: "Asking rent er leienivået utleier annonserer, mens achieved rent er det som faktisk oppnås i inngåtte kontrakter. Rapporter bør tydelig skille mellom de to. Achieved rent er mer relevant for verdivurdering fordi det gjenspeiler reelle transaksjoner, ikke ønskenivåer som kanskje aldri oppnås i markedet."
+  - question: "Hvorfor varierer tallene mellom ulike markedsrapporter?"
+    answer: "Ulike aktører bruker forskjellige definisjoner av prime yield, ulik geografisk avgrensning av markedet og ulikt datagrunnlag. En rapport kan inkludere salg med kortere kontrakter som prime, mens en annen setter strengere kriterier. Sammenlign alltid tall fra samme kilde over tid, ikke tall fra ulike rapporter på samme tidspunkt."
+---
+
+## Hva finner du i en markedsrapport for næringseiendom?
+
+En markedsrapport for næringseiendom sammenstiller fire typer nøkkeltall: [prime yield](/help/article/prime-yield), markedsleie, ledighet og transaksjonsvolum. Å lese rapporten riktig betyr å forstå hva hvert av disse tallene faktisk måler — og hva de ikke sier noe om. Se [Advantis markedsinnsikt](/markedsinnsikt) for et kontinuerlig oppdatert bilde av det nordnorske markedet.
+
+## Prime yield — markedets prisingspuls
+
+[Prime yield](/help/article/prime-yield) er avkastningskravet på de best kvalifiserte eiendommene i markedet: sentral beliggenhet, høy teknisk standard, lange kontrakter og solide leietakere. Det er markedets referansepunkt. Alle andre eiendommer prises med et risikopåslag — en høyere yield — relativt til prime.
+
+Prime yield forteller deg hva investorer er villige til å betale for mest mulig sikker og langsiktig kontantstrøm. Et fall i prime yield betyr at etterspørselen etter prime-eiendom er høy og risikopremien lav. En stigning betyr at markedet krever mer kompensasjon for å investere i eiendom — typisk drevet av rentemarkedet, generell usikkerhet eller et skift i kapitalilstrøm.
+
+## Markedsleie — hva er oppnåelig ved ny utleie?
+
+[Markedsleie](/help/article/markedsleie-og-leieniva) er leienivået et lokale kan oppnå ved ny utleie under gjeldende markedsforhold. Det er sentralt i verdivurdering fordi det representerer hva eiendommen kan forventes å generere av inntekter ved neste kontraktsforfall — uavhengig av hva den løpende kontrakten sier.
+
+Rapporter skiller gjerne mellom prime markedsleie og gjennomsnittlig markedsleie. Prime markedsleie gjelder de mest attraktive lokalene i de beste delmarkedene. Gjennomsnittlig markedsleie sier noe om bredden. Begge er nyttige: prime indikerer taket i markedet, gjennomsnittet sier noe om det brede prisbildet.
+
+## Ledighet — et mål på markedsbalansen
+
+Ledighetsraten viser andelen av kontormassen som er tilgjengelig for leie. En stram ledighet indikerer at etterspørselen er sterk relativt til tilbudet, noe som støtter leienivåene. Høy ledighet snur forhandlingspakten til leietakernes fordel og fører over tid til press nedover på markedsleie.
+
+Ledighet er også fremoverrettet dersom man kombinerer den med ferdigstillelsespipeline: store volum under bygging kombinert med avtakende etterspørsel kan varsle en kommende ledighetsstigning, selv om dagens tall er lave.
+
+## Transaksjonsvolum — aktivitet og likviditet
+
+Transaksjonsvolum er samlet omsatt verdi i et definert marked over en periode. Det sier noe om markedets likviditet og prisingskraft: mange transaksjoner betyr at priser faktisk avklares mellom kjøpere og selgere, og at markedet er aktivt. Lavt volum kan skyldes store prisgap mellom partene, krevende finansiering eller lite tilbud — men det er vanskelig å avgjøre hvilken forklaring som dominerer uten å se det i sammenheng med andre indikatorer.
+
+<Note variant="info">
+  Transaksjonsvolum er et laggsignal — det forteller hva som allerede har skjedd. Kombinert med ledighetsdata og yield-bevegelser gir det likevel nyttig informasjon om retningen i markedet og om markedssentimentet.
+</Note>
+
+## Fallgruver i rapportlesingen
+
+### Smale utvalg i regionale markeder
+
+I markeder med begrenset omsetning kan enkelthandler dominere statistikken. Én transaksjon med en uvanlig strukturert kjøper eller selger kan trekke gjennomsnittlig yield vesentlig. Vær kritisk til rapporter med lite transaksjonsgrunnlag, og sjekk alltid om kilde og metode er beskrevet.
+
+### Asking rents vs achieved rents
+
+Markedsleietall baseres tidvis på annonserte leiepriser — asking rents — ikke faktisk avtalte nivåer. I markeder med ubalanse vil achieved rents avvike nedover i form av frie perioder, innredningsbidrag og andre insentiver som ikke synliggjøres i listeleia. Spør alltid om rapportens markedsleietall er basert på faktiske kontrakter.
+
+### Definisjonsforskjeller mellom rapporter
+
+«Prime yield» er ikke en standardisert størrelse. Én rapport kan inkludere eiendommer med fem år igjen på kontrakten som prime, en annen krever ti. Geografisk avgrensning av markedet varierer likeledes. Tall fra to ulike rapporter for «samme» marked er sjelden direkte sammenlignbare.
+
+<Note variant="success">
+  Hold deg til én kilde over tid og analyser trender. Punktverdier er mindre nyttige enn endringstakten og retningen på tallene — det er trenden som sier noe om markedets bevegelse.
+</Note>
+
+## Slik bruker du rapporten i din analyse
+
+Markedsrapporten gir makrobildet — rammebetingelsene for analysen av den konkrete eiendommen. Bruk den til å kalibrere forutsetningene:
+
+1. **Prime yield som ankerpunkt.** Start med prime yield og juster opp basert på eiendomsspesifikke risikoer: beliggenhet, bygningsstandard, leietakerprofil og gjenværende kontraktstid. Resultatet er det individuelle avkastningskravet for eiendommen du analyserer.
+2. **Sammenlign løpende leie mot markedsleie.** Et vesentlig avvik signaliserer at kontrakten er over- eller underpriset relativt til markedet. Det er kritisk informasjon ved verdivurdering av eiendommer med nærliggende kontraktsforfall, fordi leien vil normalisere seg mot markedet.
+3. **Bruk ledighet som kontroll på leieantagelser.** Høy og stigende ledighet bør utfordre optimistiske leievekstforutsetninger. Kombiner ledighet med ferdigstillelsespipeline for å vurdere om trenden er i ferd med å snu.
+
+<Summary
+  title="Nøkkelpunkter om å lese markedsrapporter"
+  points={[
+    {
+      title: "Fire nøkkeltall",
+      description: "Prime yield, markedsleie, ledighet og transaksjonsvolum er hjørnesteinene i en markedsrapport — forstå hva hvert tall faktisk måler.",
+      iconName: "barChart"
+    },
+    {
+      title: "Kilde og metode teller",
+      description: "Definisjoner av prime, geografisk avgrensning og datagrunnlag varierer mellom aktører. Sammenlign alltid én kilde over tid.",
+      iconName: "scales"
+    },
+    {
+      title: "Asking vs achieved",
+      description: "Faktisk avtalte leienivåer kan avvike vesentlig nedover fra annonserte. Sjekk alltid om rapporten er basert på inngåtte kontrakter.",
+      iconName: "lineChart"
+    },
+    {
+      title: "Makro møter mikro",
+      description: "Rapporten gir rammen. Analysen av den konkrete eiendommen krever at du justerer forutsetningene ned til egenskapene ved det aktuelle objektet.",
+      iconName: "lightbulb"
+    }
+  ]}
+/>
+
+<CTA
+  badge="Markedsinnsikt"
+  title="Følg markedet med Advanti"
+  description="Advanti samler markedsdata for næringseiendom i Nord-Norge og gir deg verktøy for verdivurdering basert på oppdaterte forutsetninger."
+  primaryAction={{
+    label: "Prøv Advanti",
+    href: "/kontakt"
+  }}
+  secondaryAction={{
+    label: "Se markedsinnsikt",
+    href: "/markedsinnsikt"
+  }}
+  size="default"
+/>

--- a/src/content/help/kjope-naringseiendom.mdx
+++ b/src/content/help/kjope-naringseiendom.mdx
@@ -1,0 +1,165 @@
+---
+title: "Hvordan kjøpe næringseiendom: prosessen steg for steg"
+publishedAt: 2026-06-12
+updatedAt: 2026-06-12
+summary: "Kjøp av næringseiendom følger en definert prosess fra strategi til overtakelse. Her er fasene, aktørene og de vanligste feilene du bør unngå."
+author: codehagen
+categories:
+  - for-investors
+related:
+  - verdivurdering-av-naringseiendom
+  - due-diligence-naringseiendom
+  - finansiering-av-naringseiendom
+slug: kjope-naringseiendom
+howto: true
+step:
+  - name: "Strategi og søk"
+    text: "Definer investeringsstrategi — eiendomstype, geografi, risikotoleranse og avkastningskrav. Etabler mandat og begynn systematisk søk gjennom meglere og eget nettverk."
+  - name: "Analyse og verdivurdering"
+    text: "Gjennomfør innledende analyse av eiendommen: gå gjennom leiekontrakter, teknisk dokumentasjon og regnskaper. Innhent eller gjennomfør verdivurdering for å vurdere pris kontra verdi."
+  - name: "Bud og intensjonsavtale"
+    text: "Gi bindende eller ikke-bindende bud. Ved aksept inngås en intensjonsavtale som sikrer eksklusiv forhandlingsperiode og fastlegger de kommersielle hovedvilkårene."
+  - name: "Due diligence"
+    text: "Gjennomfør teknisk, juridisk, finansiell og miljømessig due diligence. Funn fra gjennomgangen brukes til å bekrefte budet, justere vilkår eller — ved vesentlige avvik — trekke budet."
+  - name: "Kjøpekontrakt og oppgjør"
+    text: "Advokatene utarbeider kjøpekontrakt basert på forhandlede vilkår. Finansiering bekreftes og kjøpesummen gjøres opp via advokatenes klientkonto."
+  - name: "Overtakelse"
+    text: "Eiendommen overtas på avtalt dato. Leietakere varsles om ny eier, dokumenter og nøkler overleveres og den løpende driften videreføres."
+faq:
+  - question: "Hvor lang tid tar et kjøp av næringseiendom?"
+    answer: "Et standard kjøp tar typisk to til seks måneder fra første bud til overtakelse. Forhandlinger, due diligence og finansiering er de fasene som oftest strekker ut tidsperspektivet. Komplekse transaksjoner med mange leietakere eller tekniske problemstillinger kan ta vesentlig lengre tid."
+  - question: "Trenger jeg megler for å kjøpe næringseiendom?"
+    answer: "En kjøpers megler eller rådgiver kan gi markedstilgang, bistand i gjennomgang og hjelp i forhandlinger — særlig viktig for kjøpere uten etablert nettverk. Mange eiendommer omsettes utenfor det åpne markedet, og et meglernettverk er verdifullt for å oppdage relevante objekter tidlig."
+  - question: "Hva er de vanligste feilene ved kjøp av næringseiendom?"
+    answer: "De hyppigst forekommende feilene er: utilstrekkelig due diligence på leiekontrakter og teknisk stand, finansiering som ikke er avklart før bud gis, og urealistiske antakelser om fremtidig markedsleie ved kontraktsforfall. En systematisk prosess og profesjonelle rådgivere reduserer risikoen vesentlig."
+---
+
+Kjøp av næringseiendom er en kapitalintensiv beslutning som følger en strukturert prosess fra strategi til overtakelse. I motsetning til boligkjøp er begge parter profesjonelle, avtalerfriheten er stor og risikoen for feil er høy. En god forståelse av hvert steg — og av hvem som bør involveres når — er avgjørende for å unngå kostbare overraskelser.
+
+## Strategi og søk
+
+Prosessen begynner ikke med et konkret objekt — den begynner med et mandat. Definer investeringsstrategien din: hvilken eiendomstype søker du (kontor, lager, handel, kombinasjon), i hvilken geografi, med hvilken risikoprofil og hvilket avkastningskrav? Et tydelig mandat gjør søket mer effektivt og hjelper deg å si nei til objekter som ikke passer.
+
+Søk skjer gjennom meglere, via eget nettverk og — i større grad enn mange tror — gjennom direkte henvendelser til eiendomsbesittere. Mange av de beste transaksjonene gjøres utenfor det åpne markedet, der kjøper og selger finner hverandre uten åpen budrunde. Særlig i mindre regionale markeder er nettverk og lokalkunnskap avgjørende for å oppdage relevante objekter tidlig.
+
+Det er også lurt å avklare finansieringskapasiteten allerede i søkefasen. En innledende dialog med bankforbindelsen gir deg en realistisk ramme for hva du kan by — og gjør deg til en troverdig kjøper når de riktige objektene dukker opp.
+
+## Innledende analyse og verdivurdering
+
+Når du har identifisert et aktuelt objekt, starter den innledende analysen. Gjennomgå de sentrale dokumentene: leiekontrakter, tekniske rapporter, regnskaper og byggtillatelser. Formålet er ikke en fullstendig gjennomgang, men å danne seg et tilstrekkelig bilde til å ta stilling til om objektet er interessant — og til hvilken pris.
+
+En [verdivurdering av næringseiendom](/help/article/verdivurdering-av-naringseiendom) er sentral i denne fasen. Enten innhenter du en uavhengig verdivurdering, eller du gjennomfører din egen yield-baserte kalkyle. Verdivurderingen gir grunnlaget for budet og er startpunktet for finansieringsdialogen med banken.
+
+<Note variant="info">
+  Den innledende analysen trenger ikke være fullstendig — formålet er å avgjøre om du vil gå videre. Den grundige gjennomgangen kommer i due diligence-fasen.
+</Note>
+
+## Prosessen steg for steg
+
+<Stepper
+  items={[
+    {
+      title: "Strategi og søk",
+      content: "Definer investeringsmandat: eiendomstype, geografi, risikoprofil og avkastningskrav. Etabler kontakt med meglere og bygg nettverk for tilgang til objekter utenfor det åpne markedet. Avklar finansieringsrammen med bank.",
+    },
+    {
+      title: "Analyse og verdivurdering",
+      content: "Gjennomgå leiekontrakter, teknisk dokumentasjon og regnskaper for å vurdere om objektet møter mandatet. Gjennomfør yield-basert verdivurdering som grunnlag for budet.",
+    },
+    {
+      title: "Bud og intensjonsavtale",
+      content: "Gi indikativt eller bindende bud. Ved aksept inngås en intensjonsavtale (Letter of Intent) som fastlegger pris, transaksjonsstruktur, due diligence-periode og eksklusivitet.",
+    },
+    {
+      title: "Due diligence",
+      content: "Gjennomfør teknisk, juridisk, finansiell og miljømessig gjennomgang. Funn brukes til å bekrefte, justere eller — ved vesentlige avvik — trekke budet. Typisk varighet tre til åtte uker.",
+    },
+    {
+      title: "Kjøpekontrakt og oppgjør",
+      content: "Advokatene utarbeider kjøpekontrakt med representasjoner, garantier og eventuell prisregulering basert på due diligence-funn. Finansiering bekreftes og kjøpesummen gjøres opp.",
+    },
+    {
+      title: "Overtakelse",
+      content: "Eiendommen overtas. Protokoll fra overtakelsesbefaringen dokumenterer tilstand. Leietakere varsles om ny eier og ny betalingsinstruksjon. Dokumenter, nøkler og driftsrutiner overleveres.",
+    }
+  ]}
+/>
+
+## Typisk tidslinje
+
+Et transaksjonsforløp varierer betydelig med kompleksitet og partenes kapasitet, men følgende er et realistisk spenn:
+
+- **Søk og innledende analyse**: løpende frem til objekt er identifisert — noen uker til mange måneder
+- **Bud og intensjonsavtale**: én til tre uker
+- **Due diligence**: tre til åtte uker
+- **Kontraktsforhandling og finansiering**: to til fire uker
+- **Oppgjør og overtakelse**: én til to uker
+
+Samlet tidsperspektiv fra første bud til overtakelse er typisk to til seks måneder. Større eller mer komplekse transaksjoner med mange leietakere, miljøproblematikk eller komplisert finansiering kan strekke seg lengre.
+
+## Hvem er involvert?
+
+Et kjøp av næringseiendom involverer som regel disse fagpersonene:
+
+**Næringsmegler** bistår med markedstilgang, prising og prosessledelse. Megleren representerer oftest selger, men kjøper kan også engasjere en egen rådgiver.
+
+**Advokat** gjennomfører juridisk due diligence, forhandler kontraktsvilkår og utarbeider kjøpekontrakten. Juridisk bistand er ikke valgfritt — næringsleiekontrakter og eiendomstransaksjoner har store verdimessige konsekvenser.
+
+**Teknisk rådgiver eller takstmann** gjennomfører teknisk due diligence og dokumenterer bygningsmessig tilstand, ventilasjon, tekniske installasjoner og eventuelle skader eller mangler.
+
+**Bank** vurderer sikkerheten og finansierer kjøpet. Bankens krav — til egenkapital, kontantstrømsdekning og leietakerkvalitet — er styrende for hva og hvor mye du kan kjøpe. Se [finansiering av næringseiendom](/help/article/finansiering-av-naringseiendom) for mer om bankens vurderinger.
+
+**Skatterådgiver eller revisor** rådgir om transaksjonsstuktur og skattemessige konsekvenser, særlig ved valg mellom aksje- og innmatkjøp.
+
+## De vanligste feilene
+
+Erfaringen fra mange transaksjoner peker på noen feil som gjentar seg:
+
+**Finansiering avklares for sent.** Å gi bud uten å ha bekreftet finansieringskapasiteten er risikabelt. Bankens prosess tar tid, og en finansiering som faller gjennom etter at intensjonsavtale er inngått, kan gi erstatningsansvar overfor selger.
+
+**For svak gjennomgang av leiekontrakter.** Leiekontraktene er eiendomsens inntektsgrunnlag. Svake klausuler, korte gjenværende løpetider eller leietakere med dårlig kredittverdighet kan gi vesentlig lavere verdi enn antatt. Les mer i artikkelen om [due diligence ved kjøp av næringseiendom](/help/article/due-diligence-naringseiendom).
+
+**Teknisk stand undervurdert.** Et bygg kan se godt ut på overflaten men ha kostbare problemer i tak, tekniske anlegg eller fundamenter. Teknisk due diligence betaler seg selv mange ganger over.
+
+**Urealistiske antakelser om fremtidig leie.** Kjøpere som betaler en høy pris med forventning om vesentlig oppside ved kontraktsforfall, bør validere leie- og yieldforutsetningene mot faktiske markedsforhold.
+
+<Summary
+  title="Nøkkelpunkter om kjøpsprosessen"
+  points={[
+    {
+      title: "Start med strategien",
+      description: "Et tydelig investeringsmandat gjør søket mer effektivt og hjelper deg å sortere bort objekter som ikke møter kravene dine.",
+      iconName: "barChart"
+    },
+    {
+      title: "Due diligence er ikke valgfritt",
+      description: "Grundig gjennomgang av leiekontrakter, teknisk stand, juridiske forhold og miljø er forutsetningen for en forsvarlig transaksjon.",
+      iconName: "scales"
+    },
+    {
+      title: "Finansiering tidlig",
+      description: "Avklar finansieringskapasitet og bankens krav allerede i søkefasen — ikke etter at bud er akseptert og intensjonsavtale er inngått.",
+      iconName: "lineChart"
+    },
+    {
+      title: "Bruk profesjonelle rådgivere",
+      description: "Megler, advokat, teknisk rådgiver og bank er ikke bare kostnader — de er risikostyring i en kompleks prosess med store verdier.",
+      iconName: "lightbulb"
+    }
+  ]}
+/>
+
+<CTA
+  badge="Kjøp smart"
+  title="Få profesjonell rådgivning ved kjøp av næringseiendom"
+  description="Advanti bistår kjøpere med verdivurdering, markedsanalyse og rådgivning gjennom hele kjøpsprosessen i Nord-Norge."
+  primaryAction={{
+    label: "Snakk med en rådgiver",
+    href: "/kontakt"
+  }}
+  secondaryAction={{
+    label: "Se våre tjenester",
+    href: "/tjenester"
+  }}
+  size="default"
+/>

--- a/src/content/help/kjope-naringseiendom.mdx
+++ b/src/content/help/kjope-naringseiendom.mdx
@@ -14,17 +14,17 @@ slug: kjope-naringseiendom
 howto: true
 step:
   - name: "Strategi og søk"
-    text: "Definer investeringsstrategi — eiendomstype, geografi, risikotoleranse og avkastningskrav. Etabler mandat og begynn systematisk søk gjennom meglere og eget nettverk."
+    text: "Definer investeringsmandat: eiendomstype, geografi, risikoprofil og avkastningskrav. Etabler kontakt med meglere og bygg nettverk for tilgang til objekter utenfor det åpne markedet. Avklar finansieringsrammen med bank."
   - name: "Analyse og verdivurdering"
-    text: "Gjennomfør innledende analyse av eiendommen: gå gjennom leiekontrakter, teknisk dokumentasjon og regnskaper. Innhent eller gjennomfør verdivurdering for å vurdere pris kontra verdi."
+    text: "Gjennomgå leiekontrakter, teknisk dokumentasjon og regnskaper for å vurdere om objektet møter mandatet. Gjennomfør yield-basert verdivurdering som grunnlag for budet."
   - name: "Bud og intensjonsavtale"
-    text: "Gi bindende eller ikke-bindende bud. Ved aksept inngås en intensjonsavtale som sikrer eksklusiv forhandlingsperiode og fastlegger de kommersielle hovedvilkårene."
+    text: "Gi indikativt eller bindende bud. Ved aksept inngås en intensjonsavtale (Letter of Intent) som fastlegger pris, transaksjonsstruktur, due diligence-periode og eksklusivitet."
   - name: "Due diligence"
-    text: "Gjennomfør teknisk, juridisk, finansiell og miljømessig due diligence. Funn fra gjennomgangen brukes til å bekrefte budet, justere vilkår eller — ved vesentlige avvik — trekke budet."
+    text: "Gjennomfør teknisk, juridisk, finansiell og miljømessig gjennomgang. Funn brukes til å bekrefte, justere eller — ved vesentlige avvik — trekke budet. Typisk varighet tre til åtte uker."
   - name: "Kjøpekontrakt og oppgjør"
-    text: "Advokatene utarbeider kjøpekontrakt basert på forhandlede vilkår. Finansiering bekreftes og kjøpesummen gjøres opp via advokatenes klientkonto."
+    text: "Advokatene utarbeider kjøpekontrakt med representasjoner, garantier og eventuell prisregulering basert på due diligence-funn. Finansiering bekreftes og kjøpesummen gjøres opp."
   - name: "Overtakelse"
-    text: "Eiendommen overtas på avtalt dato. Leietakere varsles om ny eier, dokumenter og nøkler overleveres og den løpende driften videreføres."
+    text: "Eiendommen overtas. Protokoll fra overtakelsesbefaringen dokumenterer tilstand. Leietakere varsles om ny eier og ny betalingsinstruksjon. Dokumenter, nøkler og driftsrutiner overleveres."
 faq:
   - question: "Hvor lang tid tar et kjøp av næringseiendom?"
     answer: "Et standard kjøp tar typisk to til seks måneder fra første bud til overtakelse. Forhandlinger, due diligence og finansiering er de fasene som oftest strekker ut tidsperspektivet. Komplekse transaksjoner med mange leietakere eller tekniske problemstillinger kan ta vesentlig lengre tid."
@@ -34,7 +34,7 @@ faq:
     answer: "De hyppigst forekommende feilene er: utilstrekkelig due diligence på leiekontrakter og teknisk stand, finansiering som ikke er avklart før bud gis, og urealistiske antakelser om fremtidig markedsleie ved kontraktsforfall. En systematisk prosess og profesjonelle rådgivere reduserer risikoen vesentlig."
 ---
 
-Kjøp av næringseiendom er en kapitalintensiv beslutning som følger en strukturert prosess fra strategi til overtakelse. I motsetning til boligkjøp er begge parter profesjonelle, avtalerfriheten er stor og risikoen for feil er høy. En god forståelse av hvert steg — og av hvem som bør involveres når — er avgjørende for å unngå kostbare overraskelser.
+Kjøp av næringseiendom er en kapitalintensiv beslutning som følger en strukturert prosess fra strategi til overtakelse. I motsetning til boligkjøp er begge parter profesjonelle, avtalefriheten er stor og risikoen for feil er høy. En god forståelse av hvert steg — og av hvem som bør involveres når — er avgjørende for å unngå kostbare overraskelser.
 
 ## Strategi og søk
 
@@ -109,7 +109,7 @@ Et kjøp av næringseiendom involverer som regel disse fagpersonene:
 
 **Bank** vurderer sikkerheten og finansierer kjøpet. Bankens krav — til egenkapital, kontantstrømsdekning og leietakerkvalitet — er styrende for hva og hvor mye du kan kjøpe. Se [finansiering av næringseiendom](/help/article/finansiering-av-naringseiendom) for mer om bankens vurderinger.
 
-**Skatterådgiver eller revisor** rådgir om transaksjonsstuktur og skattemessige konsekvenser, særlig ved valg mellom aksje- og innmatkjøp.
+**Skatterådgiver eller revisor** rådgir om transaksjonsstruktur og skattemessige konsekvenser, særlig ved valg mellom aksje- og innmatkjøp.
 
 ## De vanligste feilene
 

--- a/src/content/help/kontantstromsanalyse.mdx
+++ b/src/content/help/kontantstromsanalyse.mdx
@@ -1,7 +1,7 @@
 ---
 title: Kontantstrømsanalyse i næringseiendom
 updatedAt: 2025-02-18
-summary: En omfattende guide til å forstå kontantstrømsanalyse i næringseiendom - fra grunnleggende beregninger til avanserte analyser.
+summary: "Kontantstrømsanalyse viser hva en næringseiendom faktisk genererer. Lær oppsettet fra brutto leieinntekter til netto kontantstrøm — med formler."
 author: codehagen
 categories:
   - terms

--- a/src/content/help/kontorledighet.mdx
+++ b/src/content/help/kontorledighet.mdx
@@ -1,0 +1,112 @@
+---
+title: "Kontorledighet: hva tallet betyr"
+publishedAt: 2026-06-12
+updatedAt: 2026-06-12
+summary: "Kontorledighet er andelen ledig areal av total kontormasse. Lær hva som skiller strukturell fra konjunkturell ledighet og hvordan det påvirker leie og yield."
+author: codehagen
+categories:
+  - analysis
+related:
+  - markedsleie-og-leieniva
+  - hvordan-lese-markedsrapport
+slug: kontorledighet
+faq:
+  - question: "Hva er kontorledighet og hvordan beregnes den?"
+    answer: "Kontorledighet er andelen av total kontormasse som til enhver tid er ledig for utleie. Den beregnes ved å dele totalt ledig areal på den samlede kontormassen i det definerte markedet. Ledigheten er en direkte indikator på markedsbalansen mellom tilbud og etterspørsel, og et sentralt tall i enhver markedsanalyse for næringseiendom."
+  - question: "Hva er forskjellen på strukturell og konjunkturell ledighet?"
+    answer: "Strukturell ledighet er det naturlige basisnivået som alltid vil eksistere fordi leietakere bytter lokaler, bygg rehabiliteres og det tar tid å leie ut selv i et balansert marked. Konjunkturell ledighet er den delen som reflekterer faktisk ubalanse mellom tilbud og etterspørsel, og som svinger med konjunkturene og byggeaktiviteten."
+  - question: "Hvorfor svinger kontorledigheten mer i små markeder?"
+    answer: "I et lite marked med få store leietakere kan én enkelt virksomhet som ekspanderer eller konsoliderer seg representere mange prosentpoeng av total kontormasse. Ledighetstallet kan da svinge betydelig fra kvartal til kvartal som følge av enkeltaktørers valg, uten at markedets grunnleggende dynamikk egentlig har endret seg."
+---
+
+## Hva er kontorledighet?
+
+Kontorledighet er andelen av total kontormasse i et definert marked eller delmarked som til enhver tid er ledig for leie. Tallet er en direkte målestokk på balansen mellom tilbud og etterspørsel — et lavt tall indikerer at markedet er stramt, et høyt tall at tilbudet overstiger etterspørselen.
+
+<Math
+  formula="\text{Ledighet} = \frac{\text{Ledig areal}}{\text{Total kontormasse}} \times 100"
+  description="Ledighet uttrykkes som en prosentandel av total kontormasse i det definerte markedet eller delmarkedet"
+/>
+
+Definisjonen virker enkel, men gjennomføringen er mer sammensatt enn den ser ut til. Hva som regnes som «ledig» areal varierer mellom rapporter: noen inkluderer bare areal som aktivt markedsføres til leie, andre tar med underutnyttede arealer der eksisterende leietaker ikke formelt har sagt opp. Delmarkedsavgrensningen — sentrum, randsone, logistikkpol — er likeledes ulik mellom aktører. Derfor er det viktig å forstå kildens metodikk når man sammenligner tall over tid eller på tvers av rapporter.
+
+## Strukturell vs konjunkturell ledighet
+
+Ikke all ledighet er et problem. Det finnes en **strukturell ledighet** — et basisnivå som alltid vil eksistere fordi leietakere bytter lokaler, bygg rehabiliteres og det tar tid å leie ut ledig areal selv i et fullt balansert marked. Denne ledigheten er friksjonsbasert og er ikke et signal om strukturell ubalanse.
+
+**Konjunkturell ledighet** er noe annet. Det er ledigheten som oppstår fordi markedet faktisk er i ubalanse: etterspørselen har falt relativt til tilbudet, eller ny bygningsmasse er blitt ferdigstilt raskere enn markedet absorberer den. Konjunkturell ledighet er den man ønsker å overvåke tett som investor eller analytiker.
+
+I praksis er det vanskelig å skille de to presist. Mange analytikere bruker et normalisert historisk gjennomsnittsnivå som referansepunkt for strukturell ledighet i et gitt marked. Avvik fra dette normalnivået er mer informativt enn absoluttverdien alene — det er retningen og endringstakten som forteller den viktigste historien.
+
+<Note variant="info">
+  En stabil ledighet over mange kvartaler kan reflektere at markedet er i balanse nær sitt strukturelle basisnivå. En stigende trend over flere kvartaler indikerer derimot konjunkturell ubalanse og bør leses som et signal om kommende press på leienivåene.
+</Note>
+
+## Hvordan ledighet påvirker markedsleie og yield
+
+Ledighet, [markedsleie](/help/article/markedsleie-og-leieniva) og yield henger tett sammen — men koblingen er kvalitativ og med tidsetterslep, ikke mekanisk og øyeblikkelig.
+
+Når ledigheten er høy og stigende, har leietakere forhandlingsmakt. Utleiere konkurrerer om å fylle arealet, og resultatet er press nedover på oppnåelig leienivå — enten gjennom lavere nominell leie eller gjennom insentiver som frie perioder og innredningsbidrag som ikke synliggjøres i listeleien. Over tid vil dette reflekteres i lavere markedsleie.
+
+Lavere markedsleie påvirker i sin tur verdivurderingen. Verdien av en eiendom er en funksjon av forventede leieinntekter og avkastningskravet. Dersom markedsleie faller, reduseres det forventede inntektsgrunnlaget — spesielt for eiendommer med nærliggende kontraktsforfall der leien vil normalisere seg mot markedet. Investorer vil typisk kompensere for usikkerheten om fremtidig ledighet og leieinntekter gjennom et høyere yield-krav.
+
+Sammenhengen er ikke lineær. Kvaliteten på den konkrete eiendommens leietaker, restløpetid på kontrakter og beliggenhet innenfor delmarkedet kan gjøre at én eiendom er tilnærmet upåvirket av høy markedsleie i det generelle markedet — for eksempel dersom alle kontraktene er lange og solide.
+
+## Ledighetsdata og fremtidsperspektivet
+
+Historisk ledighetstall sier hva markedet har vært. En fremoverskuende analyse kombinerer ledighetsdata med tilleggsinformasjon:
+
+- **Ferdigstillelsespipeline**: Nybygg under oppføring som planlegges ferdigstilt de neste ett til to år tilsier at tilbudet øker. Dersom dette skjer uten tilsvarende vekst i etterspørsel, vil ledigheten stige.
+- **Kontraktsforfall**: En gjennomgang av når eksisterende leiekontrakter i et delmarked utløper gir signal om potensielt ledighetstrykk fremover. Et delmarked med mange forfall konsentrert i nær tid er mer utsatt enn ett med lange, overlappende kontrakter.
+- **Sysselsettingsutsikter**: Etterspørsel etter kontorplass er koblet til sysselsettingsvekst i kontorkrevende næringer. Forventede endringer i arbeidsstyrken og arbeidsmønsteret kan påvirke absorpsjonskraften i markedet over tid.
+
+## Hvorfor svinger ledigheten mer i små markeder?
+
+I et lite kontormarked er den totale kontormassen begrenset. Det betyr at én stor leietaker som ekspanderer, konsoliderer eller avvikler virksomhet kan representere mange prosentpoeng av total kontormasse. En enkelt virksomhet som frigjør en stor etasje kan alene flytte ledighetstallet vesentlig.
+
+Dette er ikke nødvendigvis et signal om et strukturelt skift i markedet — det er enkeltaktørers valg som dominerer statistikken. Resultatet er at ledighetstallet kan svinge betydelig fra kvartal til kvartal uten at markedets grunnleggende dynamikk egentlig har endret seg.
+
+<Note variant="success">
+  I regionale markeder med begrenset omsetning er det like nyttig å kjenne de største enkeltleietakerne og kontraktsstrukturene som å lese ledighetstallet isolert. Det gir grunnlag for å vurdere om ledighetsbevegelser er engangseffekter eller strukturelle trender.
+</Note>
+
+<Summary
+  title="Nøkkelpunkter om kontorledighet"
+  points={[
+    {
+      title: "Andelen av kontormassen",
+      description: "Ledighet måler ledig areal delt på total kontormasse. Enkel formel, men gjennomføringen avhenger av definisjoner og delmarkedsavgrensning.",
+      iconName: "barChart"
+    },
+    {
+      title: "Strukturell vs konjunkturell",
+      description: "Strukturell ledighet er det naturlige basisnivået. Konjunkturell ledighet er ubalansen mellom tilbud og etterspørsel — det viktige signalet å følge.",
+      iconName: "scales"
+    },
+    {
+      title: "Koblet til leie og yield",
+      description: "Høy og stigende ledighet presser markedsleie nedover over tid, og øker avkastningskravet for eiendommer med nær kontraktsforfall.",
+      iconName: "lineChart"
+    },
+    {
+      title: "Smale markeder svinger mer",
+      description: "I markeder med få store leietakere kan enkeltaktørers valg dominere statistikken. Les slike tall med kildekritikk og se etter den underliggende trenden.",
+      iconName: "lightbulb"
+    }
+  ]}
+/>
+
+<CTA
+  badge="Markedsanalyse"
+  title="Forstå ledighetsbildet med Advanti"
+  description="Advanti gir deg markedsdata og analyseverktøy for næringseiendom i Nord-Norge — slik at du kan vurdere ledighet, markedsleie og avkastningskrav på et solid grunnlag."
+  primaryAction={{
+    label: "Prøv Advanti",
+    href: "/kontakt"
+  }}
+  secondaryAction={{
+    label: "Se markedsinnsikt",
+    href: "/markedsinnsikt"
+  }}
+  size="default"
+/>

--- a/src/content/help/kpi-regulering-av-leie.mdx
+++ b/src/content/help/kpi-regulering-av-leie.mdx
@@ -2,7 +2,7 @@
 title: KPI-regulering av leie
 publishedAt: 2026-06-12
 updatedAt: 2026-06-12
-summary: "KPI-regulering justerer leien i takt med konsumprisindeksen. Lær hvordan klausulen fungerer, hva 100 % KPI betyr i praksis, og hvorfor det er avgjørende i kontantstrømsanalysen."
+summary: "KPI-regulering justerer leien med konsumprisindeksen. Lær klausulen, hva 100 % KPI betyr i praksis, og hvorfor det er avgjørende i kontantstrømsanalysen."
 author: codehagen
 categories:
   - terms

--- a/src/content/help/kpi-regulering-av-leie.mdx
+++ b/src/content/help/kpi-regulering-av-leie.mdx
@@ -1,0 +1,116 @@
+---
+title: KPI-regulering av leie
+publishedAt: 2026-06-12
+updatedAt: 2026-06-12
+summary: "KPI-regulering justerer leien i takt med konsumprisindeksen. Lær hvordan klausulen fungerer, hva 100 % KPI betyr i praksis, og hvorfor det er avgjørende i kontantstrømsanalysen."
+author: codehagen
+categories:
+  - terms
+related:
+  - markedsleie-og-leieniva
+  - kontantstromsanalyse
+  - brutto-leieinntekter
+slug: kpi-regulering-av-leie
+faq:
+  - question: "Hva betyr 100 % KPI-regulering?"
+    answer: "100 % KPI-regulering betyr at leien justeres med den fulle prosentvise endringen i konsumprisindeksen (KPI) fra ett år til det neste. Er KPI opp 3,5 %, øker leien med 3,5 %. Ingen del av inflasjonen absorberes av utleier — hele økningen veltes over på leietaker."
+  - question: "Når reguleres leien med KPI?"
+    answer: "Reguleringstidspunktet er avtalt i kontrakten — vanligvis på leiens første dag i hvert kalenderår, eller på leieforholdet ettårsjubileum. Endringen baserer seg typisk på KPI fra et referansepunkt (for eksempel oktober) ett år tilbake til samme tidspunkt inneværende år."
+  - question: "Kan partene avtale noe annet enn 100 % KPI?"
+    answer: "Ja. Leieregulering er avtalefritt i næringseiendom. Partene kan avtale 100 % KPI, en fast prosent per år, KPI begrenset til et tak, KPI med et gulv, eller markedsleieregulering til bestemte tidspunkter. Det er forhandlingsmakt og markedsbalansen som avgjør hva som avtales."
+---
+
+## Hva er KPI-regulering av leie?
+
+KPI-regulering er en klausul i næringsleiekontrakten som gir utleier rett — og ofte plikt — til å justere leien i samsvar med endringen i konsumprisindeksen (KPI). Hensikten er å bevare leieinntektenes kjøpekraft over tid. Uten KPI-regulering vil realverdien av en fast leie gradvis eroderes av inflasjonen.
+
+KPI-regulering er markedsstandard i norske næringsleiekontrakter og fremgår normalt av bransjens standardkontrakter (meglerstandarden). For [kontantstrømsanalyse](/help/article/kontantstromsanalyse) og verdivurdering er KPI-klausulen en av de mest verdirelevante bestemmelsene i avtalen.
+
+## Hvordan klausulen typisk er formulert
+
+Den vanligste formuleringen er **100 % KPI**: leien justeres hvert år med den prosentvise endringen i Statistisk sentralbyrås konsumprisindeks mellom to definerte referansemåneder.
+
+Et regneeksempel med generiske tall illustrerer mekanismen:
+
+<Math
+  formula="\text{Ny leie} = \text{Gammel leie} \times \left(1 + \frac{\Delta \text{KPI}}{100}\right)"
+  description="ΔKPI er den prosentvise endringen i konsumprisindeksen mellom to referansemåneder"
+/>
+
+Hvis gammel leie er 1 000 000 kr og KPI har steget 3,0 % siden referansepunktet:
+
+<Math
+  formula="\text{Ny leie} = 1\,000\,000 \times (1 + 0{,}03) = 1\,030\,000 \text{ kr}"
+  description="Generisk eksempel: 3 % KPI-vekst gir 30 000 kr høyere årsleie"
+/>
+
+Beløpene er kun illustrative; det er mekanismen som er poenget.
+
+## Betydningen for kontantstrømsanalysen
+
+I en [kontantstrømsanalyse](/help/article/kontantstromsanalyse) fremskrives leieinntektene år for år. KPI-reguleringsklausulen definerer vekstraten på den kontraktsfestede leien: med 100 % KPI-regulering vokser leien med KPI-antagelsen i modellen.
+
+<Note variant="info">
+  I en DCF-modell brukes typisk en langsiktig KPI-antagelse — for eksempel sentralbankens inflasjonsmål — som leievekstrate for KPI-regulerte kontrakter. Den faktiske KPI vil avvike, men antagelsen setter riktig strukturell vekst i modellen.
+</Note>
+
+Dersom kontrakten har **leietak (cap)** eller **leiegulv (floor)** på KPI-reguleringen, endres fremskrivingen: leien kan da ikke stige mer enn taket eller falle under gulvet, uansett hva KPI faktisk gjør. Dette begrenser oppsiden for utleier men gir leietaker forutsigbarhet.
+
+En [brutto leieinntekt](/help/article/brutto-leieinntekter)-analyse som ignorerer KPI-klausulen — og antar flat leie — vil systematisk undervurdere fremtidige leieinntekter i inflasjonsscenarier.
+
+## Forhandlingspunkter
+
+KPI-regulering er avtalefritt og forhandles mellom partene. De viktigste diskusjonspunktene er:
+
+**Andelen av KPI:** 100 % er standard, men i et svakt leiemarked kan leietaker forhandle frem en lavere andel — for eksempel 80 % KPI.
+
+**Tak og gulv:** Et maksimalt reguleringstak (for eksempel «ikke mer enn 4 % per år») gir leietaker forutsigbarhet. Et gulv («ikke mindre enn 2 % per år») sikrer utleier mot deflasjon eller lav inflasjon.
+
+**Referansemåned:** Valget av referansemåned (oktober er vanligst, men januar, juni og andre brukes) påvirker det konkrete reguleringstidspunktet og størrelsen det aktuelle regnskapsåret.
+
+**Markedsleieregulering:** I noen kontrakter suppleres KPI-regulering med rett til markedsleieregulering ved bestemte tidspunkter — for eksempel hvert femte år. Da kan leien justeres til markedsleie uavhengig av KPI-utviklingen.
+
+<Note variant="success">
+  I sterke leiemarkeder vil utleier foretrekke ren KPI uten tak. I leietakermarkeder er et tak på reguleringen gjerne en forutsetning for å få signert. Forhandlingen reflekterer alltid maktbalansen mellom partene.
+</Note>
+
+<Summary
+  title="Nøkkelpunkter om KPI-regulering"
+  points={[
+    {
+      title: "Bevarer realverdien",
+      description: "KPI-regulering sikrer at leieinntektenes kjøpekraft ikke eroderes av inflasjon over kontraktens løpetid.",
+      iconName: "barChart"
+    },
+    {
+      title: "100 % er standard",
+      description: "Den vanligste klausulen justerer leien med den fulle prosentvise KPI-endringen mellom to referansemåneder.",
+      iconName: "scales"
+    },
+    {
+      title: "Avgjørende i kontantstrømsanalysen",
+      description: "KPI-klausulen definerer vekstraten på leien i en DCF-modell. Å ignorere den gir systematisk feilprisede fremtidsinntekter.",
+      iconName: "lineChart"
+    },
+    {
+      title: "Forhandlbart",
+      description: "Andelen av KPI, tak, gulv og referansemåned er alle forhandlbare. Utfallet avhenger av maktbalansen mellom utleier og leietaker.",
+      iconName: "lightbulb"
+    }
+  ]}
+/>
+
+<CTA
+  badge="Modeller leievekst"
+  title="Fremskriv leieinntekter presist med Advanti"
+  description="Advanti lar deg bygge kontantstrømsmodeller med KPI-antagelser, tak og gulv — og ser hva ulike inflasjonsscenarier betyr for verdivurderingen."
+  primaryAction={{
+    label: "Prøv Advanti",
+    href: "/kontakt"
+  }}
+  secondaryAction={{
+    label: "Se alle funksjoner",
+    href: "/tjenester"
+  }}
+  size="default"
+/>

--- a/src/content/help/leiekontrakter-naringseiendom.mdx
+++ b/src/content/help/leiekontrakter-naringseiendom.mdx
@@ -75,7 +75,7 @@ Markedsstandarden for næringseiendom i Norge er typisk fem til ti år for konto
 
 I næringseiendom er det meste forhandlbart. De viktigste kommersielle vilkårene der forhandlingsresultatet varierer mest er:
 
-**Leienivå og leiefrie perioder.** Ny-utleie i et svakt marked kan gi leiefrie perioder (fra noen måneder til over ett år) eller bidrag til leietakers innredning. Nominell leie kan stå høy mens effektiv leie er lavere.
+**Leienivå og leiefrie perioder.** Nyutleie i et svakt marked kan gi leiefrie perioder (fra noen måneder til over ett år) eller bidrag til leietakers innredning. Nominell leie kan stå høy mens effektiv leie er lavere.
 
 **KPI-regulering.** Andelen av KPI, tak og gulv på reguleringen er forhandlingsbare. Se egen artikkel om [KPI-regulering av leie](/help/article/kpi-regulering-av-leie).
 

--- a/src/content/help/leiekontrakter-naringseiendom.mdx
+++ b/src/content/help/leiekontrakter-naringseiendom.mdx
@@ -2,7 +2,7 @@
 title: "Leiekontrakter i næringseiendom: typene du møter"
 publishedAt: 2026-06-12
 updatedAt: 2026-06-12
-summary: "Næringsleiekontrakter finnes i flere strukturer — brutto, netto og triple net. Lær standardstrukturen, «bare house»-prinsippet, hva som er forhandlbart, og hvilke klausuler som betyr mest for verdivurderingen."
+summary: "Næringsleiekontrakter finnes i flere strukturer — brutto, netto og triple net. Lær standardstrukturen, «bare house»-prinsippet og hva som er forhandlbart."
 author: codehagen
 categories:
   - terms

--- a/src/content/help/leiekontrakter-naringseiendom.mdx
+++ b/src/content/help/leiekontrakter-naringseiendom.mdx
@@ -1,0 +1,136 @@
+---
+title: "Leiekontrakter i næringseiendom: typene du møter"
+publishedAt: 2026-06-12
+updatedAt: 2026-06-12
+summary: "Næringsleiekontrakter finnes i flere strukturer — brutto, netto og triple net. Lær standardstrukturen, «bare house»-prinsippet, hva som er forhandlbart, og hvilke klausuler som betyr mest for verdivurderingen."
+author: codehagen
+categories:
+  - terms
+related:
+  - markedsleie-og-leieniva
+  - kpi-regulering-av-leie
+  - felleskostnader
+slug: leiekontrakter-naringseiendom
+faq:
+  - question: "Hva er meglerstandarden for næringsleie?"
+    answer: "Meglerstandarden er en bransjestandard leiekontrakt utarbeidet av næringsmeglerbransjen. Den regulerer det sentrale i leieforholdet på en balansert måte og brukes som utgangspunkt i de fleste næringsleieforhandlinger. Standarden er ikke lovpålagt — partene kan fritt avvike fra den gjennom forhandlinger."
+  - question: "Hva er forskjellen på bruttoleie og nettoleie i næringseiendom?"
+    answer: "I en bruttoleieavtale betaler leietaker én samlet sum som inkluderer husleie og driftskostnader — utleier bærer kostnadene. I en nettoleieavtale betaler leietaker husleie pluss de faktiske driftskostnadene separat. Nettoleie gir utleier lavere eierkostnader og mer forutsigbar nettoinntekt."
+  - question: "Hva er triple net-leie?"
+    answer: "Triple net (NNN) er en kontraktsstruktur der leietaker betaler husleie pluss alle løpende driftskostnader — herunder forsikring, eiendomsskatt og vedlikehold. Utleiers eierkostnader er minimale. Triple net er vanlig for store enkeltleietaker-bygg og gir svært forutsigbar nettoinntekt for eier."
+---
+
+<Note variant="warning">
+  Innholdet i denne artikkelen er generell informasjon om kontraktsstrukturer i næringseiendomsmarkedet — ikke juridisk rådgivning. Leiekontrakter kan ha store verdimessige konsekvenser. Kontakt alltid advokat med erfaring fra næringsleie for gjennomgang og forhandling av konkrete kontrakter.
+</Note>
+
+## Hva er en næringsleiekontrakt?
+
+En næringsleiekontrakt er avtalen mellom utleier og leietaker om bruk av et lokale til næringsformål. I motsetning til boligleie reguleres næringsleie i svært liten grad av husleieloven — avtalefriheten er stor, og partene forutsettes å være profesjonelle. Det betyr at forhandlingsresultatet i stor grad reflekterer maktbalansen mellom partene på avtaletidspunktet.
+
+De fleste næringsleiekontrakter tar utgangspunkt i **meglerstandarden** — en bransjestandard leiekontrakt som regulerer det sentrale i leieforholdet på en balansert måte. Standarden dekker leiesummen, leieperiodens lengde, oppsigelse og forlengelse, vedlikeholdsansvar, [KPI-regulering](/help/article/kpi-regulering-av-leie), [felleskostnader](/help/article/felleskostnader) og en rekke andre praktiske og kommersielle vilkår.
+
+## «Bare house»-prinsippet
+
+I profesjonell næringseiendom møter man ofte begrepet **bare house**: leietaker leier lokalet «som det er» og tar ansvar for innvendig vedlikehold, tekniske installasjoner og tilpasning til eget bruk. Utleier beholder ansvaret for byggets skall — fasade, tak og bærende konstruksjoner.
+
+«Bare house» er mer et prinsipp enn en fast kontraktstype. Det beskriver fordelingen av ansvar og risiko mellom partene: jo mer «bare house»-preget kontrakten er, desto mer av den løpende driftskostnaden bærer leietaker. For utleier gir dette lavere eierkostnader og mer forutsigbar nettoinntekt.
+
+## Kontraktsstrukturer: brutto, netto og triple net
+
+Valget av kontraktsstruktur er en av de viktigste kommersielle beslutningene i et leieforhold og har direkte konsekvenser for eiendomsverdien.
+
+<Stepper
+  items={[
+    {
+      title: "Bruttoleie",
+      content: "Leietaker betaler én samlet sum. Utleier bærer alle løpende driftskostnader og er eksponert for kostnadsvekst. Bruttoleie er vanligst i eldre kontrakter og for leietakere i svak forhandlingsposisjon. Utleiers eierkostnader er høye, noe som trekker ned netto yield.",
+    },
+    {
+      title: "Nettoleie",
+      content: "Leietaker betaler husleie pluss faktiske felleskostnader og eventuelle andre driftsposter separat — enten som à-konto med etterskuddsvis avregning eller som faktisk forbruk. Utleier bærer forsikring, eiendomsskatt og utvendig vedlikehold, men felleskostnadene viderebelastes leietaker. Nettoleie er markedsstandard i norsk næringseiendom.",
+    },
+    {
+      title: "Triple net (NNN)",
+      content: "Leietaker betaler husleie pluss alle løpende kostnader — inklusive forsikring, eiendomsskatt og vedlikehold som normalt ligger hos eier. Utleiers eierkostnader er minimale. Triple net er utbredt for store enkeltleietaker-eiendommer med lange kontrakter, og gir svært forutsigbar nettoinntekt for eier.",
+    }
+  ]}
+/>
+
+<Note variant="info">
+  I en verdivurdering er det avgjørende å forstå kontraktsstrukturen: to eiendommer med identisk nominell leie kan ha svært forskjellig netto yield dersom den ene er brutto og den andre er triple net. Sammenlign alltid på netto leieinntekter.
+</Note>
+
+## Varighet, oppsigelse og opsjoner
+
+Leiekontraktens **løpetid** er et sentralt verdiparameter. Lange kontrakter med solide leietakere gir forutsigbar kontantstrøm og prises lavere i yield enn kortvarige kontrakter med høyere re-utleierisiko.
+
+Markedsstandarden for næringseiendom i Norge er typisk fem til ti år for kontor og lengre for logistikk og spesialeiendom, men dette varierer med forhandlingsmakt og markedsforhold.
+
+**Opsjoner** — rett for leietaker til å forlenge kontrakten — er vanlig i næringsleie. En opsjon er verdifull for leietaker (som får forutsigbarhet) men innebærer at utleier binder seg til vilkårene i opsjonsperioden. For verdivurderingen betyr en lang opsjonskjede at leievilkårene som ble satt på signeringstidspunktet kan gjelde lenge — noe som er bra dersom leienivået er over markedsleie, men uheldig dersom det er under.
+
+**Oppsigelse** fra utleiers side er svært begrenset i næringsleie — partene binder seg til løpetiden. Fra leietakers side er oppsigelse i kontraktstiden normalt bare mulig ved vesentlig mislighold fra utleier.
+
+## Hva som er forhandlbart
+
+I næringseiendom er det meste forhandlbart. De viktigste kommersielle vilkårene der forhandlingsresultatet varierer mest er:
+
+**Leienivå og leiefrie perioder.** Ny-utleie i et svakt marked kan gi leiefrie perioder (fra noen måneder til over ett år) eller bidrag til leietakers innredning. Nominell leie kan stå høy mens effektiv leie er lavere.
+
+**KPI-regulering.** Andelen av KPI, tak og gulv på reguleringen er forhandlingsbare. Se egen artikkel om [KPI-regulering av leie](/help/article/kpi-regulering-av-leie).
+
+**Vedlikeholdsgrense.** Grensen for hva som regnes som løpende vedlikehold (leietakers ansvar) versus større arbeider (utleiers ansvar) er sentral og bør beskrives presist.
+
+**Fremleie og bruksendring.** Retten til å fremleie hele eller deler av lokalene, og til å endre bruksformål, er ofte forhandlet spesifikt.
+
+**Sikkerhet.** Depositum, bankgaranti eller morselskapsgaranti er standard. Størrelsen og formen forhandles konkret.
+
+## Kontraktens betydning for verdivurderingen
+
+En [verdivurdering av næringseiendom](/help/article/verdivurdering-av-naringseiendom) er i stor grad en analyse av den eksisterende leiekontrakten. Nøkkelparametere som analyseres inkluderer:
+
+- **Gjenværende kontraktstid (WAULT)** — vektet gjennomsnittlig gjenværende kontraktstid. Lang WAULT reduserer risiko og trekker ned yield-krav.
+- **Leietakerkvalitet** — Evne og vilje til å betjene leien gjennom kontrakten.
+- **Over- eller underleid** — Differansen mellom kontraktsfestet leie og [markedsleie](/help/article/markedsleie-og-leieniva). Overleid eiendom har risiko ved kontraktsforfall; underleid har oppsidepotensial.
+- **Kontraktsstruktur** — Netto versus brutto, KPI-klausul, opsjonstruktur.
+
+<Summary
+  title="Nøkkelpunkter om leiekontrakter"
+  points={[
+    {
+      title: "Avtalefrihet — med ansvar",
+      description: "Næringsleie reguleres i liten grad av husleieloven. Partene kan avtale nesten hva som helst — kontrakten er det viktigste dokumentet.",
+      iconName: "barChart"
+    },
+    {
+      title: "Struktur betyr mye for yield",
+      description: "Brutto, netto og triple net gir svært ulike eierkostnader og dermed ulik netto yield — selv ved identisk nominell leie.",
+      iconName: "scales"
+    },
+    {
+      title: "Varighet og opsjon er verdidrivere",
+      description: "Gjenværende kontraktstid (WAULT) og opsjonsstruktur er sentrale parametere i en verdivurdering — lang WAULT reduserer risiko.",
+      iconName: "lineChart"
+    },
+    {
+      title: "Bruk advokat",
+      description: "Næringsleiekontrakter kan ha store verdimessige konsekvenser. La alltid en advokat med næringsleieerfaring gjennomgå og forhandle konkrete avtaler.",
+      iconName: "lightbulb"
+    }
+  ]}
+/>
+
+<CTA
+  badge="Forstå leiebildet"
+  title="Analyser kontraktsporteføljen med Advanti"
+  description="Advanti hjelper deg å kartlegge leiekontrakter, beregne WAULT, analysere over- og underleid og forstå hva kontraktsbildet betyr for verdivurderingen."
+  primaryAction={{
+    label: "Prøv Advanti",
+    href: "/kontakt"
+  }}
+  secondaryAction={{
+    label: "Se alle funksjoner",
+    href: "/tjenester"
+  }}
+  size="default"
+/>

--- a/src/content/help/markedsleie-og-leieniva.mdx
+++ b/src/content/help/markedsleie-og-leieniva.mdx
@@ -1,7 +1,7 @@
 ---
 title: Markedsleie og leienivåer
 updatedAt: 2025-02-20
-summary: En grundig gjennomgang av markedsleie i næringseiendom - fra fastsettelse av leienivåer til analyse av markedstrender og prismekanismer.
+summary: "Markedsleie er leien et lokale oppnår ved ny utleie i dagens marked. Lær hva som driver leienivåene og hvordan markedsleie fastsettes i praksis."
 author: codehagen
 categories:
   - getting-started

--- a/src/content/help/prime-yield.mdx
+++ b/src/content/help/prime-yield.mdx
@@ -1,0 +1,127 @@
+---
+title: Prime yield vs sekundær yield
+publishedAt: 2026-06-12
+updatedAt: 2026-06-12
+summary: "Prime yield er markedets referansepunkt for prising av næringseiendom. Lær hva prime betyr, hva yield-spread forteller og slik brukes det i verdivurdering."
+author: codehagen
+categories:
+  - analysis
+related:
+  - hva-er-yield
+  - exit-yield
+  - hvordan-lese-markedsrapport
+slug: prime-yield
+faq:
+  - question: "Hva er prime yield i næringseiendom?"
+    answer: "Prime yield er avkastningskravet for den best kvalifiserte eiendommen i et marked — typisk med sentral beliggenhet, høy teknisk standard, lang gjenværende kontrakt og en solid leietaker. Prime yield brukes som markedets referansepunkt; alle andre eiendommer prises med et risikopåslag relativt til prime."
+  - question: "Hva forteller yield-spread mellom prime og sekundæreiendom?"
+    answer: "Yield-spread er differansen mellom prime yield og yield for sekundæreiendom. Et smalt spread betyr at investorer godtar lav risikopremie for å eie sekundæreiendom, typisk i oppgangsmarkeder med høy risikovilje. Et bredt spread signaliserer at markedet priser risiko tydeligere og at sekundæreiendom krever vesentlig høyere avkastningskrav."
+  - question: "Hvordan brukes prime yield i en verdivurdering?"
+    answer: "Prime yield brukes som ankerpunkt: analytikeren starter med prime yield og justerer opp basert på eiendomsspesifikke risikoer som beliggenhet, bygningskvalitet, leietakerprofil og gjenværende kontraktstid. I DCF-analyser er prime yield også referansepunkt for valget av exit yield ved analyseperiodens slutt."
+---
+
+## Hva er prime yield?
+
+[Prime yield](/help/article/prime-yield) er avkastningskravet for den best kvalifiserte eiendommen i et marked — og dermed markedets prisingspunkt for lavest mulig risiko i den aktuelle eiendomsklassen. Begrepet er sentralt i næringseiendom fordi det danner grunnlinjen som alle andre eiendommer prises relativt til. Se [hva er yield](/help/article/hva-er-yield) for en grundigere innføring i yield som begrep.
+
+## Hva kjennetegner en prime-eiendom?
+
+Ikke alle eiendommer kan kvalifisere som prime. Typisk må fire egenskaper være oppfylt samtidig:
+
+**Beliggenhet**: Eiendommen ligger i det mest etterspurte delmarkedet — typisk sentrum av en by eller i den ledende kontorklyngen. Beliggenhet er det viktigste enkeltkriteriet, og det kan ikke kompenseres av andre egenskaper.
+
+**Bygningskvalitet og teknisk standard**: Moderne bygningstekniske løsninger, energieffektivitet og fleksibilitet i planløsninger. Et eldre bygg kan ha god beliggenhet, men uten høy teknisk standard oppfyller det sjelden prime-kriteriet.
+
+**Lang gjenværende kontraktstid**: Prime-eiendommer kjennetegnes av lange leiekontrakter som gir trygg og forutsigbar kontantstrøm. Jo kortere gjenværende kontraktstid, desto mer usikker er fremtidig inntekt — og desto høyere avkastningskrav krever markedet.
+
+**Solid leietaker**: En leietaker med høy kredittverdighet og lav risiko for mislighold eller fraflytting. Offentlige aktører, store finansinstitusjoner og solide industrikonsern er typiske prime-leietakere.
+
+Dersom ett av disse kriteriene svikter — for eksempel at kontrakten nærmer seg forfall, at byggets standard er lav, eller at leietaker er liten og usikker — vil eiendommen prises med et risikopåslag ut fra prime: en høyere yield.
+
+<Note variant="info">
+  Definisjonen av «prime» er ikke standardisert på tvers av markedsrapporter. En rapport kan kreve ti år igjen på kontrakten for å kalle en eiendom prime, mens en annen setter grensen lavere. Det er viktig å forstå hvilken definisjon rapporten legger til grunn, slik at prime yield-tallene brukes korrekt som referansepunkt.
+</Note>
+
+## Yield-spread mot sekundæreiendom
+
+Differansen mellom prime yield og yield for sekundæreiendom kalles yield-spread. Den forteller noe om markedets samlede risikoappetitt og prisingsdisiplin.
+
+Et smalt spread betyr at investorer er villige til å betale nesten like mye for en sekundæreiendom som for prime. Det kan reflektere sterk konkurranse om eiendommer generelt, mangel på prime-tilbud som presser kapital mot sekundærsegmentet, eller en generell risikovilje i markedet.
+
+Et bredt spread betyr at investorer er mer selektive. Markedet priser risikoen tydeligere — sekundæreiendom krever vesentlig høyere avkastningskrav for at investorer skal se det som attraktivt.
+
+Spreaden er ikke statisk. Den endrer seg med markedssyklusen:
+
+- I oppgangsmarkeder med sterk risikovilje tenderer spreaden til å smal inn fordi kapital søker yield og presser prisene opp også i sekundærsegmentet.
+- I nedgangsmarkeder og perioder med usikkerhet tenderer spreaden til å utvide seg fordi investorer søker kvalitet. Sekundæreiendom blir vanskeligere å omsette, og prisingen justeres deretter.
+
+Spreaden er dermed et nyttig barometer på det generelle markedssentimentet, og et signal om hvorvidt markedet belønner eller straffer risiko på et gitt tidspunkt.
+
+## Hva prime yield ikke sier
+
+Prime yield er et kraftfullt referansepunkt, men det har reelle begrensninger man bør kjenne til:
+
+**Det er et vurdert estimat, ikke alltid en observert transaksjon.** Prime yield publisert i markedsrapporter er analytikernes vurdering av hva en prime-eiendom ville prises til under gjeldende markedsforhold. Det er ikke nødvendigvis et gjennomsnitt av faktiske prime-transaksjoner i siste kvartal — prime-eiendommer selges relativt sjelden.
+
+**Definisjoner varierer.** Som omtalt i artikkelen om [markedsrapporter](/help/article/hvordan-lese-markedsrapport), bruker ulike aktører ulike kriterier for hva som er prime. To rapporter kan publisere ulike prime yield-tall for «samme» marked fordi de definerer prime ulikt.
+
+**Prime finnes sjelden til salgs.** De beste eiendommene med de beste leietakerne på de lengste kontraktene holdes gjerne lenge av eierne. Markedsomsetningen av faktiske prime-eiendommer er begrenset, noe som gjør at prime yield-estimater tidvis er basert på et tynt transaksjonsgrunnlag.
+
+<Note variant="success">
+  Bruk prime yield som orienteringspunkt, men kombiner alltid med konkret transaksjonsevidens og en gjennomgang av den individuelle eiendomsprofilen. Et godt ankerpunkt er kun nyttig dersom justeringene fra ankerpunktet er velbegrunnede.
+</Note>
+
+## Prime yield i verdivurdering og DCF
+
+I en verdivurdering av en konkret eiendom er prime yield utgangspunktet for kalibrasjon av avkastningskravet. Analytikeren tar prime yield som referanse og justerer opp basert på eiendomsspesifikke risikoer:
+
+1. **Beliggenhet**: Rangert relativ til prime-delmarkedet — er eiendommen i kjernen eller i randsonen?
+2. **Bygningskvalitet**: Krever bygget snart betydelig rehabilitering, eller er teknisk standard høy og fremtidsrettet?
+3. **Leietakerprofil**: Er leietaker et solid konsern med lang historikk, eller et yngre selskap med usikker fremtid?
+4. **Gjenværende kontraktstid**: Kort restløpetid øker risikoen for ledighet og forhandlingssituasjon ved forfall.
+5. **Arealfleksibilitet**: Et bygg med mange små arealer er vanskeligere å leie ut igjen enn ett med fleksible etasjeplan.
+
+Resultatet av disse justeringene er eiendommens individuelle yield — kalibrert mot prime men tilpasset den faktiske risikoprofilen.
+
+I [DCF-analyser](/help/article/diskontert-kontantstrom) brukes prime yield dessuten som referansepunkt for valget av [exit yield](/help/article/exit-yield). Exit yield settes typisk noe høyere enn dagens prime yield for å reflektere fremtidig usikkerhet og byggets aldring — men selve basisnivået forankres i prime yield-observasjoner fra markedsrapporter.
+
+<Summary
+  title="Nøkkelpunkter om prime yield"
+  points={[
+    {
+      title: "Markedets referansepunkt",
+      description: "Prime yield er avkastningskravet for den best kvalifiserte eiendommen og danner grunnlinjen som alle andre eiendommer prises relativt til.",
+      iconName: "barChart"
+    },
+    {
+      title: "Fire prime-kriterier",
+      description: "Sentral beliggenhet, høy bygningskvalitet, lang gjenværende kontraktstid og solid leietaker — alle fire må typisk være oppfylt.",
+      iconName: "scales"
+    },
+    {
+      title: "Yield-spread forteller om risikoappetitt",
+      description: "Spreaden mellom prime og sekundær yield er et barometer på markedssentimentet. Smalt spread = høy risikovilje. Bredt spread = selektive investorer.",
+      iconName: "lineChart"
+    },
+    {
+      title: "Ankerpunkt i verdivurderingen",
+      description: "Start med prime yield, juster opp for eiendomsspesifikke risikoer. Samme prinsipp gjelder for exit yield-valg i DCF-analyser.",
+      iconName: "lightbulb"
+    }
+  ]}
+/>
+
+<CTA
+  badge="Verdivurdering"
+  title="Kalibrert yield-analyse med Advanti"
+  description="Advanti gir deg verktøy for yield-beregning, DCF-modeller og markedsdata — slik at du kan kalibrere avkastningskravet mot prime yield og eiendommens individuelle risikoprofil."
+  primaryAction={{
+    label: "Prøv Advanti",
+    href: "/kontakt"
+  }}
+  secondaryAction={{
+    label: "Se alle funksjoner",
+    href: "/tjenester"
+  }}
+  size="default"
+/>

--- a/src/content/help/prime-yield.mdx
+++ b/src/content/help/prime-yield.mdx
@@ -52,7 +52,7 @@ Et bredt spread betyr at investorer er mer selektive. Markedet priser risikoen t
 
 Spreaden er ikke statisk. Den endrer seg med markedssyklusen:
 
-- I oppgangsmarkeder med sterk risikovilje tenderer spreaden til å smal inn fordi kapital søker yield og presser prisene opp også i sekundærsegmentet.
+- I oppgangsmarkeder med sterk risikovilje tenderer spreaden til å smalne inn fordi kapital søker yield og presser prisene opp også i sekundærsegmentet.
 - I nedgangsmarkeder og perioder med usikkerhet tenderer spreaden til å utvide seg fordi investorer søker kvalitet. Sekundæreiendom blir vanskeligere å omsette, og prisingen justeres deretter.
 
 Spreaden er dermed et nyttig barometer på det generelle markedssentimentet, og et signal om hvorvidt markedet belønner eller straffer risiko på et gitt tidspunkt.

--- a/src/content/help/sensitivitetsanalyse.mdx
+++ b/src/content/help/sensitivitetsanalyse.mdx
@@ -219,6 +219,8 @@ For å bedre forstå hvordan ulike faktorer påvirker eiendomsverdien, kan vi br
   ]}
 />
 
+Vil du se metoden brukt på en konkret investeringscase? Les [slik stressetester du en eiendomsinvestering med sensitivitetsanalyse](/blog/sensitivitetsanalyse-naringseiendom) for en praktisk gjennomgang med regneeksempler og scenariomodellering — fra identifisering av nøkkelvariable til tolkning av worst case-utfall.
+
 <CTA
   badge="Analyser nå"
   title="Utfør profesjonelle sensitivitetsanalyser med Advanti"

--- a/src/content/help/sensitivitetsanalyse.mdx
+++ b/src/content/help/sensitivitetsanalyse.mdx
@@ -1,7 +1,7 @@
 ---
 title: Sensitivitetsanalyse i næringseiendom
 updatedAt: 2025-02-18
-summary: En omfattende guide til sensitivitetsanalyse i næringseiendom - forstå hvordan ulike faktorer påvirker eiendomsverdien.
+summary: "Hvor robust er eiendomsverdien hvis yield eller leie endrer seg? Sensitivitetsanalyse viser hvilke forutsetninger som betyr mest for verdien."
 author: codehagen
 categories:
   - terms

--- a/src/content/help/skatt-avskrivninger-naringseiendom.mdx
+++ b/src/content/help/skatt-avskrivninger-naringseiendom.mdx
@@ -1,0 +1,139 @@
+---
+title: "Skatt og avskrivninger på næringseiendom"
+publishedAt: 2026-06-12
+updatedAt: 2026-06-12
+summary: "Saldoavskrivninger reduserer skattebelastningen og påvirker kontantstrøm etter skatt. Lær systemet, skillet mellom tomt, bygg og teknisk installasjon, og formuesskatt."
+author: codehagen
+categories:
+  - for-investors
+related:
+  - aksjekjop-vs-innmatskjop
+  - kontantstromsanalyse
+  - eierkostnader
+slug: skatt-avskrivninger-naringseiendom
+faq:
+  - question: "Kan man avskrive tomt skattemessig?"
+    answer: "Nei. Tomteverdi kan ikke avskrives skattemessig. Kun bygget og faste tekniske installasjoner er avskrivbare. Det er derfor viktig å skille klart mellom tomteverdi, bygningsverdien og tekniske installasjoner i kjøpesummen — fordelingen påvirker avskrivningsgrunnlaget og dermed fremtidige skattefradrag."
+  - question: "Hva er saldoavskrivning?"
+    answer: "Saldoavskrivning er det norske systemet for skattemessig avskrivning av driftsmidler. I stedet for lineær avskrivning på samme beløp hvert år, beregnes avskrivningen som en fast prosentandel av den gjenstående saldoverdien. Systemet gir høyest avskrivning i de tidlige årene og deretter gradvis lavere fradrag over tid."
+  - question: "Hva er forskjellen på skattemessig og regnskapsmessig avskrivning?"
+    answer: "Regnskapsmessig avskrivning følger regnskapsreglene (NGAAP) og kan settes til antatt faktisk verdifall. Skattemessig avskrivning følger skattelovens saldosystem med faste satser etter gruppe — og denne avskrivningen er den som gir faktiske skattefradrag. De to kan avvike vesentlig, og det er den skattemessige saldoverdien som er relevant for den latente skatteberegningen ved transaksjoner."
+---
+
+<Note variant="warning">
+  Denne artikkelen er generell informasjon om skatt og avskrivninger på næringseiendom — ikke skatterådgivning. Reglene er komplekse, endres over tid og anvendes ulikt avhengig av eierstruktur og eiendomstype. Involver alltid kvalifisert skatterådgiver for konkrete vurderinger.
+</Note>
+
+Avskrivninger er en av de viktigste skattemessige mekanismene for eiendomsinvestorer. De reduserer skattbart overskudd, påvirker kontantstrøm etter skatt, og danner grunnlaget for beregningen av latent skatt ved transaksjoner. En grunnleggende forståelse av avskrivningssystemet er nødvendig for å analysere eiendomsinvesteringer korrekt.
+
+## Saldoavskrivningssystemet
+
+Norsk skattelov benytter et saldoavskrivningssystem for driftsmidler. Driftsmidlene deles inn i saldogrupper basert på type — og hvert år avskrives en fast prosentandel av den gjenstående saldoverdien i gruppen.
+
+Saldoavskrivning er **degressiv**: avskrivningsbeløpet er høyest i de første årene og faller gradvis over tid etter hvert som saldoverdien synker. Dette skiller seg fra lineær avskrivning, der samme beløp avskrives hvert år.
+
+<Note variant="info">
+  De konkrete saldosatsene for de ulike gruppene fastsettes av Stortinget og kan endres. Denne artikkelen beskriver systemet kvalitativt uten å oppgi konkrete satser, ettersom satsene bør verifiseres mot gjeldende regelverk hos Skatteetaten (skatteetaten.no) ved praktisk bruk.
+</Note>
+
+## Skillet tomt — bygg — teknisk installasjon
+
+Det kanskje viktigste prinsippet i eiendomsskatteretten er at **tomt ikke kan avskrives**. Tomteverdien er ikke et saldodriftsmiddel og gir ingen skattemessig fradragsrett. Kun bygningsdelen og faste tekniske installasjoner er avskrivbare.
+
+Dette skillet er praktisk viktig ved kjøp. Dersom en eiendom er kjøpt til en samlet sum, må kjøpesummen fordeles mellom:
+
+1. **Tomt** — ingen avskrivning
+2. **Bygningsdelen** — avskrives i sin saldogruppe
+3. **Fast teknisk installasjon** — avskrives i en separat, gunstigere saldogruppe
+
+Fordelingen er ikke alltid åpenbar og bør fastsettes av en fagperson. En høyere andel til tekniske installasjoner gir raskere avskrivning og høyere skattefradrag i tidlige år — noe som er verdifullt for kontantstrøm etter skatt.
+
+## Saldogruppene for næringseiendom
+
+To saldogrupper er særlig relevante for næringseiendom:
+
+**Forretningsbygg** (kontorbygg, lagerbygg, handelsbygg og lignende) avskrives i en bestemt saldogruppe med lav avskrivningssats. Den lave satsen reflekterer at bygningsstrukturen forventes å ha lang levetid.
+
+**Fast teknisk installasjon i bygninger** — herunder ventilasjonssystemer, elektriske anlegg, heis, sprinkler og liknende — avskrives i en separat saldogruppe med en merkbart høyere sats enn selve bygningsdelen. Dette er et strukturelt insentiv til å skille ut tekniske installasjoner som eget saldodriftsmiddel.
+
+Fordelene ved å allokere en større del av kjøpesummen til tekniske installasjoner fremfor bygget er:
+- Høyere avskrivningssats gir høyere fradrag tidlig i eierperioden
+- Bedre kontantstrøm etter skatt i de første årene
+- Men: tekniske installasjoner utgjør realistisk sett en begrenset andel av et byggs verdi, og allokering må reflektere faktisk verdi
+
+## Avskrivninger og kontantstrøm etter skatt
+
+Avskrivninger er **ikke** en kontantutgift — de er et regnskapsmessig og skattemessig fradrag uten at penger faktisk forlater selskapet. Denne egenskapen gjør avskrivninger til en effektiv skatteoptimering.
+
+Mekanismen er slik: Et selskap med netto leieinntekter på eksempelvis 5 millioner kroner og skattemessige avskrivninger på 1 million kroner, skatter bare av 4 millioner. Selskapsskatten (for tiden 22 prosent i Norge) beregnes på det lavere grunnlaget, og dermed frigjøres kapital som forblir i selskapet.
+
+En fullstendig [kontantstrømsanalyse](/help/article/kontantstromsanalyse) av en næringseiendom bør alltid inkludere en modellering av skattemessige avskrivninger og effektiv skattebelastning — fordi disse faktorene påvirker hva investoren faktisk sitter igjen med etter skatt.
+
+<Note variant="info">
+  I en DCF-analyse (diskontert kontantstrøm) er det vanlig å beregne kontantstrøm både før og etter skatt. Avskrivningenes verdi synker over tid etter hvert som saldoverdien faller — det betyr at skattefordelen gradvis reduseres gjennom eierperioden.
+</Note>
+
+## Avskrivninger og latent skatt
+
+Samspillet mellom avskrivninger og latent skatt er sentralt i eiendomstransaksjoner. Hvert år en eiendom avskrives skattemessig, synker saldoverdien. Dersom markedsverdien stiger eller holder seg stabil mens saldoverdien faller, vokser differansen — og dermed den potensielle skatteforpliktelsen ved en fremtidig realisering.
+
+Denne merverdien — differansen mellom markedsverdi og skattemessig saldoverdi — representerer **latent skatt**. Kjøper som overtar et eiendomsselskap med lang historikk og lave saldoverdier, overtar også en stor latent skatteforpliktelse. Les mer om dette i artikkelen om [aksjekjøp eller innmatskjøp](/help/article/aksjekjop-vs-innmatskjop).
+
+## Formuesskatt på næringseiendom
+
+Privatpersoner som eier næringseiendom direkte eller indirekte gjennom selskaper, kan være eksponert for formuesskatt. Formuesskatt beregnes av nettoformuen over et bunnfradrag, med en sats på grunnbeløpet.
+
+For næringseiendom fastsettes formueverdien normalt med utgangspunkt i en beregnet utleieverdi kapitalisert med en offentlig sats — en metode som historisk har gitt lavere formuesverdi enn reell markedsverdi for næringseiendommer. Sekundærbolig og primærbolig verdsettes ulikt fra næringseiendom.
+
+Formuesskatt er en kostnad som påvirker investorens totalavkastning og bør inkluderes i investeringsanalysen, særlig for personlige investorer med store eiendomsposisjoner.
+
+## Vedlikeholdskostnader vs. påkostninger
+
+Et relatert skattemessig skille er det mellom **vedlikeholdskosnader** og **påkostninger**:
+
+**Vedlikeholdskostnader** er utgifter til å opprettholde eiendommens eksisterende stand — utskifting av som-ny, løpende reparasjoner, maling. Disse er normalt direkte fradragsberettigede i inntektsåret og gir umiddelbar skatteeffekt.
+
+**Påkostninger** er utgifter som forbedrer eiendommen utover dens opprinnelige stand — en utvidelse, en oppgradering til høyere standard. Påkostninger aktiveres og avskrives over tid via saldosystemet, ikke fradragsføres direkte.
+
+Grensedragningen mellom vedlikehold og påkostning er ikke alltid enkel og er en kilde til skattemessige diskusjoner. God dokumentasjon av arbeidene — hva som er gjort, og hva formålet er — er viktig for korrekt klassifisering. Se [eierkostnader](/help/article/eierkostnader) for mer om kostnadstruktur fra et driftsperspektiv.
+
+<Summary
+  title="Nøkkelpunkter om skatt og avskrivninger"
+  points={[
+    {
+      title: "Tomt kan ikke avskrives",
+      description: "Fordeling av kjøpesummen mellom tomt, bygg og tekniske installasjoner er skattemessig viktig. Tekniske installasjoner avskrives raskere enn bygget.",
+      iconName: "barChart"
+    },
+    {
+      title: "Avskrivninger er ikke en kontantutgift",
+      description: "Saldoavskrivninger reduserer skattbart overskudd uten å kreve utbetaling — og gir bedre kontantstrøm etter skatt i eierperioden.",
+      iconName: "scales"
+    },
+    {
+      title: "Latent skatt vokser med avskrivningene",
+      description: "Jo lengre en eiendom er eid og avskrevet, desto større er differansen mellom markedsverdi og saldoverdi — og desto større er latent skatteforpliktelse.",
+      iconName: "lineChart"
+    },
+    {
+      title: "Bruk skatterådgiver",
+      description: "Reglene er komplekse og kan endre seg. Skattemessig optimering av eiendomsportefølje bør alltid gjøres med hjelp av kvalifisert skatterådgiver.",
+      iconName: "lightbulb"
+    }
+  ]}
+/>
+
+<CTA
+  badge="Forstå skattebildet"
+  title="Analyser kontantstrøm etter skatt med Advanti"
+  description="Advanti hjelper deg å modellere eiendomsinvesteringen med korrekte avskrivninger og skatteeffekter — slik at du ser den reelle avkastningen."
+  primaryAction={{
+    label: "Ta kontakt",
+    href: "/kontakt"
+  }}
+  secondaryAction={{
+    label: "Les om kontantstrømsanalyse",
+    href: "/help/article/kontantstromsanalyse"
+  }}
+  size="default"
+/>

--- a/src/content/help/skatt-avskrivninger-naringseiendom.mdx
+++ b/src/content/help/skatt-avskrivninger-naringseiendom.mdx
@@ -89,7 +89,7 @@ Formuesskatt er en kostnad som påvirker investorens totalavkastning og bør ink
 
 ## Vedlikeholdskostnader vs. påkostninger
 
-Et relatert skattemessig skille er det mellom **vedlikeholdskosnader** og **påkostninger**:
+Et relatert skattemessig skille er det mellom **vedlikeholdskostnader** og **påkostninger**:
 
 **Vedlikeholdskostnader** er utgifter til å opprettholde eiendommens eksisterende stand — utskifting av som-ny, løpende reparasjoner, maling. Disse er normalt direkte fradragsberettigede i inntektsåret og gir umiddelbar skatteeffekt.
 

--- a/src/content/help/skatt-avskrivninger-naringseiendom.mdx
+++ b/src/content/help/skatt-avskrivninger-naringseiendom.mdx
@@ -2,7 +2,7 @@
 title: "Skatt og avskrivninger på næringseiendom"
 publishedAt: 2026-06-12
 updatedAt: 2026-06-12
-summary: "Saldoavskrivninger reduserer skattebelastningen og påvirker kontantstrøm etter skatt. Lær systemet, skillet mellom tomt, bygg og teknisk installasjon, og formuesskatt."
+summary: "Saldoavskrivninger reduserer skattebelastningen og påvirker kontantstrøm etter skatt. Lær systemet, skillet mellom tomt, bygg og teknisk installasjon."
 author: codehagen
 categories:
   - for-investors

--- a/src/content/help/tjene-mer-pa-naringseiendom.mdx
+++ b/src/content/help/tjene-mer-pa-naringseiendom.mdx
@@ -9,6 +9,7 @@ related:
   - felleskostnader
   - driftskostnader
   - verdivurdering-av-naringseiendom
+  - finansiering-av-naringseiendom
 slug: tjene-mer-pa-naringseiendom
 ---
 

--- a/src/content/help/yield-gap.mdx
+++ b/src/content/help/yield-gap.mdx
@@ -56,7 +56,7 @@ Yield gap er et nyttig bakteppebegrep for vurdering av eiendomsinvesteringer i e
 - **Hva er bufferkapasiteten?** Et bredt yield gap gir rom for at rentene kan stige noe uten at eiendom umiddelbart blir uattraktivt priset.
 
 <Note variant="info">
-  Yield gap er en markedsindikator, ikke en fasit. En eiendom med smal yield gap kan fortsatt være en god investering dersom leieinntektene er særlig sikre og stabile. Analysen bør alltid kombineres med en vurdering av kontrakts- og leietakerkvalitet, og med en [sensitivitetsanalyse](/help/article/sensitivitetsanalyse) av rentescenarier.
+  Yield gap er en markedsindikator, ikke en fasit. En eiendom med smalt yield gap kan fortsatt være en god investering dersom leieinntektene er særlig sikre og stabile. Analysen bør alltid kombineres med en vurdering av kontrakts- og leietakerkvalitet, og med en [sensitivitetsanalyse](/help/article/sensitivitetsanalyse) av rentescenarier.
 </Note>
 
 ## Yield gap i kontantstrømsanalysen

--- a/src/content/help/yield-gap.mdx
+++ b/src/content/help/yield-gap.mdx
@@ -1,0 +1,105 @@
+---
+title: "Yield gap: eiendomsyield mot rente"
+publishedAt: 2026-06-12
+updatedAt: 2026-06-12
+summary: "Yield gap er differansen mellom eiendomsyield og risikofri rente — en målestokk for risikopremien investorer krever. Lær hva gapet sier om prisnivå og rentesensitivitet."
+author: codehagen
+categories:
+  - terms
+related:
+  - hva-er-yield
+  - exit-yield
+  - diskontert-kontantstrom
+slug: yield-gap
+faq:
+  - question: "Hva er yield gap i næringseiendom?"
+    answer: "Yield gap er differansen mellom eiendomsyield og en referanserente — vanligvis en risikofri statsobligasjonsrente eller en swap-rente med tilsvarende løpetid. Gapet representerer den meravkastningen investoren krever for å bære risikoen knyttet til eiendomsinvesteringen fremfor en risikofri plassering."
+  - question: "Hva betyr et smalt yield gap?"
+    answer: "Et smalt yield gap betyr at eiendom er priset nær rentemarkedet — investorer godtar liten risikopremie. Dette kan signalisere at eiendom er høyt priset relativt til rentene, og at prissensitiviteten for renteendringer er stor. Et bredere gap gir mer buffer mot renteoppgang."
+  - question: "Hvordan påvirker renteøkninger eiendomsverdier?"
+    answer: "Når risikofri rente stiger, må eiendomsyield typisk stige tilsvarende for å opprettholde et rimelig yield gap. Siden yield og verdi er inverse størrelser — høyere yield betyr lavere verdi gitt samme netto leieinntekt — fører renteøkninger til press nedover på eiendomspriser."
+---
+
+## Hva er yield gap?
+
+[Yield gap](/help/article/yield-gap) er differansen mellom [eiendomsyield](/help/article/hva-er-yield) og en risikofri referanserente — typisk en statsobligasjonsrente eller en swap-rente med løpetid tilsvarende en typisk leiekontrakt. Gapet er en direkte målestokk på den risikopremien markedet setter på eiendomsinvesteringer relativt til rentebærende instrumenter uten kreditrisiko.
+
+<Math
+  formula="\text{Yield gap} = \text{Eiendomsyield} - \text{Risikofri rente}"
+  description="Yield gap måles typisk mot en statsobligasjonsrente eller swap-rente med relevant løpetid"
+/>
+
+## Yield gap som risikopremie
+
+Investorer i næringseiendom tar på seg risiko som ikke finnes i en statsobligasjon: ledighetsrisiko, leietakerrisiko, teknisk risiko i bygget, likviditetsrisiko i transaksjonen og usikkerhet om fremtidig verdiutvikling. Yield gap er markedets aggregerte pris for denne risikoen.
+
+Et bredt yield gap betyr at eiendom gir vesentlig høyere avkastning enn risikofri rente — eiendom er priset rimelig relativt til rentemarkedet, og investorene kompenseres godt for risikoen. Et smalt yield gap betyr at prisingen av eiendom er nær rentemarkedet — lite rom for renteoppgang uten at eiendomsverdiene presses ned.
+
+<Note variant="info">
+  Yield gap er ikke en fast størrelse. Det varierer over tid med markedssentiment, tilbud og etterspørsel etter eiendom, og ikke minst med rentenivået. I perioder med fallende renter har yield gap i mange markeder blitt svært smale, noe som reflekterer at eiendom har blitt priset som et kvasi-obligasjonsprodukt.
+</Note>
+
+## Hvordan renteendringer presser eiendomsverdier
+
+Mekanismen er direkte: eiendomsverdien er netto leieinntekter delt på yield. Når risikofri rente stiger, vil investorer forvente at eiendomsyield følger etter — ellers er risikopremien ikke tilstrekkelig. Men leieinntektene endrer seg ikke umiddelbart med renten. Resultatet er at yield må opp, og når yield går opp, går verdien ned.
+
+Matematikken er enkel å illustrere: en eiendom med gitte netto leieinntekter og en gitt yield har en beregnet verdi. Dersom markedet krever ett prosentpoeng høyere yield for å gjenspeile renteoppgangen, faller verdien — og fallet er ikke lineært, men akselererer jo lavere utgangsnivå på yield.
+
+Dette er årsaken til at eiendommer med svært lav yield er spesielt eksponert for renteoppgang: selv en moderat renteøkning kan gi stor relativ verdinedgang.
+
+## Hva investor bør se på
+
+Yield gap er et nyttig bakteppebegrep for vurdering av eiendomsinvesteringer i et renteperspektiv. Det gir svar på spørsmål som:
+
+- **Er eiendom priset rimelig relativt til alternativene?** Et historisk lavt yield gap kan indikere at investorer godtar lav risikopremie.
+- **Hva er rentesensitiviteten?** Eiendommer med smalt yield gap og lav absolutt yield er mest utsatt ved renteoppgang.
+- **Hva er bufferkapasiteten?** Et bredt yield gap gir rom for at rentene kan stige noe uten at eiendom umiddelbart blir uattraktivt priset.
+
+<Note variant="info">
+  Yield gap er en markedsindikator, ikke en fasit. En eiendom med smal yield gap kan fortsatt være en god investering dersom leieinntektene er særlig sikre og stabile. Analysen bør alltid kombineres med en vurdering av kontrakts- og leietakerkvalitet, og med en [sensitivitetsanalyse](/help/article/sensitivitetsanalyse) av rentescenarier.
+</Note>
+
+## Yield gap i kontantstrømsanalysen
+
+I en [DCF-analyse](/help/article/diskontert-kontantstrom) er forholdet mellom eiendomsyield og rente innbakt i diskonteringsrenten: diskonteringsrenten settes typisk som sum av risikofri rente, markedsrisikopremie og eiendomsspesifikk risiko. Exit yield-antagelsen bør likeledes reflektere et rimelig yield gap på et fremtidig tidspunkt — noe som betyr at exit yield bør settes med bevisst forhold til rentescenarier.
+
+<Summary
+  title="Nøkkelpunkter om yield gap"
+  points={[
+    {
+      title: "Differansen mot renten",
+      description: "Yield gap er eiendomsyield minus risikofri rente — den kompensasjonen investorer krever for eiendomsrisiko relativt til sikre renteplasseringer.",
+      iconName: "barChart"
+    },
+    {
+      title: "Smalt gap, høy sensitivitet",
+      description: "Et smalt yield gap betyr at eiendom er priset nær rentemarkedet. Da er verdiene mer utsatt for verdifall ved renteoppgang.",
+      iconName: "scales"
+    },
+    {
+      title: "Renteoppgang presser yield",
+      description: "Når renten stiger, følger eiendomsyield vanligvis etter. Siden yield og verdi er inverse, faller eiendomsverdier når yield øker.",
+      iconName: "lineChart"
+    },
+    {
+      title: "Kombiner med andre analyser",
+      description: "Yield gap er et bakteppebegrep. Kombiner alltid med kontrakts- og leietakervurdering og sensitivitetsanalyse av rentescenarier.",
+      iconName: "lightbulb"
+    }
+  ]}
+/>
+
+<CTA
+  badge="Forstå markedet"
+  title="Analyser risikopremie og yield gap med Advanti"
+  description="Advanti gir deg verktøy for yield-analyse, DCF-modeller og sensitivitetstesting — slik at du forstår eiendommens rentesensitivitet."
+  primaryAction={{
+    label: "Prøv Advanti",
+    href: "/kontakt"
+  }}
+  secondaryAction={{
+    label: "Se alle funksjoner",
+    href: "/tjenester"
+  }}
+  size="default"
+/>

--- a/src/content/help/yield-gap.mdx
+++ b/src/content/help/yield-gap.mdx
@@ -2,7 +2,7 @@
 title: "Yield gap: eiendomsyield mot rente"
 publishedAt: 2026-06-12
 updatedAt: 2026-06-12
-summary: "Yield gap er differansen mellom eiendomsyield og risikofri rente — en målestokk for risikopremien investorer krever. Lær hva gapet sier om prisnivå og rentesensitivitet."
+summary: "Yield gap er differansen mellom eiendomsyield og risikofri rente — risikopremien investorer krever. Lær hva gapet sier om prisnivå og rentesensitivitet."
 author: codehagen
 categories:
   - terms

--- a/src/styles/advanti-design.css
+++ b/src/styles/advanti-design.css
@@ -3929,6 +3929,36 @@ h1, h2, h3 {
 }
 .ks-feedback button:hover { background: var(--warm-grey); color: var(--warm-white); border-color: var(--warm-grey); }
 
+/* FAQ section */
+.ks-faq {
+  margin-top: 56px;
+  border-top: var(--hairline);
+  padding-top: 40px;
+}
+.ks-faq h2 {
+  font-family: var(--font-display);
+  font-size: 26px;
+  font-weight: 400;
+  letter-spacing: -0.015em;
+  margin-bottom: 32px;
+}
+.ks-faq-item {
+  padding: 20px 0;
+  border-bottom: var(--hairline);
+}
+.ks-faq-item h3 {
+  font-family: var(--font-display);
+  font-size: 18px;
+  font-weight: 500;
+  letter-spacing: -0.01em;
+  margin-bottom: 10px;
+}
+.ks-faq-item p {
+  font-size: 15px;
+  line-height: 1.65;
+  color: var(--warm-grey-85);
+}
+
 /* Related articles */
 .ks-related {
   margin-top: 56px;


### PR DESCRIPTION
## Sammendrag

Fire implementasjonsplaner fra improve-gjennomgangen av kunnskapssenteret (/help), utført av executor-agenter i isolerte worktrees og reviewet plan for plan (alle done-kriterier re-kjørt av reviewer før godkjenning).

### Plan 009 — Tekniske SEO-fikser
- Tomme help-kategorier gates ut av sitemap + får `noindex` til de har innhold (selvopphevende)
- `author: "christer"` → `codehagen` (forfatterboks + Person-@id i Article-schema tilbake på mest populære artikkel)
- Ekte `datePublished` (nytt `publishedAt`-felt) + `timeRequired`/`articleSection` i Article-JSON-LD
- FAQ-infrastruktur: `faq:`-frontmatter → synlig seksjon + FAQPage-JSON-LD fra samme kilde (kan ikke drifte)

### Plan 010 — Pilarside + meta descriptions
- «Hva er næringseiendom? En komplett guide»: 292 → 1542 ord (6 kategorier, sammenligningstabell, verdsettelse, investeringsveier, Nord-Norge, begrepslenker, FAQ)
- 7 formelaktige summaries («En omfattende guide til …») erstattet med unike, intensjonsdrevne meta descriptions

### Plan 011 — 15 nye artikler (12 → 27 totalt)
- **Begreper (7):** brutto leieinntekter, eierkostnader, exit yield, yield gap, KPI-regulering, leiekontrakter, arealbegreper (BTA/BRA)
- **For investorer (5, tidligere tom kategori):** kjøpsprosessen (m/ HowTo-schema, verbatim-speilet), due diligence, finansiering, aksje- vs innmatskjøp, skatt/avskrivninger
- **Markedsanalyse (3, tidligere tom kategori):** lese markedsrapport, kontorledighet, prime yield
- Full intern lenkevev + FAQ på alle nye artikler

### Plan 012 — Blog↔help-avkannibalisering
- Sensitivitetsanalyse-blogposten retittlert mot praktisk stresstest-intensjon; definisjonen lenkes til help
- Kryss-lenker begge veier for både sensitivitetsanalyse- og DCF-paret
- Rolleregel: help = kanonisk begrep («hva er X»), blog = praktisk/aktuelt

## Innholdsregler fulgt
- **Ingen markedstall** (yield-nivåer, kr/kvm, ledighet per by) i noen artikkel — kun offentlige satser (dokumentavgift 2,5 %, selskapsskatt 22 %) og generiske regneeksempler
- Juridisk/skattemessig disclaimer (`Note variant="warning"`) på kontrakt- og skatteartiklene
- Saldosatser bevisst utelatt (kunne ikke verifiseres mot skatteetaten.no ved skrivetidspunkt)

## Verifikasjon
- `pnpm build` exit 0 (148 statiske sider), `pnpm test:unit` 69/69
- Live-gates verifisert mot prod-server: 27 artikler i sitemap, begge nye kategorier indeksert uten noindex, FAQPage- og HowTo-JSON-LD rendres, ny bloggtittel live
- Kjente pre-eksisterende feil (urørt av denne PR-en): `pnpm typecheck`-feil i `tests/unit/naringsmegler.test.ts`, Playwright-feil i analyseportal/markedsinnsikt-specs

## Oppfølging etter merge
- Valider søkeord mot Google Search Console etter 4–8 uker; juster titler/summaries etter CTR
- Vurder å oppdatere `POPULAR_ARTICLES` når trafikkdata foreligger
- `markedsleie-og-leieniva.mdx` har pre-eksisterende historiske kr/kvm-tall — verdt en proofstats-sjekk (egen sak)

🤖 Generated with [Claude Code](https://claude.com/claude-code)