### PR TITLE
feat(verktoy): næringskalkulator — yield-basert verdiestimat

### DIFF
--- a/src/app/verktoy/naringskalkulator/page.tsx
+++ b/src/app/verktoy/naringskalkulator/page.tsx
@@ -1,0 +1,105 @@
+import { CtaStrip } from "@/components/site/CtaStrip";
+import { SubHero } from "@/components/site/SubHero";
+import { NaringskalkulatorClient } from "@/components/verktoy/NaringskalkulatorClient";
+import { constructMetadata } from "@/lib/utils";
+
+export const metadata = constructMetadata({
+  path: "/verktoy/naringskalkulator",
+  title: "Næringskalkulator | Verdiestimat på næringseiendom | Advanti Estate",
+  description:
+    "Regn ut et verdiestimat for næringseiendommen din på minuttet. Yield-basert anslag på markedsverdi for Nord-Norge — et godt utgangspunkt før en presis verdivurdering.",
+});
+
+export default function NaringskalkulatorPage() {
+  return (
+    <>
+      <SubHero
+        crumb={[
+          { label: "Hjem", href: "/" },
+          { label: "Verktøy", href: "/verktoy" },
+          { label: "Næringskalkulator" },
+        ]}
+        eyebrow="Verktøy · Verdiestimat på minuttet"
+        title={
+          <>
+            Regn ut et <span className="italic">verdiestimat</span> <br />
+            for næringseiendommen din.
+          </>
+        }
+        lede="Legg inn noen få tall, så får du et øyeblikkelig anslag på markedsverdi — basert på samme yield-metodikk vi bruker i ekte verdivurderinger. Et godt utgangspunkt før den presise vurderingen."
+      />
+
+      {/* CALCULATOR */}
+      <section className="section section-divider" style={{ paddingTop: 64 }}>
+        <div className="wrap">
+          <NaringskalkulatorClient />
+        </div>
+      </section>
+
+      {/* SLIK REGNER VI */}
+      <section className="section">
+        <div className="wrap">
+          <div className="head-compact">
+            <span className="eyebrow">Metoden bak tallet</span>
+            <div>
+              <h2>
+                Samme prinsipp som{" "}
+                <span className="italic">en ekte vurdering.</span>
+              </h2>
+              <p>
+                Kalkulatoren bruker en forenklet yield-betraktning. Den gir et
+                godt utgangspunkt — men erstatter ikke en faglig vurdering av
+                kontrakter, beliggenhet og tilstand.
+              </p>
+            </div>
+          </div>
+
+          <div className="feat-3">
+            <div className="feat">
+              <div className="num">I</div>
+              <h3>Netto leieinntekt</h3>
+              <p>
+                Vi tar brutto leie, trekker fra forventet ledighet og
+                eierkostnader, og står igjen med netto leieinntekt (NOI) — det
+                eiendommen faktisk kaster av seg.
+              </p>
+            </div>
+            <div className="feat">
+              <div className="num">II</div>
+              <h3>Markedsyield</h3>
+              <p>
+                NOI deles på en yield som speiler avkastningskravet for ditt
+                segment og din by i Nord-Norge. Lavere yield i likvide markeder,
+                høyere der risikoen er større.
+              </p>
+            </div>
+            <div className="feat">
+              <div className="num">III</div>
+              <h3>Verdiintervall</h3>
+              <p>
+                Vi viser et intervall rundt estimatet (yield ±0,5
+                prosentpoeng), fordi små endringer i avkastningskravet gir store
+                utslag på verdien.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <CtaStrip
+        eyebrow="Klar for et presist tall?"
+        title={
+          <>
+            Fra estimat til <span className="italic">verdivurdering.</span>
+          </>
+        }
+        sub="Estimatet er et godt utgangspunkt. Vil du vite hva eiendommen faktisk er verdt i dagens marked, gir en av partnerne våre deg en presis vurdering innen 24 timer — uforpliktende."
+        primary={{ label: "Få verdivurdering", href: "/kontakt" }}
+        secondary={{
+          label: "Slik jobber vi med verdivurdering",
+          href: "/tjenester/verdivurdering",
+        }}
+      />
+    </>
+  );
+}

--- a/src/app/verktoy/page.tsx
+++ b/src/app/verktoy/page.tsx
@@ -4,6 +4,7 @@ import FeatureDivider from "@/components/ui/FeatureDivider";
 import { constructMetadata } from "@/lib/utils";
 import {
   RiBarChartBoxLine,
+  RiBuilding2Line,
   RiCalculatorLine,
   RiLineChartLine,
   RiPieChartLine,
@@ -19,6 +20,14 @@ export const metadata = constructMetadata({
 });
 
 const calculators = [
+  {
+    title: "Næringskalkulator",
+    description:
+      "Få et yield-basert verdiestimat på næringseiendommen din på minuttet — med NOI, anvendt yield og verdiintervall.",
+    icon: RiBuilding2Line,
+    href: "/verktoy/naringskalkulator",
+    color: "text-light-blue",
+  },
   {
     title: "Pris på Verdivurdering",
     description:

--- a/src/components/verktoy/NaringskalkulatorClient.tsx
+++ b/src/components/verktoy/NaringskalkulatorClient.tsx
@@ -1,0 +1,327 @@
+"use client";
+
+import NumberFlow from "@number-flow/react";
+import Link from "next/link";
+import { useMemo, useState } from "react";
+
+import {
+  CITIES,
+  PROPERTY_TYPES,
+  RENT_RATE,
+  computeEstimate,
+  parseNorwegianNumber,
+  type City,
+  type PropertyType,
+} from "@/lib/verktoy/naringskalkulator";
+
+const fmtInt = (n: number) => Math.round(n).toLocaleString("nb-NO");
+
+/** Format a kr amount in millions, nb-NO, one decimal (e.g. "40,5"). */
+function millOnly(n: number) {
+  return (n / 1e6).toLocaleString("nb-NO", {
+    minimumFractionDigits: 1,
+    maximumFractionDigits: 1,
+  });
+}
+
+export function NaringskalkulatorClient() {
+  const [type, setType] = useState<PropertyType>("Kontor");
+  const [city, setCity] = useState<City>("Bodø");
+  // Numeric fields kept as strings so we can show nb-NO thousands and tolerate
+  // partial input; parsed via parseNorwegianNumber for the actual math.
+  const [areaStr, setAreaStr] = useState("2 000");
+  const [rentStr, setRentStr] = useState("3 200 000");
+  const [vacancyStr, setVacancyStr] = useState("5");
+  const [opexStr, setOpexStr] = useState("10");
+
+  const result = useMemo(
+    () =>
+      computeEstimate({
+        type,
+        city,
+        area: parseNorwegianNumber(areaStr) ?? 0,
+        grossRent: parseNorwegianNumber(rentStr) ?? 0,
+        vacancyPct: parseNorwegianNumber(vacancyStr) ?? 0,
+        opexPct: parseNorwegianNumber(opexStr) ?? 0,
+      }),
+    [type, city, areaStr, rentStr, vacancyStr, opexStr],
+  );
+
+  const rentRate = RENT_RATE[type];
+
+  function useMarketRent() {
+    const area = parseNorwegianNumber(areaStr);
+    if (area && area > 0) setRentStr(fmtInt(area * rentRate));
+  }
+
+  function formatThousands(value: string, set: (v: string) => void) {
+    const n = parseNorwegianNumber(value);
+    if (n && n > 0) set(fmtInt(n));
+  }
+
+  // Prefill params carried into the verdivurdering funnel.
+  const ctaHref = useMemo(() => {
+    const params = new URLSearchParams({
+      type,
+      by: city,
+      areal: String(Math.round(parseNorwegianNumber(areaStr) ?? 0)),
+      leie: String(Math.round(parseNorwegianNumber(rentStr) ?? 0)),
+    });
+    return `/kontakt?${params.toString()}`;
+  }, [type, city, areaStr, rentStr]);
+
+  return (
+    <div className="calc-grid">
+      {/* INPUTS */}
+      <div className="calc-inputs">
+        <div className="step-mark">01 — Eiendommen</div>
+
+        <span className="calc-lbl" id="lbl-type">
+          Eiendomstype
+        </span>
+        <div className="vv-seg" role="radiogroup" aria-labelledby="lbl-type">
+          {PROPERTY_TYPES.map((t) => (
+            <label key={t}>
+              <input
+                type="radio"
+                name="type"
+                value={t}
+                checked={type === t}
+                onChange={() => setType(t)}
+              />
+              <span>{t}</span>
+            </label>
+          ))}
+        </div>
+
+        <span className="calc-lbl" id="lbl-by">
+          By / marked
+        </span>
+        <div className="vv-seg" role="radiogroup" aria-labelledby="lbl-by">
+          {CITIES.map((c) => (
+            <label key={c}>
+              <input
+                type="radio"
+                name="by"
+                value={c}
+                checked={city === c}
+                onChange={() => setCity(c)}
+              />
+              <span>{c}</span>
+            </label>
+          ))}
+        </div>
+
+        <div className="num-field">
+          <label className="calc-lbl" htmlFor="in-areal">
+            Utleibart areal
+          </label>
+          <div className="num-wrap">
+            <input
+              id="in-areal"
+              type="text"
+              inputMode="numeric"
+              value={areaStr}
+              onChange={(e) => setAreaStr(e.target.value)}
+              onBlur={() => formatThousands(areaStr, setAreaStr)}
+            />
+            <span className="suffix">m² BTA</span>
+          </div>
+        </div>
+
+        <div className="step-mark">02 — Leieinntekter</div>
+
+        <div className="num-field">
+          <label className="calc-lbl" htmlFor="in-leie">
+            Årlig brutto leieinntekt
+          </label>
+          <div className="num-wrap">
+            <input
+              id="in-leie"
+              type="text"
+              inputMode="numeric"
+              value={rentStr}
+              onChange={(e) => setRentStr(e.target.value)}
+              onBlur={() => formatThousands(rentStr, setRentStr)}
+            />
+            <span className="suffix">kr / år</span>
+          </div>
+          <p className="num-hint">
+            Vet du ikke leien?{" "}
+            <button type="button" onClick={useMarketRent}>
+              Bruk et markedsanslag
+            </button>{" "}
+            basert på areal og type ({fmtInt(rentRate)} kr/m²).
+          </p>
+        </div>
+
+        <div className="calc-two">
+          <div className="num-field">
+            <label className="calc-lbl" htmlFor="in-ledighet">
+              Ledighet
+            </label>
+            <div className="num-wrap">
+              <input
+                id="in-ledighet"
+                type="text"
+                inputMode="numeric"
+                value={vacancyStr}
+                onChange={(e) => setVacancyStr(e.target.value)}
+              />
+              <span className="suffix">%</span>
+            </div>
+          </div>
+          <div className="num-field">
+            <label className="calc-lbl" htmlFor="in-opex">
+              Eierkostnader
+            </label>
+            <div className="num-wrap">
+              <input
+                id="in-opex"
+                type="text"
+                inputMode="numeric"
+                value={opexStr}
+                onChange={(e) => setOpexStr(e.target.value)}
+              />
+              <span className="suffix">%</span>
+            </div>
+          </div>
+        </div>
+
+        <p className="num-hint" style={{ marginTop: 4 }}>
+          Eierkostnader dekker forvaltning, vedlikehold, forsikring og
+          eiendomsskatt — typisk 8–12 % av brutto leie for godt drevne bygg.
+        </p>
+      </div>
+
+      {/* RESULT */}
+      <div className="calc-result">
+        <div className="r-lbl">Estimert markedsverdi</div>
+
+        {result.valid ? (
+          <>
+            <div className="r-value">
+              <NumberFlow
+                value={Number(millOnly(result.value).replace(",", "."))}
+                locales="nb-NO"
+                format={{
+                  minimumFractionDigits: 1,
+                  maximumFractionDigits: 1,
+                }}
+                prefix="kr "
+                suffix=" mill."
+              />
+            </div>
+            <div className="r-range">
+              Sannsynlig intervall:{" "}
+              <strong>
+                kr {millOnly(result.low)} – {millOnly(result.high)} mill.
+              </strong>
+            </div>
+
+            <div className="range-bar">
+              <div className="fill" />
+              <div className="dot" />
+            </div>
+            <div className="range-ends">
+              <span>{millOnly(result.low)} mill.</span>
+              <span>{millOnly(result.high)} mill.</span>
+            </div>
+
+            <div className="r-stats">
+              <div className="r-stat">
+                <div className="k">Netto leieinntekt</div>
+                <div className="v">
+                  <NumberFlow
+                    value={Number(millOnly(result.noi).replace(",", "."))}
+                    locales="nb-NO"
+                    format={{
+                      minimumFractionDigits: 1,
+                      maximumFractionDigits: 1,
+                    }}
+                    prefix="kr "
+                    suffix=" mill."
+                  />
+                </div>
+              </div>
+              <div className="r-stat">
+                <div className="k">Anvendt yield</div>
+                <div className="v">
+                  <NumberFlow
+                    value={result.appliedYield}
+                    locales="nb-NO"
+                    format={{
+                      minimumFractionDigits: 2,
+                      maximumFractionDigits: 2,
+                    }}
+                  />
+                  <span className="u">%</span>
+                </div>
+              </div>
+              <div className="r-stat">
+                <div className="k">Verdi pr. m²</div>
+                <div className="v">
+                  <NumberFlow
+                    value={Math.round(result.valuePerM2)}
+                    locales="nb-NO"
+                    format={{ maximumFractionDigits: 0 }}
+                  />
+                  <span className="u">kr</span>
+                </div>
+              </div>
+              <div className="r-stat">
+                <div className="k">Brutto yield</div>
+                <div className="v">
+                  <NumberFlow
+                    value={result.grossYield}
+                    locales="nb-NO"
+                    format={{
+                      minimumFractionDigits: 1,
+                      maximumFractionDigits: 1,
+                    }}
+                  />
+                  <span className="u">%</span>
+                </div>
+              </div>
+            </div>
+          </>
+        ) : (
+          <>
+            <div className="r-value">—</div>
+            <div className="r-range">Fyll inn leie og areal</div>
+            <div className="range-bar">
+              <div className="fill" />
+              <div className="dot" />
+            </div>
+            <div className="r-stats">
+              <div className="r-stat">
+                <div className="k">Netto leieinntekt</div>
+                <div className="v">—</div>
+              </div>
+              <div className="r-stat">
+                <div className="k">Anvendt yield</div>
+                <div className="v">—</div>
+              </div>
+              <div className="r-stat">
+                <div className="k">Verdi pr. m²</div>
+                <div className="v">—</div>
+              </div>
+              <div className="r-stat">
+                <div className="k">Brutto yield</div>
+                <div className="v">—</div>
+              </div>
+            </div>
+          </>
+        )}
+
+        <Link className="r-cta" href={ctaHref}>
+          Få en presis verdivurdering <span className="arrow">→</span>
+        </Link>
+        <p className="r-foot">
+          Et veiledende estimat — ikke en formell verdivurdering. En partner kan
+          gi deg et presist tall basert på kontrakter, beliggenhet og tilstand.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -188,6 +188,7 @@ export const REGISTRY: NavEntry[] = [
   { path: "/blog/[slug]", label: "Blogginnlegg", parent: "/blog" },
   { path: "/blog/category/[slug]", label: "Bloggkategori", parent: "/blog" },
   // Verktøy sub-pages
+  { path: "/verktoy/naringskalkulator", label: "Næringskalkulator", parent: "/verktoy" },
   { path: "/verktoy/yield-kalkulator", label: "Yield-kalkulator", parent: "/verktoy" },
   { path: "/verktoy/roi-kalkulator", label: "ROI-kalkulator", parent: "/verktoy" },
   { path: "/verktoy/pris-verdivurdering", label: "Prisvurderingskalkulator", parent: "/verktoy" },

--- a/src/lib/verktoy/naringskalkulator.ts
+++ b/src/lib/verktoy/naringskalkulator.ts
@@ -1,0 +1,158 @@
+// Pure value-estimate logic for the næringskalkulator (commercial-property
+// value estimate). No React, no DOM — so the math is unit-testable in isolation
+// from the rendering component. The UI layer (NaringskalkulatorClient) only
+// owns input state and formatting; every number it shows comes from here.
+
+export const PROPERTY_TYPES = [
+  "Kontor",
+  "Handel",
+  "Lager / logistikk",
+  "Kombinasjon",
+] as const;
+export type PropertyType = (typeof PROPERTY_TYPES)[number];
+
+export const CITIES = [
+  "Bodø",
+  "Tromsø",
+  "Alta",
+  "Mo i Rana",
+  "Narvik",
+  "Harstad",
+] as const;
+export type City = (typeof CITIES)[number];
+
+// Indicative standard assumptions for Nord-Norge. These are NOT verified
+// per-deal proof stats — they are tool defaults ("standardforutsetninger"),
+// surfaced to the user as such. Keep them here, stamped, so they are trivial
+// to revise (or later swap for a verified data source) in one place.
+export const ASSUMPTIONS_UPDATED_AT = "2026-06";
+
+// Prime-ish base yields by segment (%).
+export const YIELDS: Record<PropertyType, number> = {
+  Kontor: 6.75,
+  Handel: 7.25,
+  "Lager / logistikk": 7.25,
+  Kombinasjon: 7.0,
+};
+
+// City adjustment in percentage points — liquid markets lower, peripheral higher.
+export const CITY_ADJ: Record<City, number> = {
+  Bodø: 0,
+  Tromsø: -0.25,
+  Alta: 0.25,
+  "Mo i Rana": 0.5,
+  Narvik: 0.5,
+  Harstad: 0.25,
+};
+
+// Indicative market rent per m²/year by type — used by the "bruk et
+// markedsanslag" helper to prefill gross rent from area.
+export const RENT_RATE: Record<PropertyType, number> = {
+  Kontor: 1600,
+  Handel: 1800,
+  "Lager / logistikk": 900,
+  Kombinasjon: 1400,
+};
+
+// Yield band applied around the point estimate (±0.5 pp).
+export const YIELD_RANGE_PP = 0.5;
+
+export interface EstimateInputs {
+  type: PropertyType;
+  city: City;
+  /** Lettable area, m² BTA. */
+  area: number;
+  /** Annual gross rent, kr/year. */
+  grossRent: number;
+  /** Vacancy as a percent value, e.g. 5 means 5%. */
+  vacancyPct: number;
+  /** Owner costs as a percent value, e.g. 10 means 10%. */
+  opexPct: number;
+}
+
+export interface ValidEstimate {
+  valid: true;
+  appliedYield: number; // %
+  noi: number; // kr/year
+  value: number; // kr
+  low: number; // kr
+  high: number; // kr
+  valuePerM2: number; // kr/m²
+  grossYield: number; // %
+}
+
+export interface InvalidEstimate {
+  valid: false;
+}
+
+export type EstimateResult = ValidEstimate | InvalidEstimate;
+
+/**
+ * Parse a Norwegian-formatted number string ("3 200 000", "1,5") into a finite
+ * non-negative number, or null when the input is empty/garbage/negative.
+ * Returns null rather than 0 so callers can tell "blank" from "zero".
+ */
+export function parseNorwegianNumber(input: string): number | null {
+  const cleaned = input
+    .replace(/\s/g, "")
+    .replace(/ /g, "")
+    .replace(",", ".");
+  if (cleaned === "" || !/^\d*\.?\d+$/.test(cleaned)) return null;
+  const n = Number(cleaned);
+  if (!Number.isFinite(n) || n < 0) return null;
+  return n;
+}
+
+function clampPct(pct: number): number {
+  if (!Number.isFinite(pct)) return 0;
+  // Clamp to [0, 100]. 100% lands on NOI = 0, which the `noi > 0` guard rejects
+  // as an invalid (empty) result — never a negative value.
+  return Math.min(100, Math.max(0, pct));
+}
+
+/**
+ * Yield-based value estimate. value = NOI / yield, with NOI = gross net of
+ * vacancy and owner costs. Returns { valid: false } for any input that would
+ * produce a non-finite, zero, or negative result so the UI never renders
+ * NaN / Infinity / a negative "value".
+ */
+export function computeEstimate(inputs: EstimateInputs): EstimateResult {
+  const { type, city, area, grossRent } = inputs;
+  const vacancy = clampPct(inputs.vacancyPct) / 100;
+  const opex = clampPct(inputs.opexPct) / 100;
+
+  const appliedYield = (YIELDS[type] ?? 7.0) + (CITY_ADJ[city] ?? 0);
+  const noi = grossRent * (1 - vacancy) * (1 - opex);
+
+  const lowYield = appliedYield + YIELD_RANGE_PP;
+  const highYield = appliedYield - YIELD_RANGE_PP;
+
+  // Guard every denominator and the result sign. highYield (the smaller yield
+  // that produces the HIGH value) must stay positive too.
+  if (
+    !(area > 0) ||
+    !(grossRent > 0) ||
+    !(appliedYield > 0) ||
+    !(highYield > 0) ||
+    !(noi > 0)
+  ) {
+    return { valid: false };
+  }
+
+  const value = noi / (appliedYield / 100);
+  const low = noi / (lowYield / 100);
+  const high = noi / (highYield / 100);
+
+  if (!Number.isFinite(value) || value <= 0) return { valid: false };
+
+  return {
+    valid: true,
+    appliedYield,
+    noi,
+    value,
+    low,
+    high,
+    valuePerM2: value / area,
+    grossYield: (grossRent / value) * 100,
+  };
+}

--- a/src/styles/advanti-design.css
+++ b/src/styles/advanti-design.css
@@ -9084,3 +9084,160 @@ h1, h2, h3 {
 }
 .office-map-loading { background: var(--warm-grey-75); }
 .office-map .leaflet-container { background: var(--warm-grey-75); }
+
+/* ============================================================
+   NÆRINGSKALKULATOR — verdiestimat-verktøy (bygd på eksisterende tokens)
+   ============================================================ */
+.calc-grid {
+  display: grid;
+  grid-template-columns: 1.15fr 1fr;
+  gap: 64px;
+  align-items: start;
+}
+@media (max-width: 980px) {
+  .calc-grid { grid-template-columns: 1fr; gap: 48px; }
+}
+
+.calc-inputs .step-mark {
+  font-size: 11px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin-bottom: 22px;
+  padding-bottom: 14px;
+  border-bottom: var(--hairline);
+}
+.calc-inputs .step-mark:not(:first-of-type) { margin-top: 40px; }
+
+.calc-lbl {
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--warm-grey);
+  font-weight: 500;
+  display: block;
+  margin-bottom: 12px;
+}
+
+/* Segmented controls */
+.vv-seg { display: flex; flex-wrap: wrap; gap: 10px; margin-bottom: 24px; }
+.vv-seg label { flex: 1 1 auto; min-width: 110px; }
+.vv-seg input { position: absolute; opacity: 0; pointer-events: none; }
+.vv-seg span {
+  display: flex; align-items: center; justify-content: center; text-align: center;
+  padding: 12px 14px; border: var(--hairline);
+  font-size: 13.5px; color: var(--warm-grey-85);
+  cursor: pointer; transition: border-color 0.18s, background 0.18s, color 0.18s;
+  line-height: 1.2;
+}
+.vv-seg label:hover span { border-color: var(--warm-grey-85); }
+.vv-seg input:checked + span {
+  border-color: var(--warm-grey); background: var(--warm-grey); color: var(--warm-white);
+}
+.vv-seg input:focus-visible + span { outline: 2px solid var(--warm-grey); outline-offset: 2px; }
+
+/* Numeric field with suffix */
+.num-field { margin-bottom: 24px; }
+.num-wrap {
+  display: flex; align-items: baseline; gap: 8px;
+  border-bottom: 1px solid var(--warm-grey-75);
+  transition: border-color 0.2s;
+}
+.num-wrap:focus-within { border-color: var(--warm-grey); }
+.num-wrap input {
+  font: inherit; font-family: var(--font-body);
+  flex: 1; min-width: 0;
+  background: transparent; border: 0; padding: 10px 0;
+  font-size: 21px; letter-spacing: -0.01em; color: var(--warm-grey);
+  font-variant-numeric: tabular-nums;
+}
+.num-wrap input:focus { outline: none; }
+.num-wrap .suffix { font-size: 14px; color: var(--warm-grey-85); white-space: nowrap; }
+.num-hint { margin-top: 8px; font-size: 12.5px; color: var(--warm-grey-85); line-height: 1.5; }
+.num-hint button {
+  color: var(--accent); cursor: pointer; font-weight: 500;
+  background: none; border: 0; padding: 0; font: inherit;
+}
+.num-hint button:hover { text-decoration: underline; }
+
+.calc-two { display: grid; grid-template-columns: 1fr 1fr; gap: 28px; }
+@media (max-width: 580px) { .calc-two { grid-template-columns: 1fr; gap: 0; } }
+
+/* RESULT CARD */
+.calc-result {
+  position: sticky; top: 96px;
+  background: var(--warm-grey);
+  color: var(--warm-white);
+  padding: 44px;
+}
+.calc-result .r-lbl {
+  font-size: 11px; letter-spacing: 0.18em; text-transform: uppercase;
+  color: rgba(243,241,239,0.6); margin-bottom: 18px;
+}
+.calc-result .r-value {
+  font-family: var(--font-display);
+  font-size: clamp(44px, 5.2vw, 60px);
+  font-weight: 400; letter-spacing: -0.03em; line-height: 0.98;
+  color: var(--warm-white);
+  font-variant-numeric: tabular-nums;
+}
+.calc-result .r-range {
+  margin-top: 16px; font-size: 14.5px; color: rgba(243,241,239,0.72);
+  font-variant-numeric: tabular-nums;
+}
+.calc-result .r-range strong { color: var(--accent); font-weight: 500; }
+
+.range-bar {
+  margin: 28px 0 6px; height: 4px; border-radius: 2px;
+  background: rgba(243,241,239,0.18); position: relative;
+}
+.range-bar .fill {
+  position: absolute; top: 0; bottom: 0; left: 18%; right: 18%;
+  background: var(--accent); border-radius: 2px;
+}
+.range-bar .dot {
+  position: absolute; top: 50%; left: 50%; transform: translate(-50%,-50%);
+  width: 12px; height: 12px; border-radius: 50%;
+  background: var(--warm-white); border: 2px solid var(--accent);
+}
+.range-ends {
+  display: flex; justify-content: space-between;
+  font-size: 11.5px; color: rgba(243,241,239,0.5);
+  font-variant-numeric: tabular-nums; letter-spacing: 0.02em;
+}
+
+.r-stats {
+  margin-top: 34px; padding-top: 30px;
+  border-top: 1px solid rgba(243,241,239,0.16);
+  display: grid; grid-template-columns: 1fr 1fr; gap: 26px 20px;
+}
+.r-stat .k {
+  font-size: 10.5px; letter-spacing: 0.14em; text-transform: uppercase;
+  color: rgba(243,241,239,0.55); margin-bottom: 7px;
+}
+.r-stat .v {
+  font-family: var(--font-display); font-size: 24px; font-weight: 400;
+  letter-spacing: -0.015em; color: var(--warm-white);
+  font-variant-numeric: tabular-nums;
+  display: flex; align-items: baseline;
+}
+.r-stat .v .u { font-size: 0.5em; font-style: italic; color: rgba(243,241,239,0.6); margin-left: 3px; }
+
+.calc-result .r-cta {
+  display: flex; align-items: center; justify-content: center; gap: 10px;
+  width: 100%; margin-top: 34px;
+  background: var(--accent); color: var(--warm-grey);
+  border: 0; cursor: pointer;
+  font-family: var(--font-body); font-size: 14.5px; font-weight: 500;
+  letter-spacing: 0.01em; padding: 17px 24px;
+  text-decoration: none; transition: opacity 0.2s;
+}
+.calc-result .r-cta:hover { opacity: 0.88; }
+.calc-result .r-foot {
+  margin-top: 18px; font-size: 11.5px; line-height: 1.55;
+  color: rgba(243,241,239,0.5); text-align: center;
+}
+
+@media (max-width: 980px) {
+  .calc-result { position: static; }
+}

--- a/tests/unit/naringskalkulator.test.ts
+++ b/tests/unit/naringskalkulator.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from "vitest"
+import {
+  computeEstimate,
+  parseNorwegianNumber,
+  type EstimateInputs,
+} from "@/lib/verktoy/naringskalkulator"
+
+const base: EstimateInputs = {
+  type: "Kontor",
+  city: "Bodø",
+  area: 2000,
+  grossRent: 3_200_000,
+  vacancyPct: 5,
+  opexPct: 10,
+}
+
+describe("computeEstimate — known vector (Kontor · Bodø)", () => {
+  // NOTE: the design mock's "41,1 mill." is stale placeholder text. The actual
+  // yield math gives 40.5M — these assertions encode the correct numbers.
+  const r = computeEstimate(base)
+
+  it("is valid", () => {
+    expect(r.valid).toBe(true)
+  })
+
+  it("applies the base yield with no city adjustment", () => {
+    if (!r.valid) throw new Error("expected valid")
+    expect(r.appliedYield).toBeCloseTo(6.75, 5)
+  })
+
+  it("computes NOI net of vacancy and opex", () => {
+    if (!r.valid) throw new Error("expected valid")
+    // 3 200 000 × 0.95 × 0.90
+    expect(r.noi).toBeCloseTo(2_736_000, 0)
+  })
+
+  it("computes value ≈ 40.5M and a ±0.5pp band of 37.7–43.8M", () => {
+    if (!r.valid) throw new Error("expected valid")
+    expect(r.value / 1e6).toBeCloseTo(40.53, 1)
+    expect(r.low / 1e6).toBeCloseTo(37.74, 1)
+    expect(r.high / 1e6).toBeCloseTo(43.78, 1)
+    expect(r.low).toBeLessThan(r.value)
+    expect(r.value).toBeLessThan(r.high)
+  })
+
+  it("derives value/m² and gross yield", () => {
+    if (!r.valid) throw new Error("expected valid")
+    expect(Math.round(r.valuePerM2)).toBe(20_267)
+    expect(r.grossYield).toBeCloseTo(7.9, 1)
+  })
+})
+
+describe("computeEstimate — city & type adjustments", () => {
+  it("Tromsø lowers the applied yield by 0.25pp", () => {
+    const r = computeEstimate({ ...base, city: "Tromsø" })
+    if (!r.valid) throw new Error("expected valid")
+    expect(r.appliedYield).toBeCloseTo(6.5, 5)
+  })
+
+  it("Mo i Rana raises the applied yield by 0.5pp", () => {
+    const r = computeEstimate({ ...base, city: "Mo i Rana" })
+    if (!r.valid) throw new Error("expected valid")
+    expect(r.appliedYield).toBeCloseTo(7.25, 5)
+  })
+
+  it("Handel uses a higher base yield than Kontor → lower value", () => {
+    const kontor = computeEstimate(base)
+    const handel = computeEstimate({ ...base, type: "Handel" })
+    if (!kontor.valid || !handel.valid) throw new Error("expected valid")
+    expect(handel.appliedYield).toBeGreaterThan(kontor.appliedYield)
+    expect(handel.value).toBeLessThan(kontor.value)
+  })
+})
+
+describe("computeEstimate — invalid guards (no NaN/Infinity/negative)", () => {
+  it("zero area is invalid", () => {
+    expect(computeEstimate({ ...base, area: 0 }).valid).toBe(false)
+  })
+
+  it("zero gross rent is invalid", () => {
+    expect(computeEstimate({ ...base, grossRent: 0 }).valid).toBe(false)
+  })
+
+  it("100% vacancy drives NOI to zero → invalid", () => {
+    expect(computeEstimate({ ...base, vacancyPct: 100 }).valid).toBe(false)
+  })
+
+  it("100% opex drives NOI to zero → invalid", () => {
+    expect(computeEstimate({ ...base, opexPct: 100 }).valid).toBe(false)
+  })
+
+  it("vacancy + opex are clamped, never producing a negative NOI", () => {
+    const r = computeEstimate({ ...base, vacancyPct: 150, opexPct: 150 })
+    expect(r.valid).toBe(false)
+  })
+})
+
+describe("parseNorwegianNumber", () => {
+  it("parses spaced thousands", () => {
+    expect(parseNorwegianNumber("3 200 000")).toBe(3_200_000)
+  })
+
+  it("parses a comma decimal", () => {
+    expect(parseNorwegianNumber("1,5")).toBe(1.5)
+  })
+
+  it("returns null for blank and garbage", () => {
+    expect(parseNorwegianNumber("")).toBeNull()
+    expect(parseNorwegianNumber("12abc")).toBeNull()
+    expect(parseNorwegianNumber("abc")).toBeNull()
+  })
+
+  it("rejects negative numbers", () => {
+    expect(parseNorwegianNumber("-5")).toBeNull()
+  })
+})


### PR DESCRIPTION
Ny `/verktoy/naringskalkulator` fra design-handoff (claude.ai/design). Yield-basert verdiestimat-verktøy for næringseiendom: eier legger inn noen tall og får et øyeblikkelig markedsverdi-anslag med intervall og nøkkeltall, og en CTA inn i verdivurderings-funnelen.

## Arkitektur
- **`src/lib/verktoy/naringskalkulator.ts`** — ren, testbar logikk. Typede konstanter (YIELDS / CITY_ADJ / RENT_RATE, stemplet `ASSUMPTIONS_UPDATED_AT` og merket som standardforutsetninger), `parseNorwegianNumber → number | null`, `computeEstimate` med vakter mot NaN/Infinity/negativ verdi.
- **`NaringskalkulatorClient.tsx`** — "use client": segmenterte kontroller, numeriske felt, mørkt sticky resultatkort. NumberFlow på resultattallene (samme bibliotek som ROI-/MortgageCalculator). NumberFlow rendres kun for endelige tall; ugyldig input viser "—".
- **`page.tsx`** — Server Component i editorial design­system (SubHero, .section, feat-3, CtaStrip), som karriere/kontakt.
- Registrert i `navigation.ts` + `/verktoy`-oversikten.

## Reviewet via /autoplan
Codex adversarial eng-stemme ga 8 funn, alle foldet inn. Viktigst: **testvektoren var feil** — handoffens `41,1 mill.` er utdatert placeholder-tekst; faktisk yield-matte gir **40,5 mill.** (intervall 37,7–43,8). Verifisert. Også: percent-normalisering (/100 + clamp), parse-robusthet, range-vakter, NumberFlow kun for gyldige tall, konstant-proveniens.

## Designsystem-valg
Følger handoff (editorial), ikke den eldre `CalculatorLayout`-stilen de 4 andre kalkulatorene bruker. Bevisst valg (din avgjørelse i autoplan-gaten). Migrering av de andre er separat scope.

## Verifisert
- 17/17 enhetstester (`vitest run tests/unit/naringskalkulator.test.ts`)
- `pnpm build` ✓ (ruten prerendres statisk), tsc ✓, lint ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)