### PR TITLE
fix(nav): no layout shift when opening a dropdown (Emil #1)

### DIFF
--- a/src/components/site/Nav.tsx
+++ b/src/components/site/Nav.tsx
@@ -341,9 +341,13 @@ export function Nav({ groups }: NavProps) {
     setOpenGroup(null);
   };
 
+  // `scrolled` (size change) is driven ONLY by real scroll. `solid` (opaque
+  // background) also applies while a dropdown / mobile menu is open — so opening
+  // a panel never resizes the bar (no layout shift on hover).
   const navClass = [
     "nav",
-    scrolled || menuOpen || !!openGroup ? "scrolled" : "",
+    scrolled ? "scrolled" : "",
+    scrolled || menuOpen || !!openGroup ? "solid" : "",
   ]
     .filter(Boolean)
     .join(" ");

--- a/src/styles/advanti-design.css
+++ b/src/styles/advanti-design.css
@@ -150,15 +150,24 @@ h1, h2, h3 {
   align-items: center;
   justify-content: space-between;
   color: var(--warm-white);
-  transition: background 0.35s ease, color 0.35s ease, padding 0.3s ease;
+  /* Reserve the hairline always (transparent) so going solid adds no height. */
+  border-bottom: 1px solid transparent;
+  transition: background 0.35s ease, color 0.35s ease, padding 0.3s ease,
+    border-color 0.35s ease;
   mix-blend-mode: normal;
 }
-.nav.scrolled {
+/* Solid surface (background + readable text). Applied when scrolled OR a
+   dropdown / mobile menu is open — NO size change, so opening never shifts the
+   bar (Emil: no layout shift). */
+.nav.solid {
   background: rgba(243, 241, 239, 0.95);
   backdrop-filter: blur(14px);
   -webkit-backdrop-filter: blur(14px);
   color: var(--warm-grey);
   border-bottom: var(--hairline);
+}
+/* Size change is scroll-only — never triggered by hover/open. */
+.nav.scrolled {
   padding: 16px var(--gutter);
 }
 .nav-logo {
@@ -226,7 +235,7 @@ h1, h2, h3 {
    on the light fill; the scrolled rule below handles the solid nav. */
 .nav-cta:hover span { color: var(--warm-grey); }
 .dark .nav-cta:hover span { color: var(--warm-grey); }
-.nav.scrolled .nav-cta:hover span { color: var(--warm-white); }
+.nav.solid .nav-cta:hover span { color: var(--warm-white); }
 
 /* Mobile menu — hamburger toggle + full-screen panel. Hidden on desktop. */
 .nav-toggle {


### PR DESCRIPTION
Hovering a nav dropdown forced the bar into its scrolled state, shrinking padding 22px→16px — so the header **jumped up on hover and dropped back on leave**.

Fix (per Emil's #1 "No Layout Shift"): split the opaque background from the size change.
- `.nav.solid` (background + readable text) applies on scroll **or** when a dropdown/mobile menu is open — no size change.
- `.nav.scrolled` (the padding shrink) applies **only** on real scroll.
- Reserve the hairline with an always-present transparent `border-bottom`, so going solid adds zero height; the colour fades with the background.

**Verified:** nav height identical closed vs open (87px → 87px, measured live), clean build, nav.spec 17/17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed navigation bar styling to apply scroll-triggered appearance only when the user actually scrolls, not when opening menus or dropdown panels
  * Improved visual transitions and layout consistency when toggling between transparent and solid navigation backgrounds

<!-- end of auto-generated comment: release notes by coderabbit.ai -->