### PR TITLE
feat(nav): centered nav + contained card dropdown (reference look, icon-free)

### DIFF
--- a/src/components/site/Nav.tsx
+++ b/src/components/site/Nav.tsx
@@ -21,31 +21,57 @@ export interface NavProps {
 
 type GroupId = "tjenester" | "innsikt" | "om-oss";
 
+// Featured promo block shown in each panel's support column (icon-free).
+const PROMO: Record<GroupId, {
+  href: string;
+  eyebrow: string;
+  title: string;
+  desc: string;
+  cta: string;
+}> = {
+  tjenester: {
+    href: "/naringsmegler",
+    eyebrow: "Lokal tilstedeværelse",
+    title: "Næringsmegler i din by",
+    desc: "Lokal megler i ti byer i Nord-Norge.",
+    cta: "Se alle byer",
+  },
+  innsikt: {
+    href: "/markedsrapport",
+    eyebrow: "Fersk innsikt",
+    title: "Markedsrapport",
+    desc: "Kvartalsvise tall: yield, leie og ledighet.",
+    cta: "Les rapporten",
+  },
+  "om-oss": {
+    href: "/karriere",
+    eyebrow: "Jobb hos oss",
+    title: "Karriere i Advanti",
+    desc: "Vi bygger Nord-Norges sterkeste fagmiljø.",
+    cta: "Se ledige roller",
+  },
+};
+
 /**
  * Site navigation — fixed; transparent over a dark hero, solid otherwise.
  *
  * Disclosure model (E1A + hover enhancement):
- *   Three grouped labels (Tjenester, Innsikt, Om oss) are <button> triggers
- *   with aria-expanded / aria-controls pointing at full-width .nav-panel
- *   divs. Panels are ALWAYS in the server HTML (crawlable) and hidden via
- *   CSS + the `inert` attribute when closed. Opening one group closes others.
+ *   Three centered group labels (Tjenester, Innsikt, Om oss) are <button>
+ *   triggers with aria-expanded / aria-controls. Their panels live in a single
+ *   contained card "shell" that morphs height between groups. Panels are ALWAYS
+ *   in the server HTML (crawlable) and hidden via CSS + `inert` when closed.
  *
- *   POINTER: hovering a trigger opens its panel; moving between triggers
- *   morphs the open panel; leaving the trigger-or-panel closes after a short
- *   intent delay. Hover is gated to `(hover: hover)` devices so touch never
- *   gets a sticky hover state.
- *   KEYBOARD/CLICK: the trigger toggles on click/Enter; Escape closes and
- *   returns focus to the trigger. Tab order never auto-opens panels.
- *   Click-outside and link-click also close the panel.
+ *   POINTER: hovering a trigger opens it and morphs between groups; leaving the
+ *   trigger-or-card closes after an intent delay. Gated to `(hover: hover)`.
+ *   KEYBOARD/CLICK: trigger toggles; Escape closes + returns focus. Click
+ *   outside and link-click close.
  *
- * --nav-h ownership (E7):
- *   Nav measures its own rendered height via ResizeObserver and writes
- *   --nav-h on document.documentElement. AnalyseportalShell only reads it.
+ * --nav-h ownership (E7): Nav measures its own height via ResizeObserver and
+ *   writes --nav-h on documentElement; AnalyseportalShell only reads it.
  *
- * Transparent/solid sentinel (unchanged):
- *   page WITH a dark hero → renders <div id="hero-sentinel" /> at hero base.
- *   Nav is transparent until sentinel scrolls out of view, then goes solid.
- *   page WITHOUT a hero → no sentinel → Nav is solid immediately.
+ * Transparent/solid sentinel (unchanged): a dark-hero page renders
+ *   <div id="hero-sentinel" /> at the hero base; Nav stays transparent until it
+ *   scrolls behind the nav. No sentinel → solid immediately.
  */
 export function Nav({ cities, groups }: NavProps) {
   const pathname = usePathname();
@@ -56,6 +82,7 @@ export function Nav({ cities, groups }: NavProps) {
 
   const navRef = useRef<HTMLElement>(null);
   const toggleRef = useRef<HTMLButtonElement>(null);
+  const shellRef = useRef<HTMLDivElement>(null);
   const panelRefs = useRef<Partial<Record<GroupId, HTMLDivElement>>>({});
   const groupBtnRefs = useRef<Partial<Record<GroupId, HTMLButtonElement>>>({});
 
@@ -112,14 +139,26 @@ export function Nav({ cities, groups }: NavProps) {
       );
     apply();
     const ro = new ResizeObserver(apply);
-    // border-box: padding transitions (scrolled/unscrolled) fire content-box
-    // observations, which we'd miss with the default content-box mode.
     ro.observe(nav, { box: "border-box" });
     return () => {
       ro.disconnect();
       document.documentElement.style.removeProperty("--nav-h");
     };
   }, []);
+
+  // ── panel card: morph the shell height to the open panel's content ──────
+  useIsoLayoutEffect(() => {
+    const shell = shellRef.current;
+    if (!shell) return;
+    if (!openGroup) {
+      shell.style.removeProperty("--nav-panel-h");
+      return;
+    }
+    const panel = panelRefs.current[openGroup];
+    if (panel) {
+      shell.style.setProperty("--nav-panel-h", `${panel.scrollHeight}px`);
+    }
+  }, [openGroup]);
 
   // ── transparent/solid sentinel ─────────────────────────────────────────
   useIsoLayoutEffect(() => {
@@ -185,10 +224,8 @@ export function Nav({ cities, groups }: NavProps) {
     const onMouseDown = (e: MouseEvent) => {
       const target = e.target as Node;
       const inNav = navRef.current?.contains(target) ?? false;
-      const inPanel = Object.values(panelRefs.current).some(
-        (p) => p?.contains(target),
-      );
-      if (!inNav && !inPanel) setOpenGroup(null);
+      const inShell = shellRef.current?.contains(target) ?? false;
+      if (!inNav && !inShell) setOpenGroup(null);
     };
     document.addEventListener("mousedown", onMouseDown);
     return () => document.removeEventListener("mousedown", onMouseDown);
@@ -199,7 +236,6 @@ export function Nav({ cities, groups }: NavProps) {
   const isLinkActive = (href: string) =>
     cleanPath === href || cleanPath.startsWith(`${href}/`);
 
-  // A group is active if any of its non-dynamic entries match the current path.
   const isGroupActive = (id: GroupId): boolean =>
     (groups[id] ?? []).some(
       (e) => !e.path.includes("[") && isLinkActive(e.path),
@@ -207,7 +243,6 @@ export function Nav({ cities, groups }: NavProps) {
 
   const toggleGroup = (id: GroupId) => {
     cancelClose();
-    // A click riding along with this group's hover-open confirms it (stay open).
     if (hoverOpened.current === id) {
       hoverOpened.current = null;
       return;
@@ -225,7 +260,6 @@ export function Nav({ cities, groups }: NavProps) {
     setOpenGroup(null);
   };
 
-  // Force solid nav while any panel or mobile menu is open.
   const navClass = [
     "nav",
     scrolled || menuOpen || !!openGroup ? "scrolled" : "",
@@ -233,7 +267,6 @@ export function Nav({ cities, groups }: NavProps) {
     .filter(Boolean)
     .join(" ");
 
-  // Stable memoized ref callbacks — identity never changes between renders.
   const groupBtnCb = useMemo(
     () => ({
       tjenester: (el: HTMLButtonElement | null) => {
@@ -264,7 +297,6 @@ export function Nav({ cities, groups }: NavProps) {
     [],
   );
 
-  // Hover handlers bound per group (stable closures not required — cheap).
   const hoverProps = (id: GroupId) => ({
     onMouseEnter: () => openByHover(id),
     onMouseLeave: scheduleClose,
@@ -274,13 +306,39 @@ export function Nav({ cities, groups }: NavProps) {
     onMouseLeave: scheduleClose,
   };
 
-  // Tjenester services shown in the grid (parent + næringsmegler rendered apart).
+  // Tjenester services shown in the grid (parent + næringsmegler rendered apart;
+  // næringsmegler is the panel's featured promo, so it is excluded here).
   const tjenesterServices = groups.tjenester.filter(
     (e) => e.path !== "/tjenester" && e.path !== "/naringsmegler",
   );
-  const naringsmegler = groups.tjenester.find(
-    (e) => e.path === "/naringsmegler",
+  // Innsikt links minus the parent and minus markedsrapport (the promo).
+  const innsiktLinks = groups.innsikt.filter(
+    (e) => e.path !== "/markedsinnsikt" && e.path !== "/markedsrapport",
   );
+  // Om oss links minus the parent and minus karriere (the promo).
+  const omOssLinks = groups["om-oss"].filter(
+    (e) => e.path !== "/om-oss" && e.path !== "/karriere",
+  );
+
+  const renderPromo = (id: GroupId) => {
+    const p = PROMO[id];
+    return (
+      <Link
+        prefetch={false}
+        href={p.href}
+        className="nav-promo"
+        aria-current={isLinkActive(p.href) ? "page" : undefined}
+        onClick={closePanel}
+      >
+        <span className="nav-promo-eyebrow">{p.eyebrow}</span>
+        <span className="nav-promo-title">{p.title}</span>
+        <span className="nav-promo-desc">{p.desc}</span>
+        <span className="nav-promo-cta">
+          {p.cta} <span aria-hidden>→</span>
+        </span>
+      </Link>
+    );
+  };
 
   return (
     <>
@@ -295,7 +353,6 @@ export function Nav({ cities, groups }: NavProps) {
         </Link>
 
         <div className="nav-links">
-          {/* ── Tjenester group ─────────────────────────────────────────── */}
           <button
             type="button"
             className="nav-group-btn"
@@ -309,7 +366,6 @@ export function Nav({ cities, groups }: NavProps) {
             Tjenester
           </button>
 
-          {/* ── Eiendommer plain link ───────────────────────────────────── */}
           <Link
             href="/eiendommer"
             aria-current={isLinkActive("/eiendommer") ? "page" : undefined}
@@ -318,7 +374,6 @@ export function Nav({ cities, groups }: NavProps) {
             Eiendommer
           </Link>
 
-          {/* ── Innsikt group ───────────────────────────────────────────── */}
           <button
             type="button"
             className="nav-group-btn"
@@ -332,7 +387,6 @@ export function Nav({ cities, groups }: NavProps) {
             Innsikt
           </button>
 
-          {/* ── Om oss group ────────────────────────────────────────────── */}
           <button
             type="button"
             className="nav-group-btn"
@@ -346,7 +400,6 @@ export function Nav({ cities, groups }: NavProps) {
             Om oss
           </button>
 
-          {/* ── Kontakt plain link ──────────────────────────────────────── */}
           <Link
             href="/kontakt"
             aria-current={isLinkActive("/kontakt") ? "page" : undefined}
@@ -356,47 +409,51 @@ export function Nav({ cities, groups }: NavProps) {
           </Link>
         </div>
 
-        <Link
-          href="/verktoy/pris-verdivurdering"
-          className="nav-cta"
-          onClick={() => trackEvent("cta_verdivurdering", { source: "nav" })}
-        >
-          <span>Få verdivurdering</span>
-          <span className="arrow">→</span>
-        </Link>
+        <div className="nav-right">
+          <Link
+            href="/verktoy/pris-verdivurdering"
+            className="nav-cta"
+            onClick={() => trackEvent("cta_verdivurdering", { source: "nav" })}
+            onMouseEnter={scheduleClose}
+          >
+            <span>Få verdivurdering</span>
+            <span className="arrow">→</span>
+          </Link>
 
-        <button
-          type="button"
-          ref={toggleRef}
-          className={menuOpen ? "nav-toggle open" : "nav-toggle"}
-          aria-label={menuOpen ? "Lukk meny" : "Åpne meny"}
-          aria-expanded={menuOpen}
-          aria-controls="nav-mobile"
-          onClick={() => setMenuOpen((o) => !o)}
-        >
-          <span />
-          <span />
-        </button>
+          <button
+            type="button"
+            ref={toggleRef}
+            className={menuOpen ? "nav-toggle open" : "nav-toggle"}
+            aria-label={menuOpen ? "Lukk meny" : "Åpne meny"}
+            aria-expanded={menuOpen}
+            aria-controls="nav-mobile"
+            onClick={() => setMenuOpen((o) => !o)}
+          >
+            <span />
+            <span />
+          </button>
+        </div>
       </nav>
 
       {/* ──────────────────────────────────────────────────────────────────
-          DESKTOP PANELS (always in DOM for SSR/crawlability).
-          Hidden via CSS + inert when closed; no `hidden` attr so links
-          stay in the initial server HTML for search engines.
+          DESKTOP PANEL SHELL — one contained card that morphs height between
+          groups. Panels are always in the DOM (SSR/crawlability), hidden via
+          opacity + inert when their group is closed.
           ────────────────────────────────────────────────────────────── */}
-
-      {/* Tjenester panel — services grid + Næringsmegler column */}
       <div
-        id="nav-panel-tjenester"
-        className={`nav-panel${openGroup === "tjenester" ? " open" : ""}`}
-        ref={panelRefCb["tjenester"]}
-        inert={openGroup !== "tjenester"}
+        className={`nav-panel-shell${openGroup ? " open" : ""}`}
+        ref={shellRef}
         {...panelHoverProps}
       >
-        <div className="wrap">
+        {/* Tjenester */}
+        <div
+          id="nav-panel-tjenester"
+          className={`nav-panel${openGroup === "tjenester" ? " open" : ""}`}
+          ref={panelRefCb["tjenester"]}
+          inert={openGroup !== "tjenester"}
+        >
           <div className="nav-panel-inner nav-panel-grid">
-            {/* Left — services in a two-column grid, parent first */}
-            <div className="nav-panel-col nav-panel-col-wide">
+            <div className="nav-panel-col-wide">
               <span className="nav-panel-eyebrow">Tjenester</span>
               <ul
                 className="nav-panel-list nav-panel-list-grid"
@@ -429,61 +486,40 @@ export function Nav({ cities, groups }: NavProps) {
                 ))}
               </ul>
             </div>
-
-            {/* Right — Næringsmegler highlight + all-cities link */}
-            {naringsmegler && (
-              <div className="nav-panel-col">
-                <span className="nav-panel-eyebrow">Lokal tilstedeværelse</span>
-                <ul className="nav-panel-list" onClick={closePanel}>
-                  <li className="nav-panel-parent">
-                    <Link
-                      prefetch={false}
-                      href={naringsmegler.path}
-                      aria-current={
-                        isLinkActive(naringsmegler.path) ? "page" : undefined
-                      }
-                    >
-                      {naringsmegler.label}
-                    </Link>
-                    {naringsmegler.description && (
-                      <span className="nav-panel-desc">
-                        {naringsmegler.description}
-                      </span>
-                    )}
-                  </li>
-                </ul>
-              </div>
-            )}
+            {renderPromo("tjenester")}
           </div>
         </div>
-      </div>
 
-      {/* Innsikt panel — two columns: links with descriptions + city list */}
-      <div
-        id="nav-panel-innsikt"
-        className={`nav-panel${openGroup === "innsikt" ? " open" : ""}`}
-        ref={panelRefCb["innsikt"]}
-        inert={openGroup !== "innsikt"}
-        {...panelHoverProps}
-      >
-        <div className="wrap">
+        {/* Innsikt */}
+        <div
+          id="nav-panel-innsikt"
+          className={`nav-panel${openGroup === "innsikt" ? " open" : ""}`}
+          ref={panelRefCb["innsikt"]}
+          inert={openGroup !== "innsikt"}
+        >
           <div className="nav-panel-inner nav-panel-grid">
-            {/* Left column — innsikt links in a two-column grid */}
-            <div className="nav-panel-col nav-panel-col-wide">
+            <div className="nav-panel-col-wide">
               <span className="nav-panel-eyebrow">Innsikt</span>
               <ul
                 className="nav-panel-list nav-panel-list-grid"
                 onClick={closePanel}
               >
-                {groups.innsikt.map((e) => (
-                  <li
-                    key={e.path}
-                    className={
-                      e.path === "/markedsinnsikt"
-                        ? "nav-panel-parent"
-                        : undefined
+                <li className="nav-panel-parent">
+                  <Link
+                    prefetch={false}
+                    href="/markedsinnsikt"
+                    aria-current={
+                      isLinkActive("/markedsinnsikt") ? "page" : undefined
                     }
                   >
+                    Markedsinnsikt
+                  </Link>
+                  <span className="nav-panel-desc">
+                    Oversikt over næringseiendomsmarkedet i Nord-Norge.
+                  </span>
+                </li>
+                {innsiktLinks.map((e) => (
+                  <li key={e.path}>
                     <Link
                       prefetch={false}
                       href={e.path}
@@ -499,52 +535,41 @@ export function Nav({ cities, groups }: NavProps) {
               </ul>
             </div>
 
-            {/* Right column — byer */}
-            <div className="nav-panel-col">
-              <span className="nav-panel-eyebrow">Byer</span>
-              <div className="nav-panel-cities" onClick={closePanel}>
-                {cities.map((city) => (
-                  <Link
-                    prefetch={false}
-                    key={city.slug}
-                    href={`/naringsmegler/${city.slug}`}
-                    aria-current={
-                      isLinkActive(`/naringsmegler/${city.slug}`)
-                        ? "page"
-                        : undefined
-                    }
-                  >
-                    {city.name}
-                  </Link>
-                ))}
+            {/* Right column — featured Markedsrapport promo + city quick-links */}
+            <div className="nav-panel-aside">
+              {renderPromo("innsikt")}
+              <div className="nav-panel-cities-block">
+                <span className="nav-panel-eyebrow">Byer</span>
+                <div className="nav-panel-cities" onClick={closePanel}>
+                  {cities.slice(0, 8).map((city) => (
+                    <Link
+                      prefetch={false}
+                      key={city.slug}
+                      href={`/naringsmegler/${city.slug}`}
+                      aria-current={
+                        isLinkActive(`/naringsmegler/${city.slug}`)
+                          ? "page"
+                          : undefined
+                      }
+                    >
+                      {city.name}
+                    </Link>
+                  ))}
+                </div>
               </div>
-              <Link
-                prefetch={false}
-                href="/naringsmegler"
-                className="nav-panel-all-cities"
-                aria-current={
-                  cleanPath === "/naringsmegler" ? "page" : undefined
-                }
-                onClick={closePanel}
-              >
-                Se alle byer →
-              </Link>
             </div>
           </div>
         </div>
-      </div>
 
-      {/* Om oss panel — two-column link list (no descriptions in registry) */}
-      <div
-        id="nav-panel-om-oss"
-        className={`nav-panel${openGroup === "om-oss" ? " open" : ""}`}
-        ref={panelRefCb["om-oss"]}
-        inert={openGroup !== "om-oss"}
-        {...panelHoverProps}
-      >
-        <div className="wrap">
-          <div className="nav-panel-inner">
-            <div className="nav-panel-col nav-panel-col-wide">
+        {/* Om oss */}
+        <div
+          id="nav-panel-om-oss"
+          className={`nav-panel${openGroup === "om-oss" ? " open" : ""}`}
+          ref={panelRefCb["om-oss"]}
+          inert={openGroup !== "om-oss"}
+        >
+          <div className="nav-panel-inner nav-panel-grid">
+            <div className="nav-panel-col-wide">
               <span className="nav-panel-eyebrow">Advanti</span>
               <ul
                 className="nav-panel-list nav-panel-list-grid"
@@ -559,29 +584,26 @@ export function Nav({ cities, groups }: NavProps) {
                     Om oss
                   </Link>
                 </li>
-                {groups["om-oss"]
-                  .filter((e) => e.path !== "/om-oss")
-                  .map((e) => (
-                    <li key={e.path}>
-                      <Link
-                        prefetch={false}
-                        href={e.path}
-                        aria-current={isLinkActive(e.path) ? "page" : undefined}
-                      >
-                        {e.label}
-                      </Link>
-                    </li>
-                  ))}
+                {omOssLinks.map((e) => (
+                  <li key={e.path}>
+                    <Link
+                      prefetch={false}
+                      href={e.path}
+                      aria-current={isLinkActive(e.path) ? "page" : undefined}
+                    >
+                      {e.label}
+                    </Link>
+                  </li>
+                ))}
               </ul>
             </div>
+            {renderPromo("om-oss")}
           </div>
         </div>
       </div>
 
       {/* ──────────────────────────────────────────────────────────────────
-          MOBILE MENU (full-screen overlay, ≤780px)
-          Groups are 4A inline-accordion disclosures. Cities are footer
-          territory on mobile — not shown here.
+          MOBILE MENU (full-screen overlay, ≤780px) — inline accordion (4A).
           ────────────────────────────────────────────────────────────── */}
       <div
         id="nav-mobile"

--- a/src/styles/advanti-design.css
+++ b/src/styles/advanti-design.css
@@ -185,9 +185,15 @@ h1, h2, h3 {
   text-transform: uppercase;
   opacity: 0.85;
 }
+/* Centered nav: logo sits left, the CTA group right (.nav-right), and the
+   links are absolutely centred in the bar (reference layout). */
 .nav-links {
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
   display: flex;
-  gap: 36px;
+  align-items: center;
+  gap: 32px;
   font-size: 14px;
   font-weight: 500;
   letter-spacing: -0.005em;
@@ -195,6 +201,11 @@ h1, h2, h3 {
 }
 .nav-links a { position: relative; padding: 4px 0; }
 .nav-links a:hover { opacity: 0.7; }
+.nav-right {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
 .nav-cta {
   display: inline-flex;
   align-items: center;
@@ -278,7 +289,7 @@ h1, h2, h3 {
 @media (max-width: 780px) {
   .nav-links { display: none; }
   /* Hide only the nav-bar CTA — the one inside .nav-mobile keeps showing. */
-  .nav > .nav-cta { display: none; }
+  .nav-right .nav-cta { display: none; }
   .nav-toggle { display: flex; }
   .nav-mobile { display: flex; }
 }
@@ -319,6 +330,7 @@ h1, h2, h3 {
 .nav-panel-list a:focus-visible,
 .nav-panel-cities a:focus-visible,
 .nav-panel-all-cities:focus-visible,
+.nav-promo:focus-visible,
 .nav-mobile-group-btn:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
@@ -331,83 +343,164 @@ h1, h2, h3 {
   padding-bottom: 2px;
 }
 
-/* ── NAV PANEL ───────────────────────────────────────────────────────────────
-   Full-width disclosure panel anchored to the measured nav height.
-   Desktop only (≥781px). No box-shadow, no border-radius per spec.
-   Motion: open 180ms ease-out, close 120ms ease-out — opacity + translateY
-   only (never `transition: all`, never height).
+/* ── NAV PANEL CARD ───────────────────────────────────────────────────────────
+   Contained dropdown CARD (reference look): centred under the nav, rounded,
+   hairline border + soft shadow, on the white --paper surface. ONE shell holds
+   all three group panels stacked; its height MORPHS to the open group (the JS
+   writes --nav-panel-h = the open panel's scrollHeight). Desktop only.
+   Motion: height + opacity + translateY, eased; reduced-motion → fade only.
    ────────────────────────────────────────────────────────────────────────── */
-.nav-panel {
+.nav-panel-shell {
   position: fixed;
-  top: var(--nav-h, 72px);
-  left: 0;
-  right: 0;
+  top: calc(var(--nav-h, 72px) + 8px);
+  left: 50%;
+  transform: translateX(-50%) translateY(-6px);
   z-index: 48;
-  border-top: 1px solid var(--warm-grey-75);
-  border-bottom: 1px solid var(--warm-grey-75);
-  background: var(--warm-white);
-
-  /* Closed state — opacity + translateY; visibility gates AT */
+  width: min(940px, calc(100vw - 2 * var(--gutter)));
+  height: var(--nav-panel-h, 0px);
+  background: var(--paper);
+  border: 1px solid var(--warm-grey-75);
+  border-radius: 18px;
+  box-shadow:
+    0 18px 50px -16px rgba(44, 40, 37, 0.24),
+    0 4px 12px -6px rgba(44, 40, 37, 0.10);
+  overflow: hidden;
   opacity: 0;
-  transform: translateY(-4px);
   visibility: hidden;
   pointer-events: none;
-  transition: opacity 120ms ease-out, transform 120ms ease-out,
-    visibility 0s linear 120ms;
+  transition:
+    height 240ms cubic-bezier(0.22, 1, 0.36, 1),
+    opacity 160ms ease-out,
+    transform 220ms cubic-bezier(0.22, 1, 0.36, 1),
+    visibility 0s linear 240ms;
 }
-.nav-panel.open {
+.nav-panel-shell.open {
+  transform: translateX(-50%) translateY(0);
   opacity: 1;
-  transform: translateY(0);
   visibility: visible;
   pointer-events: auto;
-  /* Open transition is slower (enters more gently) */
-  transition: opacity 180ms ease-out, transform 180ms ease-out,
+  transition:
+    height 260ms cubic-bezier(0.22, 1, 0.36, 1),
+    opacity 200ms ease-out,
+    transform 240ms cubic-bezier(0.22, 1, 0.36, 1),
     visibility 0s linear 0s;
 }
 @media (prefers-reduced-motion: reduce) {
-  .nav-panel { transition: none; }
-  .nav-panel.open { transition: none; }
+  .nav-panel-shell,
+  .nav-panel-shell.open {
+    transition: opacity 1ms linear, visibility 0s;
+  }
 }
-/* Panels are desktop-only; on mobile they are hidden entirely. */
 @media (max-width: 780px) {
-  .nav-panel { display: none; }
+  .nav-panel-shell { display: none; }
 }
 
-/* Panel content wrapper */
-.nav-panel-inner {
-  padding: 28px 0 32px;
+/* Each group's content is stacked inside the shell; only the open one shows. */
+.nav-panel {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 140ms ease-out;
 }
-/* Panel inner grid: a wide content area + a narrower support column.
-   Used by the Tjenester and Innsikt panels. */
+.nav-panel.open {
+  opacity: 1;
+  pointer-events: auto;
+  transition: opacity 200ms ease-out 40ms;
+}
+@media (prefers-reduced-motion: reduce) {
+  .nav-panel,
+  .nav-panel.open {
+    transition: none;
+  }
+}
+
+/* Card content padding */
+.nav-panel-inner {
+  padding: 26px 30px 30px;
+}
+
+/* Wide link area + a fixed-width support/promo column. */
 .nav-panel-grid {
   display: grid;
-  grid-template-columns: minmax(0, auto) minmax(0, max-content);
-  gap: 56px;
-  max-width: 960px;
+  grid-template-columns: minmax(0, 1fr) 272px;
+  gap: 40px;
+  /* Top-align so the promo column sizes to its content, never stretching. */
+  align-items: start;
 }
 .nav-panel-col-wide {
   min-width: 0;
 }
 
-/* Link list laid out as two tidy columns; the emphasized parent spans both. */
-.nav-panel-list-grid {
+/* Link list laid out as two tidy columns; the emphasized parent spans both.
+   Selector doubled so grid beats .nav-panel-list's flex display (same
+   specificity → source order would otherwise win). */
+.nav-panel-list.nav-panel-list-grid {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 240px));
-  column-gap: 44px;
-  row-gap: 4px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  column-gap: 36px;
+  row-gap: 6px;
   align-content: start;
 }
-.nav-panel-list-grid .nav-panel-parent {
+.nav-panel-list.nav-panel-list-grid .nav-panel-parent {
   grid-column: 1 / -1;
   margin-bottom: 8px;
 }
 
-/* Legacy two-column layout (kept for any consumer still using it). */
-.nav-panel-two-col {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 40px;
-  max-width: 720px;
+/* Innsikt right column: featured promo on top, city quick-links beneath. */
+.nav-panel-aside {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  min-width: 0;
+}
+
+/* ── FEATURED PROMO (icon-free) ───────────────────────────────────────────────
+   A single-anchor card in the panel's support column — accent wash, hairline,
+   rounded; eyebrow + display title + muted line + arrow CTA. */
+.nav-promo {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  padding: 18px 20px;
+  background: var(--accent-faint);
+  border: 1px solid var(--warm-grey-75);
+  border-radius: 12px;
+  transition: background 0.18s ease, border-color 0.18s ease;
+}
+@media (hover: hover) {
+  .nav-promo:hover {
+    background: var(--accent-soft);
+    border-color: var(--accent);
+  }
+}
+.nav-promo-eyebrow {
+  font-size: 10.5px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-weight: 600;
+  color: var(--warm-grey-85);
+}
+.nav-promo-title {
+  font-family: var(--font-display);
+  font-size: 17px;
+  font-weight: 500;
+  letter-spacing: -0.01em;
+  color: var(--warm-grey);
+  margin-top: 2px;
+}
+.nav-promo-desc {
+  font-size: 12.5px;
+  line-height: 1.45;
+  color: var(--warm-grey-85);
+}
+.nav-promo-cta {
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--warm-grey);
+  margin-top: 6px;
 }
 
 /* Column eyebrow label */


### PR DESCRIPTION
Reshapes the mega-dropdown toward the reference design (centered nav + contained dropdown card) while keeping DESIGN.md's **icon-free, light-only editorial** system. Built on #49.

## What changed
- **Centered nav** — logo left, links absolutely centred, CTA group right (`.nav-right` wraps CTA + mobile toggle).
- **Contained card dropdown** — one card "shell" on the `--paper` surface (hairline, rounded, soft shadow), centred under the nav, replacing the full-width C2 band. Its **height morphs** to the open group via `--nav-panel-h` (measured `scrollHeight`); panels stay in the DOM (SSR/crawlable) and cross-fade.
- **Two-column link grid + featured promo** — each panel has a wide label+description grid beside a support column. Tjenester & Om oss feature an icon-free promo card (`.nav-promo`, accent wash); Innsikt keeps the city quick-links under a Markedsrapport promo.
- Fixed `.nav-panel-list` grid specificity (flex rule was overriding the 2-column grid).
- Preserves hover/keyboard disclosure, Escape/focus-return, click-outside, `data-active` trail, `--nav-h` writer, hero-sentinel, analytics, and the mobile accordion.

## Verification
- `next build` — all routes compile
- Nav E2E (`tests/nav.spec.ts`): **17 passed** — disclosure, crawlability, SSR hrefs, analytics, mobile
- CTA-journey E2E: **4 passed** — desktop + mobile CTA → `/verktoy/pris-verdivurdering`
- Before/after screenshots confirm match to the reference (centered nav, contained card, 2-col grid, promo), icon-free in the warm palette.

🤖 Generated with [Claude Code](https://claude.com/claude-code)