### PR TITLE
fix(ci): drop pre-build typecheck step that breaks on content-collections

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,12 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      - run: pnpm typecheck
+      # No standalone `pnpm typecheck` step: `tsc --noEmit` needs the
+      # content-collections generated types, which only exist after the Next
+      # plugin runs during `next build`. The Playwright step below runs
+      # `pnpm build` (ignoreBuildErrors: false), so the full app is type-checked
+      # there with the generated types present. A separate pre-build typecheck
+      # fails on a clean checkout with "Cannot find module 'content-collections'".
 
       - run: pnpm lint
 


### PR DESCRIPTION
## Problem
`main` has been red on every PR since the `pnpm typecheck` step was added to `ci.yml`. It runs `tsc --noEmit` right after `pnpm install`, before content-collections types are generated. Those types only exist after the Next plugin runs during `next build`, and `.content-collections/generated` is gitignored — so the step fails instantly with `Cannot find module 'content-collections'` and a cascade of implicit-any errors in pre-existing files.

## Fix
Remove the standalone typecheck step. The Playwright step already runs `pnpm build` (webServer) with `ignoreBuildErrors: false`, which type-checks the whole app **with the generated types present** — so the separate step was redundant as well as broken. This restores the green CI we had through PR #52 (which had no typecheck step).

## Follow-up (not in this PR)
If a fast standalone typecheck is wanted back, it needs a content-collections generation step before it (e.g. add `@content-collections/cli` and run `content-collections build` ahead of `tsc`). Out of scope here — this PR just unblocks main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)