### PR TITLE
feat(nav): editorial hybrid dropdown (direction C) — flat panel, eyebrow columns

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,7 +4,6 @@ import { TrackingListener } from "@/components/analytics/TrackingListener";
 import { Footer } from "@/components/site/Footer";
 import { Nav } from "@/components/site/Nav";
 import { navGroups } from "@/lib/navigation";
-import { getCities } from "@/lib/navigationServer";
 import { baseMetadata } from "@/lib/utils";
 import type { Viewport } from "next";
 import { Inter } from "next/font/google";
@@ -34,10 +33,6 @@ export default async function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  // Derived from content-collections at build time — passed to the Nav
-  // client component so it never imports content-collections itself.
-  const cities = getCities();
-
   return (
     <html
       lang="nb"
@@ -52,7 +47,7 @@ export default async function RootLayout({
       <body className="min-h-screen antialiased selection:bg-light-blue selection:text-warm-grey">
         <GoogleTagManager />
         <TrackingListener />
-        <Nav cities={cities} groups={navGroups} />
+        <Nav groups={navGroups} />
         {children}
         <Footer />
         {/* Only on real Vercel deploys — locally/CI the insights script 404s

--- a/src/components/site/Nav.tsx
+++ b/src/components/site/Nav.tsx
@@ -6,7 +6,6 @@ import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { trackEvent } from "@/lib/analytics";
 import type { NavEntry } from "@/lib/navigation";
 import { stripHash } from "@/lib/stripHash";
-import type { CityLink } from "@/lib/navigation";
 
 // useLayoutEffect on the client so the sentinel check runs BEFORE first paint
 // (no solid-nav flash on dark-hero pages); useEffect during SSR to keep React
@@ -15,65 +14,73 @@ const useIsoLayoutEffect =
   typeof window !== "undefined" ? useLayoutEffect : useEffect;
 
 export interface NavProps {
-  cities: CityLink[];
   groups: Record<GroupId, NavEntry[]>;
 }
 
 type GroupId = "tjenester" | "innsikt" | "om-oss";
 
-// Featured promo block shown in each panel's support column (icon-free).
-const PROMO: Record<GroupId, {
-  href: string;
-  eyebrow: string;
-  title: string;
-  desc: string;
-  cta: string;
-}> = {
-  tjenester: {
-    href: "/naringsmegler",
-    eyebrow: "Lokal tilstedeværelse",
-    title: "Næringsmegler i din by",
-    desc: "Lokal megler i ti byer i Nord-Norge.",
-    cta: "Se alle byer",
-  },
-  innsikt: {
-    href: "/markedsrapport",
-    eyebrow: "Fersk innsikt",
-    title: "Markedsrapport",
-    desc: "Kvartalsvise tall: yield, leie og ledighet.",
-    cta: "Les rapporten",
-  },
-  "om-oss": {
-    href: "/karriere",
-    eyebrow: "Jobb hos oss",
-    title: "Karriere i Advanti",
-    desc: "Vi bygger Nord-Norges sterkeste fagmiljø.",
-    cta: "Se ledige roller",
-  },
+// Panel columns (editorial direction C): each group's links split into two
+// eyebrow-labelled columns by theme. Paths resolve against the registry group
+// arrays; an optional "see all" link sits quietly at the column foot.
+const PANEL_COLUMNS: Record<
+  GroupId,
+  { eyebrow: string; paths: string[]; seeAll?: { href: string; label: string } }[]
+> = {
+  tjenester: [
+    {
+      eyebrow: "Rådgivning",
+      paths: [
+        "/tjenester/verdivurdering",
+        "/tjenester/transaksjoner",
+        "/tjenester/radgivning",
+        "/tjenester/strategisk-radgivning",
+      ],
+      seeAll: { href: "/tjenester", label: "Se alle tjenester" },
+    },
+    {
+      eyebrow: "Megling",
+      paths: ["/tjenester/salg", "/tjenester/utleie", "/naringsmegler"],
+    },
+  ],
+  innsikt: [
+    {
+      eyebrow: "Marked",
+      paths: ["/markedsinnsikt", "/markedsinnsikt/kart", "/markedsrapport"],
+    },
+    {
+      eyebrow: "Verktøy og innhold",
+      paths: ["/verktoy", "/help", "/blog"],
+    },
+  ],
+  "om-oss": [
+    {
+      eyebrow: "Selskapet",
+      paths: ["/om-oss", "/personer", "/karriere"],
+    },
+    {
+      eyebrow: "Arbeidet",
+      paths: ["/kunder", "/presserom"],
+    },
+  ],
 };
 
 /**
  * Site navigation — fixed; transparent over a dark hero, solid otherwise.
  *
- * Disclosure model (E1A + hover enhancement):
- *   Three centered group labels (Tjenester, Innsikt, Om oss) are <button>
- *   triggers with aria-expanded / aria-controls. Their panels live in a single
- *   contained card "shell" that morphs height between groups. Panels are ALWAYS
- *   in the server HTML (crawlable) and hidden via CSS + `inert` when closed.
+ * Disclosure model (E1A + hover): three left-anchored group labels (Tjenester,
+ * Innsikt, Om oss) are <button> triggers with aria-expanded / aria-controls.
+ * Their panels live in a single FLAT contained card "shell" (hairline, no
+ * shadow) that morphs height to the open group. Panels stay in the DOM
+ * (SSR/crawlable), cross-fade between groups.
  *
- *   POINTER: hovering a trigger opens it and morphs between groups; leaving the
- *   trigger-or-card closes after an intent delay. Gated to `(hover: hover)`.
- *   KEYBOARD/CLICK: trigger toggles; Escape closes + returns focus. Click
- *   outside and link-click close.
+ *   POINTER: hover opens + morphs between groups; leaving closes after an
+ *   intent delay (gated to (hover: hover)). KEYBOARD/CLICK: trigger toggles;
+ *   Escape closes + returns focus. Click-outside and link-click close.
  *
- * --nav-h ownership (E7): Nav measures its own height via ResizeObserver and
- *   writes --nav-h on documentElement; AnalyseportalShell only reads it.
- *
- * Transparent/solid sentinel (unchanged): a dark-hero page renders
- *   <div id="hero-sentinel" /> at the hero base; Nav stays transparent until it
- *   scrolls behind the nav. No sentinel → solid immediately.
+ * --nav-h ownership (E7): Nav measures its own height and writes --nav-h.
+ * Transparent/solid sentinel unchanged (#hero-sentinel).
  */
-export function Nav({ cities, groups }: NavProps) {
+export function Nav({ groups }: NavProps) {
   const pathname = usePathname();
   const [scrolled, setScrolled] = useState(true);
   const [menuOpen, setMenuOpen] = useState(false);
@@ -89,9 +96,8 @@ export function Nav({ cities, groups }: NavProps) {
   // Hover-intent: timer + a (hover: hover) gate so touch never opens on hover.
   const closeTimer = useRef<number | null>(null);
   const canHover = useRef(false);
-  // Which group was just opened by hover and not yet click-confirmed. Lets the
-  // click that rides along with a hover-open CONFIRM the panel open instead of
-  // toggling it shut (Playwright .click() hovers first; real mice do too).
+  // Which group was just opened by hover and not yet click-confirmed (so the
+  // click riding along with a hover-open confirms it open, not shut).
   const hoverOpened = useRef<GroupId | null>(null);
   useEffect(() => {
     canHover.current =
@@ -134,7 +140,6 @@ export function Nav({ cities, groups }: NavProps) {
     const apply = () =>
       document.documentElement.style.setProperty(
         "--nav-h",
-        // Math.ceil: a fraction too low lets content peek behind the nav.
         `${Math.ceil(nav.getBoundingClientRect().height)}px`,
       );
     apply();
@@ -306,39 +311,47 @@ export function Nav({ cities, groups }: NavProps) {
     onMouseLeave: scheduleClose,
   };
 
-  // Tjenester services shown in the grid (parent + næringsmegler rendered apart;
-  // næringsmegler is the panel's featured promo, so it is excluded here).
-  const tjenesterServices = groups.tjenester.filter(
-    (e) => e.path !== "/tjenester" && e.path !== "/naringsmegler",
-  );
-  // Innsikt links minus the parent and minus markedsrapport (the promo).
-  const innsiktLinks = groups.innsikt.filter(
-    (e) => e.path !== "/markedsinnsikt" && e.path !== "/markedsrapport",
-  );
-  // Om oss links minus the parent and minus karriere (the promo).
-  const omOssLinks = groups["om-oss"].filter(
-    (e) => e.path !== "/om-oss" && e.path !== "/karriere",
-  );
+  const byPath = (id: GroupId, path: string) =>
+    groups[id].find((e) => e.path === path);
 
-  const renderPromo = (id: GroupId) => {
-    const p = PROMO[id];
-    return (
-      <Link
-        prefetch={false}
-        href={p.href}
-        className="nav-promo"
-        aria-current={isLinkActive(p.href) ? "page" : undefined}
-        onClick={closePanel}
-      >
-        <span className="nav-promo-eyebrow">{p.eyebrow}</span>
-        <span className="nav-promo-title">{p.title}</span>
-        <span className="nav-promo-desc">{p.desc}</span>
-        <span className="nav-promo-cta">
-          {p.cta} <span aria-hidden>→</span>
-        </span>
-      </Link>
-    );
-  };
+  // Renders one flat eyebrow-labelled column for a desktop panel.
+  const renderPanel = (id: GroupId) => (
+    <div className="nav-panel-inner nav-panel-grid">
+      {PANEL_COLUMNS[id].map((col) => (
+        <div className="nav-panel-col" key={col.eyebrow}>
+          <span className="nav-panel-eyebrow">{col.eyebrow}</span>
+          <ul className="nav-panel-list" onClick={closePanel}>
+            {col.paths.map((p) => {
+              const e = byPath(id, p);
+              if (!e) return null;
+              return (
+                <li key={p}>
+                  <Link
+                    prefetch={false}
+                    href={e.path}
+                    aria-current={isLinkActive(e.path) ? "page" : undefined}
+                  >
+                    {e.label}
+                  </Link>
+                </li>
+              );
+            })}
+          </ul>
+          {col.seeAll && (
+            <Link
+              prefetch={false}
+              href={col.seeAll.href}
+              className="nav-panel-seeall"
+              aria-current={cleanPath === col.seeAll.href ? "page" : undefined}
+              onClick={closePanel}
+            >
+              {col.seeAll.label} →
+            </Link>
+          )}
+        </div>
+      ))}
+    </div>
+  );
 
   return (
     <>
@@ -436,169 +449,39 @@ export function Nav({ cities, groups }: NavProps) {
       </nav>
 
       {/* ──────────────────────────────────────────────────────────────────
-          DESKTOP PANEL SHELL — one contained card that morphs height between
-          groups. Panels are always in the DOM (SSR/crawlability), hidden via
-          opacity + inert when their group is closed.
+          DESKTOP PANEL SHELL — one flat contained card that morphs height.
+          Panels always in the DOM (SSR/crawlable), hidden via opacity + inert.
           ────────────────────────────────────────────────────────────── */}
       <div
         className={`nav-panel-shell${openGroup ? " open" : ""}`}
         ref={shellRef}
         {...panelHoverProps}
       >
-        {/* Tjenester */}
         <div
           id="nav-panel-tjenester"
           className={`nav-panel${openGroup === "tjenester" ? " open" : ""}`}
           ref={panelRefCb["tjenester"]}
           inert={openGroup !== "tjenester"}
         >
-          <div className="nav-panel-inner nav-panel-grid">
-            <div className="nav-panel-col-wide">
-              <span className="nav-panel-eyebrow">Tjenester</span>
-              <ul
-                className="nav-panel-list nav-panel-list-grid"
-                onClick={closePanel}
-              >
-                <li className="nav-panel-parent">
-                  <Link
-                    prefetch={false}
-                    href="/tjenester"
-                    aria-current={
-                      cleanPath === "/tjenester" ? "page" : undefined
-                    }
-                  >
-                    Alle tjenester
-                  </Link>
-                </li>
-                {tjenesterServices.map((e) => (
-                  <li key={e.path}>
-                    <Link
-                      prefetch={false}
-                      href={e.path}
-                      aria-current={isLinkActive(e.path) ? "page" : undefined}
-                    >
-                      {e.label}
-                    </Link>
-                    {e.description && (
-                      <span className="nav-panel-desc">{e.description}</span>
-                    )}
-                  </li>
-                ))}
-              </ul>
-            </div>
-            {renderPromo("tjenester")}
-          </div>
+          {renderPanel("tjenester")}
         </div>
 
-        {/* Innsikt */}
         <div
           id="nav-panel-innsikt"
           className={`nav-panel${openGroup === "innsikt" ? " open" : ""}`}
           ref={panelRefCb["innsikt"]}
           inert={openGroup !== "innsikt"}
         >
-          <div className="nav-panel-inner nav-panel-grid">
-            <div className="nav-panel-col-wide">
-              <span className="nav-panel-eyebrow">Innsikt</span>
-              <ul
-                className="nav-panel-list nav-panel-list-grid"
-                onClick={closePanel}
-              >
-                <li className="nav-panel-parent">
-                  <Link
-                    prefetch={false}
-                    href="/markedsinnsikt"
-                    aria-current={
-                      isLinkActive("/markedsinnsikt") ? "page" : undefined
-                    }
-                  >
-                    Markedsinnsikt
-                  </Link>
-                  <span className="nav-panel-desc">
-                    Oversikt over næringseiendomsmarkedet i Nord-Norge.
-                  </span>
-                </li>
-                {innsiktLinks.map((e) => (
-                  <li key={e.path}>
-                    <Link
-                      prefetch={false}
-                      href={e.path}
-                      aria-current={isLinkActive(e.path) ? "page" : undefined}
-                    >
-                      {e.label}
-                    </Link>
-                    {e.description && (
-                      <span className="nav-panel-desc">{e.description}</span>
-                    )}
-                  </li>
-                ))}
-              </ul>
-            </div>
-
-            {/* Right column — featured Markedsrapport promo + city quick-links */}
-            <div className="nav-panel-aside">
-              {renderPromo("innsikt")}
-              <div className="nav-panel-cities-block">
-                <span className="nav-panel-eyebrow">Byer</span>
-                <div className="nav-panel-cities" onClick={closePanel}>
-                  {cities.slice(0, 8).map((city) => (
-                    <Link
-                      prefetch={false}
-                      key={city.slug}
-                      href={`/naringsmegler/${city.slug}`}
-                      aria-current={
-                        isLinkActive(`/naringsmegler/${city.slug}`)
-                          ? "page"
-                          : undefined
-                      }
-                    >
-                      {city.name}
-                    </Link>
-                  ))}
-                </div>
-              </div>
-            </div>
-          </div>
+          {renderPanel("innsikt")}
         </div>
 
-        {/* Om oss */}
         <div
           id="nav-panel-om-oss"
           className={`nav-panel${openGroup === "om-oss" ? " open" : ""}`}
           ref={panelRefCb["om-oss"]}
           inert={openGroup !== "om-oss"}
         >
-          <div className="nav-panel-inner nav-panel-grid">
-            <div className="nav-panel-col-wide">
-              <span className="nav-panel-eyebrow">Advanti</span>
-              <ul
-                className="nav-panel-list nav-panel-list-grid"
-                onClick={closePanel}
-              >
-                <li className="nav-panel-parent">
-                  <Link
-                    prefetch={false}
-                    href="/om-oss"
-                    aria-current={isLinkActive("/om-oss") ? "page" : undefined}
-                  >
-                    Om oss
-                  </Link>
-                </li>
-                {omOssLinks.map((e) => (
-                  <li key={e.path}>
-                    <Link
-                      prefetch={false}
-                      href={e.path}
-                      aria-current={isLinkActive(e.path) ? "page" : undefined}
-                    >
-                      {e.label}
-                    </Link>
-                  </li>
-                ))}
-              </ul>
-            </div>
-            {renderPromo("om-oss")}
-          </div>
+          {renderPanel("om-oss")}
         </div>
       </div>
 

--- a/src/styles/advanti-design.css
+++ b/src/styles/advanti-design.css
@@ -186,11 +186,11 @@ h1, h2, h3 {
   opacity: 0.85;
 }
 /* Centered nav: logo sits left, the CTA group right (.nav-right), and the
-   links are absolutely centred in the bar (reference layout). */
+   links sit just right of the logo (left-anchored editorial layout); the
+   CTA group (.nav-right) is pushed to the far right by margin-right:auto. */
 .nav-links {
-  position: absolute;
-  left: 50%;
-  transform: translateX(-50%);
+  margin-left: 44px;
+  margin-right: auto;
   display: flex;
   align-items: center;
   gap: 32px;
@@ -330,7 +330,7 @@ h1, h2, h3 {
 .nav-panel-list a:focus-visible,
 .nav-panel-cities a:focus-visible,
 .nav-panel-all-cities:focus-visible,
-.nav-promo:focus-visible,
+.nav-panel-seeall:focus-visible,
 .nav-mobile-group-btn:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
@@ -352,18 +352,17 @@ h1, h2, h3 {
    ────────────────────────────────────────────────────────────────────────── */
 .nav-panel-shell {
   position: fixed;
-  top: calc(var(--nav-h, 72px) + 8px);
-  left: 50%;
-  transform: translateX(-50%) translateY(-6px);
+  top: calc(var(--nav-h, 72px) + 4px);
+  /* Left-anchored under the logo/links (editorial), not centred. */
+  left: var(--gutter);
+  transform: translateY(-6px);
   z-index: 48;
-  width: min(940px, calc(100vw - 2 * var(--gutter)));
+  width: min(680px, calc(100vw - 2 * var(--gutter)));
   height: var(--nav-panel-h, 0px);
   background: var(--paper);
   border: 1px solid var(--warm-grey-75);
-  border-radius: 18px;
-  box-shadow:
-    0 18px 50px -16px rgba(44, 40, 37, 0.24),
-    0 4px 12px -6px rgba(44, 40, 37, 0.10);
+  border-radius: 10px;
+  /* Flat editorial panel — hairline only, NO drop shadow. */
   overflow: hidden;
   opacity: 0;
   visibility: hidden;
@@ -375,7 +374,7 @@ h1, h2, h3 {
     visibility 0s linear 240ms;
 }
 .nav-panel-shell.open {
-  transform: translateX(-50%) translateY(0);
+  transform: translateY(0);
   opacity: 1;
   visibility: visible;
   pointer-events: auto;
@@ -422,85 +421,31 @@ h1, h2, h3 {
   padding: 26px 30px 30px;
 }
 
-/* Wide link area + a fixed-width support/promo column. */
+/* Two equal eyebrow columns (editorial — flat, typographic, sparse). */
 .nav-panel-grid {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 272px;
-  gap: 40px;
-  /* Top-align so the promo column sizes to its content, never stretching. */
+  grid-template-columns: 1fr 1fr;
+  gap: 44px;
   align-items: start;
 }
-.nav-panel-col-wide {
+.nav-panel-col {
   min-width: 0;
-}
-
-/* Link list laid out as two tidy columns; the emphasized parent spans both.
-   Selector doubled so grid beats .nav-panel-list's flex display (same
-   specificity → source order would otherwise win). */
-.nav-panel-list.nav-panel-list-grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  column-gap: 36px;
-  row-gap: 6px;
-  align-content: start;
-}
-.nav-panel-list.nav-panel-list-grid .nav-panel-parent {
-  grid-column: 1 / -1;
-  margin-bottom: 8px;
-}
-
-/* Innsikt right column: featured promo on top, city quick-links beneath. */
-.nav-panel-aside {
   display: flex;
   flex-direction: column;
-  gap: 18px;
-  min-width: 0;
 }
 
-/* ── FEATURED PROMO (icon-free) ───────────────────────────────────────────────
-   A single-anchor card in the panel's support column — accent wash, hairline,
-   rounded; eyebrow + display title + muted line + arrow CTA. */
-.nav-promo {
-  display: flex;
-  flex-direction: column;
-  gap: 5px;
-  padding: 18px 20px;
-  background: var(--accent-faint);
-  border: 1px solid var(--warm-grey-75);
-  border-radius: 12px;
-  transition: background 0.18s ease, border-color 0.18s ease;
+/* Quiet "Se alle …" link at the foot of a column (no box, no fill). */
+.nav-panel-seeall {
+  display: inline-block;
+  margin-top: 16px;
+  font-size: 13px;
+  font-weight: 500;
+  letter-spacing: -0.005em;
+  color: var(--warm-grey-85);
+  transition: color 0.15s ease;
 }
 @media (hover: hover) {
-  .nav-promo:hover {
-    background: var(--accent-soft);
-    border-color: var(--accent);
-  }
-}
-.nav-promo-eyebrow {
-  font-size: 10.5px;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-  font-weight: 600;
-  color: var(--warm-grey-85);
-}
-.nav-promo-title {
-  font-family: var(--font-display);
-  font-size: 17px;
-  font-weight: 500;
-  letter-spacing: -0.01em;
-  color: var(--warm-grey);
-  margin-top: 2px;
-}
-.nav-promo-desc {
-  font-size: 12.5px;
-  line-height: 1.45;
-  color: var(--warm-grey-85);
-}
-.nav-promo-cta {
-  font-size: 12.5px;
-  font-weight: 600;
-  color: var(--warm-grey);
-  margin-top: 6px;
+  .nav-panel-seeall:hover { color: var(--warm-grey); }
 }
 
 /* Column eyebrow label */


### PR DESCRIPTION
Resolves the "navbaren føles ikke rett" loop. After a `/plan-design-review`, the root cause was clear: each prior iteration imported SaaS conventions (drop-shadow card, accent-wash promo box, centered nav) that fight DESIGN.md's editorial system, so the nav read as a generic template. We generated three mockup directions and you picked **C — editorial hybrid**. This implements C.

## What changed (mostly subtraction)
- **Un-centered nav** — logo left, links left-anchored, CTA right.
- **Flat dropdown** — removed `box-shadow`, left-anchored under the logo, crisp 1px hairline + 10px radius on `--paper`. No floating-card look.
- **Dropped the filled promo card** — panels are now two eyebrow-labelled typographic columns (Rådgivning/Megling · Marked/Verktøy · Selskapet/Arbeidet) with a quiet "Se alle tjenester →" link. Label-only, sparse, icon-free.
- Removed the `cities` prop from Nav (cities live in the footer); dropped `getCities` from `layout.tsx`.
- Kept: hover + keyboard disclosure, height-morph, Escape/focus, click-outside, `data-active` trail, `--nav-h` writer, hero sentinel, analytics, mobile accordion.

## Verification
- `next build` — clean
- Nav E2E (`tests/nav.spec.ts`): **17 passed** — disclosure, crawlability, SSR hrefs, analytics, mobile
- Screenshot matches the approved C mockup (left-anchored, flat hairline panel, eyebrow columns).

Brand coherence 4/10 → editorial-true. Mockups + approval in `~/.gstack/projects/Codehagen-advantiestate/designs/nav-direction-20260613/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Redesigned desktop navigation dropdown with left-anchored links and two-column grid layout
  * Updated dropdown panel styling with narrower width and improved visual hierarchy
  * Simplified appearance by removing promotional content areas
  * Enhanced overall consistency with the site's editorial design

<!-- end of auto-generated comment: release notes by coderabbit.ai -->