### PR TITLE
feat(leads): lead-engine improvements (CEO audit tracks A–D)

### DIFF
--- a/src/app/actions/cta-lead.ts
+++ b/src/app/actions/cta-lead.ts
@@ -1,6 +1,6 @@
 "use server"
 
-import { notifyLead } from "@/lib/email/discord"
+import { subscribe } from "@/lib/email/subscribe"
 import { checkRateLimit } from "@/lib/rate-limit"
 
 export type CtaLeadInput = {
@@ -39,13 +39,19 @@ export async function submitCtaLead(input: CtaLeadInput): Promise<CtaLeadResult>
     if (value) intake[String(k).slice(0, 50)] = value
   }
 
-  await notifyLead({
+  // Route through the shared pipeline so these high-intent service-page leads
+  // land in Supabase crm_leads (+ crm_activities) and the Discord digest — not
+  // Discord alone, which lost them the moment a ping was missed. No
+  // marketingConsent: submitting a CTA is a contact request, not a newsletter
+  // opt-in, so the address does not enter the Resend audience.
+  const result = await subscribe({
     email,
-    source: "service",
+    source: "service-modal",
     pageUrl: input.pageUrl?.slice(0, 200),
     firstName: name,
     intake,
   })
 
+  if (!result.ok) return { ok: false, error: result.error }
   return { ok: true }
 }

--- a/src/app/actions/verdivurdering-intake.ts
+++ b/src/app/actions/verdivurdering-intake.ts
@@ -1,9 +1,18 @@
 "use server"
 
-import { subscribe } from "@/lib/email/subscribe"
+import { subscribe, type SubscribeSource } from "@/lib/email/subscribe"
 import { checkRateLimit } from "@/lib/rate-limit"
 
 export type IntakeResult = { ok: true } | { ok: false; error: string }
+
+// Surfaces allowed to reuse this intake. Both are high-intent owner
+// requests with identical fields; they differ only in the offer framing and
+// the CRM source they land under. A hidden `intakeSource` field selects which
+// — whitelisted here so a tampered form can't inject an arbitrary source.
+const ALLOWED_SOURCES: SubscribeSource[] = [
+  "verdivurdering-intake",
+  "eiernotat",
+]
 
 /**
  * Verdivurdering intake — the hardest-intent surface on the site.
@@ -48,6 +57,15 @@ export async function subscribeVerdivurderingIntake(
   // service page for backward compatibility.
   const page = get("page") ?? "/tjenester/verdivurdering"
 
+  // `intakeSource` selects the CRM source (verdivurdering vs eiernotat).
+  // Falls back to verdivurdering-intake for every existing form that doesn't
+  // send it, and ignores any value not on the whitelist.
+  const requested = get("intakeSource") as SubscribeSource | undefined
+  const source: SubscribeSource =
+    requested && ALLOWED_SOURCES.includes(requested)
+      ? requested
+      : "verdivurdering-intake"
+
   // Hard-intent minimum: email + property type + location + purpose. firstName
   // is required at the form level so we can address them in the welcome.
   if (!email || !propertyType || !location || !purpose) {
@@ -73,7 +91,7 @@ export async function subscribeVerdivurderingIntake(
   const result = await subscribe({
     email,
     firstName,
-    source: "verdivurdering-intake",
+    source,
     pageUrl: page,
     intake,
   })

--- a/src/app/eiernotat/page.tsx
+++ b/src/app/eiernotat/page.tsx
@@ -82,6 +82,8 @@ export default function EiernotatPage() {
               source="eiernotat"
               intakeSource="eiernotat"
               prefill={prefill}
+              headingTitle="Be om et eiernotat."
+              headingSubtitle="Noen få felter om eiendommen. Du får notatet innen 48 timer — uforpliktende."
             />
 
             {/* RIGHT: what the memo contains + process */}

--- a/src/app/eiernotat/page.tsx
+++ b/src/app/eiernotat/page.tsx
@@ -54,7 +54,7 @@ export default function EiernotatPage() {
             <Link
               href="/tjenester/verdivurdering"
               className="underline decoration-warm-grey-75 underline-offset-4 hover:text-warm-grey"
-              style={{ fontWeight: 500, color: "var(--accent)" }}
+              style={{ fontWeight: 500, color: "var(--warm-grey)" }}
             >
               Se verdivurdering →
             </Link>
@@ -64,7 +64,7 @@ export default function EiernotatPage() {
             <Link
               href="/verktoy/naringskalkulator"
               className="underline decoration-warm-grey-75 underline-offset-4 hover:text-warm-grey"
-              style={{ fontWeight: 500, color: "var(--accent)" }}
+              style={{ fontWeight: 500, color: "var(--warm-grey)" }}
             >
               Prøv næringskalkulatoren →
             </Link>

--- a/src/app/eiernotat/page.tsx
+++ b/src/app/eiernotat/page.tsx
@@ -1,0 +1,171 @@
+import Link from "next/link";
+
+import { constructMetadata } from "@/lib/utils";
+import { SubHero } from "@/components/site/SubHero";
+import { Breadcrumbs } from "@/components/site/Breadcrumbs";
+import {
+  VerdivurderingIntakeForm,
+  type VerdivurderingPrefill,
+} from "@/components/forms/VerdivurderingIntakeForm";
+
+export const metadata = constructMetadata({
+  path: "/eiernotat",
+  // DRAFT conversion surface. noIndex until the partner-facing offer copy and
+  // the 48-hour memo fulfilment workflow have had a human review (see PR #61 /
+  // plan Track C1). Flip to indexed once the offer is signed off.
+  noIndex: true,
+  title: "Eiernotat — beslutningsgrunnlag for næringseiendom | Advanti Estate",
+  description:
+    "Bør du selge, refinansiere, holde, leie ut eller reposisjonere? Be om et eiernotat: et kort, partner-vurdert beslutningsnotat for eiendommen din innen 48 timer.",
+});
+
+export default function EiernotatPage() {
+  // The eiernotat reuses the verdivurdering intake form (same fields), but
+  // lands under its own CRM/analytics source and frames a different offer:
+  // a written decision memo rather than a value estimate.
+  const prefill: VerdivurderingPrefill = {};
+
+  return (
+    <>
+      <SubHero
+        breadcrumbs={<Breadcrumbs path="/eiernotat" />}
+        eyebrow="Eiernotat · Partner-vurdert · 48 timer"
+        title={
+          <>
+            Bør du selge, refinansiere
+            <br />
+            eller <span className="italic">holde</span>?
+          </>
+        }
+        lede="Et eiernotat er et kort, skriftlig beslutningsgrunnlag fra en av partnerne våre — ikke en automatisk takst. Du får en indikativ yield-range, et bilde av hvem de sannsynlige kjøperne er, mulig leieoppside, og en konkret anbefaling om neste steg. Innen 48 timer, uforpliktende."
+      >
+        <p
+          style={{
+            marginTop: 24,
+            fontSize: 15,
+            color: "var(--warm-grey-85)",
+            display: "flex",
+            flexWrap: "wrap",
+            gap: "8px 28px",
+          }}
+        >
+          <span>
+            Vil du bare ha et verdianslag?{" "}
+            <Link
+              href="/tjenester/verdivurdering"
+              className="underline decoration-warm-grey-75 underline-offset-4 hover:text-warm-grey"
+              style={{ fontWeight: 500, color: "var(--accent)" }}
+            >
+              Se verdivurdering →
+            </Link>
+          </span>
+          <span>
+            Vil du regne selv først?{" "}
+            <Link
+              href="/verktoy/naringskalkulator"
+              className="underline decoration-warm-grey-75 underline-offset-4 hover:text-warm-grey"
+              style={{ fontWeight: 500, color: "var(--accent)" }}
+            >
+              Prøv næringskalkulatoren →
+            </Link>
+          </span>
+        </p>
+      </SubHero>
+
+      {/* FORM GRID */}
+      <section className="section section-divider" style={{ paddingTop: 64 }}>
+        <div className="wrap">
+          <div className="contact-grid">
+            {/* LEFT: shared intake form, eiernotat source */}
+            <VerdivurderingIntakeForm
+              page="/eiernotat"
+              source="eiernotat"
+              intakeSource="eiernotat"
+              prefill={prefill}
+            />
+
+            {/* RIGHT: what the memo contains + process */}
+            <aside>
+              <div className="vv-aside-card">
+                <div className="pre">Hva notatet inneholder</div>
+                <ul className="vv-gets">
+                  <li>
+                    <span className="ico" aria-hidden="true">
+                      I
+                    </span>
+                    <div>
+                      <h4>Indikativ yield og verdi-range</h4>
+                      <p>
+                        Avstemt mot reelle transaksjoner i ditt segment og din
+                        by — fra vår egen database, ikke en generisk kalkulator.
+                      </p>
+                    </div>
+                  </li>
+                  <li>
+                    <span className="ico" aria-hidden="true">
+                      II
+                    </span>
+                    <div>
+                      <h4>Hvem som er de sannsynlige kjøperne</h4>
+                      <p>
+                        Hvilke kjøpergrupper som er aktive for en eiendom som
+                        din nå, og hva de er villige til å betale for.
+                      </p>
+                    </div>
+                  </li>
+                  <li>
+                    <span className="ico" aria-hidden="true">
+                      III
+                    </span>
+                    <div>
+                      <h4>En konkret anbefaling</h4>
+                      <p>
+                        Selge, refinansiere, holde, leie ut eller reposisjonere
+                        — med begrunnelse for hva som tjener deg best akkurat nå.
+                      </p>
+                    </div>
+                  </li>
+                </ul>
+              </div>
+
+              <div
+                className="next-steps"
+                style={{ borderTop: "none", paddingTop: 0, marginBottom: 32 }}
+              >
+                <h3>Slik går vi frem</h3>
+                <ol>
+                  <li>
+                    <span className="n">01</span>
+                    <div>
+                      <h4>Du sender forespørselen</h4>
+                      <p>Noen få felter om eiendommen og situasjonen din.</p>
+                    </div>
+                  </li>
+                  <li>
+                    <span className="n">02</span>
+                    <div>
+                      <h4>En partner går gjennom den</h4>
+                      <p>
+                        Vi vurderer eiendommen mot markedet og skriver notatet.
+                      </p>
+                    </div>
+                  </li>
+                  <li>
+                    <span className="n">03</span>
+                    <div>
+                      <h4>Du får notatet innen 48 timer</h4>
+                      <p>
+                        Skriftlig, uforpliktende. Vil du gå videre, tar vi en
+                        samtale.
+                      </p>
+                    </div>
+                  </li>
+                </ol>
+              </div>
+            </aside>
+          </div>
+        </div>
+      </section>
+    </>
+  );
+}

--- a/src/app/verdivurdering/page.tsx
+++ b/src/app/verdivurdering/page.tsx
@@ -70,7 +70,7 @@ export default async function FaaVerdivurderingPage({
             <Link
               href="/verktoy/naringskalkulator"
               className="underline decoration-warm-grey-75 underline-offset-4 hover:text-warm-grey"
-              style={{ fontWeight: 500, color: "var(--accent)" }}
+              style={{ fontWeight: 500, color: "var(--warm-grey)" }}
             >
               Prøv næringskalkulatoren →
             </Link>
@@ -80,7 +80,7 @@ export default async function FaaVerdivurderingPage({
             <Link
               href="/sjekkliste-verdivurdering"
               className="underline decoration-warm-grey-75 underline-offset-4 hover:text-warm-grey"
-              style={{ fontWeight: 500, color: "var(--accent)" }}
+              style={{ fontWeight: 500, color: "var(--warm-grey)" }}
             >
               Se sjekklisten →
             </Link>

--- a/src/components/forms/VerdivurderingIntakeForm.tsx
+++ b/src/components/forms/VerdivurderingIntakeForm.tsx
@@ -1,9 +1,9 @@
 "use client"
 
-import { useEffect, useState, type FormEvent } from "react"
+import { useEffect, useRef, useState, type FormEvent } from "react"
 
 import { subscribeVerdivurderingIntake } from "@/app/actions/verdivurdering-intake"
-import { trackEvent } from "@/lib/analytics"
+import { trackEvent, trackLeadStart, trackLeadSubmit } from "@/lib/analytics"
 
 type FormStatus =
   | { status: "idle" }
@@ -76,11 +76,20 @@ export function VerdivurderingIntakeForm({
   showHeading = true,
 }: Props) {
   const [state, setState] = useState<FormStatus>({ status: "idle" })
+  // Dedupe the lead_form_start event so it fires once per mount, on the first
+  // real field interaction (not on mere view).
+  const startedRef = useRef(false)
 
   // Fire once when the form is shown so we can measure form-views per surface.
   useEffect(() => {
     trackEvent("journey_step", { step: "skjema", source })
   }, [source])
+
+  function handleFirstFocus() {
+    if (startedRef.current) return
+    startedRef.current = true
+    trackLeadStart(source, "verdivurdering")
+  }
 
   const hasPrefill = Boolean(
     prefill && (prefill.type || prefill.by || prefill.areal || prefill.leie),
@@ -95,6 +104,7 @@ export function VerdivurderingIntakeForm({
       if (result.ok) {
         setState({ status: "success" })
         trackEvent("rapport_bestill", { source })
+        trackLeadSubmit(source, "verdivurdering")
       } else {
         setState({ status: "error", message: result.error })
       }
@@ -125,7 +135,11 @@ export function VerdivurderingIntakeForm({
   const isSubmitting = state.status === "submitting"
 
   return (
-    <form onSubmit={handleSubmit} className="contact-form vv-form">
+    <form
+      onSubmit={handleSubmit}
+      onFocusCapture={handleFirstFocus}
+      className="contact-form vv-form"
+    >
       {showHeading && (
         <>
           <h2>Be om verdivurdering.</h2>

--- a/src/components/forms/VerdivurderingIntakeForm.tsx
+++ b/src/components/forms/VerdivurderingIntakeForm.tsx
@@ -1,9 +1,10 @@
 "use client"
 
-import { useEffect, useRef, useState, type FormEvent } from "react"
+import { useEffect, useState, type FormEvent } from "react"
 
 import { subscribeVerdivurderingIntake } from "@/app/actions/verdivurdering-intake"
-import { trackEvent, trackLeadStart, trackLeadSubmit } from "@/lib/analytics"
+import { trackEvent, trackLeadSubmit } from "@/lib/analytics"
+import { useLeadStartOnFocus } from "@/lib/hooks/useLeadFunnel"
 
 type FormStatus =
   | { status: "idle" }
@@ -36,6 +37,13 @@ type Props = {
    * provides a heading (e.g. the #bestill section on the service page).
    */
   showHeading?: boolean
+  /**
+   * Heading copy when showHeading is true. Defaults to the verdivurdering
+   * wording; the eiernotat surface overrides it so the reused form doesn't
+   * contradict the page it sits on.
+   */
+  headingTitle?: string
+  headingSubtitle?: string
 }
 
 const PROPERTY_TYPES = [
@@ -81,22 +89,19 @@ export function VerdivurderingIntakeForm({
   intakeSource,
   prefill,
   showHeading = true,
+  headingTitle = "Be om verdivurdering.",
+  headingSubtitle = "Det tar to minutter. Du forplikter deg ikke til noe.",
 }: Props) {
   const [state, setState] = useState<FormStatus>({ status: "idle" })
-  // Dedupe the lead_form_start event so it fires once per mount, on the first
-  // real field interaction (not on mere view).
-  const startedRef = useRef(false)
+  // Human form label for the funnel events — distinguishes eiernotat from the
+  // verdivurdering reuse of the same form.
+  const formLabel = intakeSource === "eiernotat" ? "eiernotat" : "verdivurdering"
+  const handleFirstFocus = useLeadStartOnFocus(source, formLabel)
 
   // Fire once when the form is shown so we can measure form-views per surface.
   useEffect(() => {
     trackEvent("journey_step", { step: "skjema", source })
   }, [source])
-
-  function handleFirstFocus() {
-    if (startedRef.current) return
-    startedRef.current = true
-    trackLeadStart(source, "verdivurdering")
-  }
 
   const hasPrefill = Boolean(
     prefill && (prefill.type || prefill.by || prefill.areal || prefill.leie),
@@ -111,7 +116,7 @@ export function VerdivurderingIntakeForm({
       if (result.ok) {
         setState({ status: "success" })
         trackEvent("rapport_bestill", { source })
-        trackLeadSubmit(source, "verdivurdering")
+        trackLeadSubmit(source, formLabel)
       } else {
         setState({ status: "error", message: result.error })
       }
@@ -149,10 +154,8 @@ export function VerdivurderingIntakeForm({
     >
       {showHeading && (
         <>
-          <h2>Be om verdivurdering.</h2>
-          <p className="sub">
-            Det tar to minutter. Du forplikter deg ikke til noe.
-          </p>
+          <h2>{headingTitle}</h2>
+          <p className="sub">{headingSubtitle}</p>
         </>
       )}
 

--- a/src/components/forms/VerdivurderingIntakeForm.tsx
+++ b/src/components/forms/VerdivurderingIntakeForm.tsx
@@ -23,6 +23,12 @@ type Props = {
   page: string
   /** Analytics source dimension (distinguishes funnel surfaces). */
   source: string
+  /**
+   * CRM source the lead lands under. Defaults server-side to
+   * "verdivurdering-intake"; the eiernotat surface passes "eiernotat" so the
+   * same form/action serves both offers without duplication.
+   */
+  intakeSource?: "verdivurdering-intake" | "eiernotat"
   /** Optional prefill carried from the næringskalkulator via URL params. */
   prefill?: VerdivurderingPrefill
   /**
@@ -72,6 +78,7 @@ function matchesType(prefill: string | undefined, value: string): boolean {
 export function VerdivurderingIntakeForm({
   page,
   source,
+  intakeSource,
   prefill,
   showHeading = true,
 }: Props) {
@@ -150,6 +157,9 @@ export function VerdivurderingIntakeForm({
       )}
 
       <input type="hidden" name="page" value={page} />
+      {intakeSource && (
+        <input type="hidden" name="intakeSource" value={intakeSource} />
+      )}
 
       {hasPrefill && (
         <p className="vv-prefill-note">

--- a/src/components/modals/AdvisoryRequestModal.tsx
+++ b/src/components/modals/AdvisoryRequestModal.tsx
@@ -7,6 +7,7 @@ import Modal from "@/components/blog/modal"
 import { RiCloseLine, RiLightbulbLine, RiCheckLine } from "@remixicon/react"
 import { useState, type Dispatch, type SetStateAction } from "react"
 import { submitCtaLead } from "@/app/actions/cta-lead"
+import { trackLeadSubmit } from "@/lib/analytics"
 
 interface AdvisoryRequestModalProps {
   showModal: boolean
@@ -42,6 +43,7 @@ export default function AdvisoryRequestModal({
 
     setIsSubmitting(false)
     if (result.ok) {
+      trackLeadSubmit("service-modal", "Rådgivning")
       setIsSuccess(true)
       setTimeout(() => { setShowModal(false); setIsSuccess(false) }, 3000)
     } else {

--- a/src/components/modals/AdvisoryRequestModal.tsx
+++ b/src/components/modals/AdvisoryRequestModal.tsx
@@ -8,6 +8,7 @@ import { RiCloseLine, RiLightbulbLine, RiCheckLine } from "@remixicon/react"
 import { useState, type Dispatch, type SetStateAction } from "react"
 import { submitCtaLead } from "@/app/actions/cta-lead"
 import { trackLeadSubmit } from "@/lib/analytics"
+import { useLeadStartOnFocus } from "@/lib/hooks/useLeadFunnel"
 
 interface AdvisoryRequestModalProps {
   showModal: boolean
@@ -19,6 +20,7 @@ export default function AdvisoryRequestModal({
   setShowModal,
 }: AdvisoryRequestModalProps) {
   const [isSubmitting, setIsSubmitting] = useState(false)
+  const onFirstFocus = useLeadStartOnFocus("service-modal", "Rådgivning")
   const [isSuccess, setIsSuccess] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -89,7 +91,7 @@ export default function AdvisoryRequestModal({
             </p>
           </div>
         ) : (
-          <form onSubmit={handleSubmit} className="px-6 py-6">
+          <form onSubmit={handleSubmit} onFocusCapture={onFirstFocus} className="px-6 py-6">
             <div className="space-y-4">
               <div className="grid gap-4 sm:grid-cols-2">
                 <div>

--- a/src/components/modals/ConsultationModal.tsx
+++ b/src/components/modals/ConsultationModal.tsx
@@ -7,6 +7,7 @@ import { RiCloseLine, RiTeamLine, RiCheckLine } from "@remixicon/react"
 import { useState, type Dispatch, type SetStateAction } from "react"
 import { submitCtaLead } from "@/app/actions/cta-lead"
 import { trackLeadSubmit } from "@/lib/analytics"
+import { useLeadStartOnFocus } from "@/lib/hooks/useLeadFunnel"
 
 interface ConsultationModalProps {
   showModal: boolean
@@ -18,6 +19,7 @@ export default function ConsultationModal({
   setShowModal,
 }: ConsultationModalProps) {
   const [isSubmitting, setIsSubmitting] = useState(false)
+  const onFirstFocus = useLeadStartOnFocus("service-modal", "Konsultasjon")
   const [isSuccess, setIsSuccess] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -94,7 +96,7 @@ export default function ConsultationModal({
         ) : (
           <>
             {/* Form */}
-            <form onSubmit={handleSubmit} className="px-6 py-6">
+            <form onSubmit={handleSubmit} onFocusCapture={onFirstFocus} className="px-6 py-6">
               <div className="space-y-4">
                 {/* Name Fields */}
                 <div className="grid gap-4 sm:grid-cols-2">

--- a/src/components/modals/ConsultationModal.tsx
+++ b/src/components/modals/ConsultationModal.tsx
@@ -6,6 +6,7 @@ import Modal from "@/components/blog/modal"
 import { RiCloseLine, RiTeamLine, RiCheckLine } from "@remixicon/react"
 import { useState, type Dispatch, type SetStateAction } from "react"
 import { submitCtaLead } from "@/app/actions/cta-lead"
+import { trackLeadSubmit } from "@/lib/analytics"
 
 interface ConsultationModalProps {
   showModal: boolean
@@ -42,6 +43,7 @@ export default function ConsultationModal({
 
     setIsSubmitting(false)
     if (result.ok) {
+      trackLeadSubmit("service-modal", "Konsultasjon")
       setIsSuccess(true)
       setTimeout(() => { setShowModal(false); setIsSuccess(false) }, 3000)
     } else {

--- a/src/components/modals/LeaseRequestModal.tsx
+++ b/src/components/modals/LeaseRequestModal.tsx
@@ -7,6 +7,7 @@ import Modal from "@/components/blog/modal"
 import { RiCloseLine, RiBuilding4Line, RiCheckLine } from "@remixicon/react"
 import { useState, type Dispatch, type SetStateAction } from "react"
 import { submitCtaLead } from "@/app/actions/cta-lead"
+import { trackLeadSubmit } from "@/lib/analytics"
 
 interface LeaseRequestModalProps {
   showModal: boolean
@@ -45,6 +46,7 @@ export default function LeaseRequestModal({
 
     setIsSubmitting(false)
     if (result.ok) {
+      trackLeadSubmit("service-modal", "Utleie")
       setIsSuccess(true)
       setTimeout(() => { setShowModal(false); setIsSuccess(false) }, 3000)
     } else {

--- a/src/components/modals/LeaseRequestModal.tsx
+++ b/src/components/modals/LeaseRequestModal.tsx
@@ -8,6 +8,7 @@ import { RiCloseLine, RiBuilding4Line, RiCheckLine } from "@remixicon/react"
 import { useState, type Dispatch, type SetStateAction } from "react"
 import { submitCtaLead } from "@/app/actions/cta-lead"
 import { trackLeadSubmit } from "@/lib/analytics"
+import { useLeadStartOnFocus } from "@/lib/hooks/useLeadFunnel"
 
 interface LeaseRequestModalProps {
   showModal: boolean
@@ -19,6 +20,7 @@ export default function LeaseRequestModal({
   setShowModal,
 }: LeaseRequestModalProps) {
   const [isSubmitting, setIsSubmitting] = useState(false)
+  const onFirstFocus = useLeadStartOnFocus("service-modal", "Utleie")
   const [isSuccess, setIsSuccess] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -97,7 +99,7 @@ export default function LeaseRequestModal({
         ) : (
           <>
             {/* Form */}
-            <form onSubmit={handleSubmit} className="px-6 py-6">
+            <form onSubmit={handleSubmit} onFocusCapture={onFirstFocus} className="px-6 py-6">
               <div className="space-y-4">
                 {/* Name Fields */}
                 <div className="grid gap-4 sm:grid-cols-2">

--- a/src/components/modals/StrategicAdvisoryModal.tsx
+++ b/src/components/modals/StrategicAdvisoryModal.tsx
@@ -7,6 +7,7 @@ import { RiCloseLine, RiRoadMapLine, RiCheckLine } from "@remixicon/react"
 import { useState, type Dispatch, type SetStateAction } from "react"
 import { submitCtaLead } from "@/app/actions/cta-lead"
 import { trackLeadSubmit } from "@/lib/analytics"
+import { useLeadStartOnFocus } from "@/lib/hooks/useLeadFunnel"
 
 interface StrategicAdvisoryModalProps {
   showModal: boolean
@@ -18,6 +19,7 @@ export default function StrategicAdvisoryModal({
   setShowModal,
 }: StrategicAdvisoryModalProps) {
   const [isSubmitting, setIsSubmitting] = useState(false)
+  const onFirstFocus = useLeadStartOnFocus("service-modal", "Strategisk Rådgivning")
   const [isSuccess, setIsSuccess] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -89,7 +91,7 @@ export default function StrategicAdvisoryModal({
             </p>
           </div>
         ) : (
-          <form onSubmit={handleSubmit} className="px-6 py-6">
+          <form onSubmit={handleSubmit} onFocusCapture={onFirstFocus} className="px-6 py-6">
             <div className="space-y-4">
               <div className="grid gap-4 sm:grid-cols-2">
                 <div>

--- a/src/components/modals/StrategicAdvisoryModal.tsx
+++ b/src/components/modals/StrategicAdvisoryModal.tsx
@@ -6,6 +6,7 @@ import Modal from "@/components/blog/modal"
 import { RiCloseLine, RiRoadMapLine, RiCheckLine } from "@remixicon/react"
 import { useState, type Dispatch, type SetStateAction } from "react"
 import { submitCtaLead } from "@/app/actions/cta-lead"
+import { trackLeadSubmit } from "@/lib/analytics"
 
 interface StrategicAdvisoryModalProps {
   showModal: boolean
@@ -42,6 +43,7 @@ export default function StrategicAdvisoryModal({
 
     setIsSubmitting(false)
     if (result.ok) {
+      trackLeadSubmit("service-modal", "Strategisk Rådgivning")
       setIsSuccess(true)
       setTimeout(() => { setShowModal(false); setIsSuccess(false) }, 3000)
     } else {

--- a/src/components/modals/TransactionRequestModal.tsx
+++ b/src/components/modals/TransactionRequestModal.tsx
@@ -7,6 +7,7 @@ import Modal from "@/components/blog/modal"
 import { RiCloseLine, RiExchangeLine, RiCheckLine } from "@remixicon/react"
 import { useState, type Dispatch, type SetStateAction } from "react"
 import { submitCtaLead } from "@/app/actions/cta-lead"
+import { trackLeadSubmit } from "@/lib/analytics"
 
 interface TransactionRequestModalProps {
   showModal: boolean
@@ -44,6 +45,7 @@ export default function TransactionRequestModal({
 
     setIsSubmitting(false)
     if (result.ok) {
+      trackLeadSubmit("service-modal", "Transaksjonshjelp")
       setIsSuccess(true)
       setTimeout(() => { setShowModal(false); setIsSuccess(false) }, 3000)
     } else {

--- a/src/components/modals/TransactionRequestModal.tsx
+++ b/src/components/modals/TransactionRequestModal.tsx
@@ -8,6 +8,7 @@ import { RiCloseLine, RiExchangeLine, RiCheckLine } from "@remixicon/react"
 import { useState, type Dispatch, type SetStateAction } from "react"
 import { submitCtaLead } from "@/app/actions/cta-lead"
 import { trackLeadSubmit } from "@/lib/analytics"
+import { useLeadStartOnFocus } from "@/lib/hooks/useLeadFunnel"
 
 interface TransactionRequestModalProps {
   showModal: boolean
@@ -19,6 +20,7 @@ export default function TransactionRequestModal({
   setShowModal,
 }: TransactionRequestModalProps) {
   const [isSubmitting, setIsSubmitting] = useState(false)
+  const onFirstFocus = useLeadStartOnFocus("service-modal", "Transaksjonshjelp")
   const [isSuccess, setIsSuccess] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -96,7 +98,7 @@ export default function TransactionRequestModal({
         ) : (
           <>
             {/* Form */}
-            <form onSubmit={handleSubmit} className="px-6 py-6">
+            <form onSubmit={handleSubmit} onFocusCapture={onFirstFocus} className="px-6 py-6">
               <div className="space-y-4">
                 {/* Name Fields */}
                 <div className="grid gap-4 sm:grid-cols-2">

--- a/src/components/modals/ValuationRequestModal.tsx
+++ b/src/components/modals/ValuationRequestModal.tsx
@@ -7,6 +7,7 @@ import Modal from "@/components/blog/modal"
 import { RiCloseLine, RiCalculatorLine, RiCheckLine } from "@remixicon/react"
 import { useState, type Dispatch, type SetStateAction } from "react"
 import { submitCtaLead } from "@/app/actions/cta-lead"
+import { trackLeadSubmit } from "@/lib/analytics"
 
 interface ValuationRequestModalProps {
   showModal: boolean
@@ -44,6 +45,7 @@ export default function ValuationRequestModal({
 
     setIsSubmitting(false)
     if (result.ok) {
+      trackLeadSubmit("service-modal", "Verdsettelse")
       setIsSuccess(true)
       setTimeout(() => { setShowModal(false); setIsSuccess(false) }, 3000)
     } else {

--- a/src/components/modals/ValuationRequestModal.tsx
+++ b/src/components/modals/ValuationRequestModal.tsx
@@ -8,6 +8,7 @@ import { RiCloseLine, RiCalculatorLine, RiCheckLine } from "@remixicon/react"
 import { useState, type Dispatch, type SetStateAction } from "react"
 import { submitCtaLead } from "@/app/actions/cta-lead"
 import { trackLeadSubmit } from "@/lib/analytics"
+import { useLeadStartOnFocus } from "@/lib/hooks/useLeadFunnel"
 
 interface ValuationRequestModalProps {
   showModal: boolean
@@ -19,6 +20,7 @@ export default function ValuationRequestModal({
   setShowModal,
 }: ValuationRequestModalProps) {
   const [isSubmitting, setIsSubmitting] = useState(false)
+  const onFirstFocus = useLeadStartOnFocus("service-modal", "Verdsettelse")
   const [isSuccess, setIsSuccess] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -100,7 +102,7 @@ export default function ValuationRequestModal({
         ) : (
           <>
             {/* Form */}
-            <form onSubmit={handleSubmit} className="px-6 py-6">
+            <form onSubmit={handleSubmit} onFocusCapture={onFirstFocus} className="px-6 py-6">
               <div className="space-y-4">
                 {/* Name Fields */}
                 <div className="grid gap-4 sm:grid-cols-2">

--- a/src/components/naringsmegler/CityLeadForm.tsx
+++ b/src/components/naringsmegler/CityLeadForm.tsx
@@ -12,7 +12,8 @@ import { useRef, useState, useTransition } from "react"
 import { track } from "@vercel/analytics"
 
 import { submitCityLead } from "@/app/actions/naringsmegler-lead"
-import { trackLeadStart, trackLeadSubmit } from "@/lib/analytics"
+import { trackLeadSubmit } from "@/lib/analytics"
+import { useLeadStartOnFocus } from "@/lib/hooks/useLeadFunnel"
 import { PROPERTY_TYPES } from "./leadConstants"
 
 type Props = {
@@ -29,14 +30,7 @@ export function CityLeadForm({ cityName, slug, phone }: Props) {
   // Synchronous double-submit guard: `pending` only flips after a re-render,
   // so two clicks in the same frame would both dispatch the action.
   const submitting = useRef(false)
-  // Fire the funnel start event once, on first field interaction.
-  const started = useRef(false)
-
-  function onFirstFocus() {
-    if (started.current) return
-    started.current = true
-    trackLeadStart("naringsmegler", "city-lead")
-  }
+  const onFirstFocus = useLeadStartOnFocus("naringsmegler", "city-lead")
 
   function onSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault()

--- a/src/components/naringsmegler/CityLeadForm.tsx
+++ b/src/components/naringsmegler/CityLeadForm.tsx
@@ -12,6 +12,7 @@ import { useRef, useState, useTransition } from "react"
 import { track } from "@vercel/analytics"
 
 import { submitCityLead } from "@/app/actions/naringsmegler-lead"
+import { trackLeadStart, trackLeadSubmit } from "@/lib/analytics"
 import { PROPERTY_TYPES } from "./leadConstants"
 
 type Props = {
@@ -28,6 +29,14 @@ export function CityLeadForm({ cityName, slug, phone }: Props) {
   // Synchronous double-submit guard: `pending` only flips after a re-render,
   // so two clicks in the same frame would both dispatch the action.
   const submitting = useRef(false)
+  // Fire the funnel start event once, on first field interaction.
+  const started = useRef(false)
+
+  function onFirstFocus() {
+    if (started.current) return
+    started.current = true
+    trackLeadStart("naringsmegler", "city-lead")
+  }
 
   function onSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault()
@@ -41,6 +50,7 @@ export function CityLeadForm({ cityName, slug, phone }: Props) {
         if (result.ok) {
           setSent(true)
           track("naringsmegler_lead", { city: slug })
+          trackLeadSubmit("naringsmegler", "city-lead")
           // Move focus to the receipt so the state change is announced.
           requestAnimationFrame(() => doneHeading.current?.focus())
         } else {
@@ -76,7 +86,7 @@ export function CityLeadForm({ cityName, slug, phone }: Props) {
   }
 
   return (
-    <form className="cy-form" onSubmit={onSubmit}>
+    <form className="cy-form" onSubmit={onSubmit} onFocusCapture={onFirstFocus}>
       <div className="fpre">Uforpliktende · svar vanligvis samme dag</div>
       <h3>
         Din eiendom, <span className="it">vurdert lokalt.</span>

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -26,3 +26,21 @@ export function trackContactSubmitted(): void {
     form_location: "contact_page",
   });
 }
+
+/**
+ * Minimal lead-funnel instrumentation (CEO audit, Track B). Two events per
+ * lead form — start (first interaction) and submit (success) — both tagged
+ * with the lead `source`, so completion rate per surface is answerable
+ * without building an analytics cathedral. `form` is the human form label.
+ *
+ * Response-time SLA (Track B2) is measured CRM-side from crm_activities, not
+ * here — it needs the team's first-contact timestamp, which the web app
+ * never sees.
+ */
+export function trackLeadStart(source: string, form: string): void {
+  trackEvent("lead_form_start", { source, form });
+}
+
+export function trackLeadSubmit(source: string, form: string): void {
+  trackEvent("lead_form_submit", { source, form });
+}

--- a/src/lib/email/discord.ts
+++ b/src/lib/email/discord.ts
@@ -10,6 +10,7 @@ const SOURCE_LABEL: Record<SubscribeSource, string> = {
   markedsinnsikt: "Markedsinnsikt",
   analyseportal: "Analyseportal (datainteressert!)",
   service: "Tjeneste-side",
+  "service-modal": "Tjeneste-modal CTA (HØY INTENT)",
   "sjekkliste-verdivurdering": "Sjekkliste-PDF (verdivurdering)",
   markedsrapport: "Markedsrapport (lead magnet)",
   "verdivurdering-intake": "Verdivurdering-intake (HØY INTENT)",
@@ -25,6 +26,7 @@ const SOURCE_LABEL: Record<SubscribeSource, string> = {
 // brand-neutral; intake forms are light-blue.
 const HIGH_INTENT: SubscribeSource[] = [
   "verdivurdering-intake",
+  "service-modal",
   "kontakt",
   "eiendommer",
   "investorportal",

--- a/src/lib/email/discord.ts
+++ b/src/lib/email/discord.ts
@@ -14,6 +14,7 @@ const SOURCE_LABEL: Record<SubscribeSource, string> = {
   "sjekkliste-verdivurdering": "Sjekkliste-PDF (verdivurdering)",
   markedsrapport: "Markedsrapport (lead magnet)",
   "verdivurdering-intake": "Verdivurdering-intake (HØY INTENT)",
+  eiernotat: "Eiernotat — 48t beslutningsnotat (HØY INTENT)",
   kontakt: "Kontakt-skjema",
   eiendommer: "Eiendommer (varsel om nye oppdrag)",
   presserom: "Presserom (pressevarsel — journalist!)",
@@ -26,6 +27,7 @@ const SOURCE_LABEL: Record<SubscribeSource, string> = {
 // brand-neutral; intake forms are light-blue.
 const HIGH_INTENT: SubscribeSource[] = [
   "verdivurdering-intake",
+  "eiernotat",
   "service-modal",
   "kontakt",
   "eiendommer",

--- a/src/lib/email/subscribe.ts
+++ b/src/lib/email/subscribe.ts
@@ -15,6 +15,7 @@ export type SubscribeSource =
   | "markedsinnsikt"
   | "analyseportal"
   | "service"
+  | "service-modal"
   | "sjekkliste-verdivurdering"
   | "markedsrapport"
   | "verdivurdering-intake"
@@ -52,6 +53,7 @@ const RESEND_CONFIGURED = () =>
 
 const HIGH_INTENT: SubscribeSource[] = [
   "verdivurdering-intake",
+  "service-modal",
   "kontakt",
   "eiendommer",
   "investorportal",

--- a/src/lib/email/subscribe.ts
+++ b/src/lib/email/subscribe.ts
@@ -19,6 +19,7 @@ export type SubscribeSource =
   | "sjekkliste-verdivurdering"
   | "markedsrapport"
   | "verdivurdering-intake"
+  | "eiernotat"
   | "kontakt"
   | "eiendommer"
   | "presserom"
@@ -53,6 +54,7 @@ const RESEND_CONFIGURED = () =>
 
 const HIGH_INTENT: SubscribeSource[] = [
   "verdivurdering-intake",
+  "eiernotat",
   "service-modal",
   "kontakt",
   "eiendommer",

--- a/src/lib/hooks/useLeadFunnel.ts
+++ b/src/lib/hooks/useLeadFunnel.ts
@@ -1,0 +1,23 @@
+"use client"
+
+import { useCallback, useRef } from "react"
+
+import { trackLeadStart } from "@/lib/analytics"
+
+/**
+ * Returns an `onFocusCapture` handler that fires `lead_form_start` exactly once
+ * per mount, on the first real field interaction (not on mere view). Shared by
+ * every lead form so the start→submit funnel is measured consistently and we
+ * don't repeat the dedupe-ref boilerplate in each component.
+ *
+ * `source` is the analytics source dimension (e.g. "service-modal"); `form` is
+ * the human form label (e.g. "Verdsettelse").
+ */
+export function useLeadStartOnFocus(source: string, form: string): () => void {
+  const started = useRef(false)
+  return useCallback(() => {
+    if (started.current) return
+    started.current = true
+    trackLeadStart(source, form)
+  }, [source, form])
+}

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -274,6 +274,7 @@ export const REGISTRY: NavEntry[] = [
   // ── deliberately outside nav/footer (gated or landing pages) ─────────────
   { path: "/presentasjon", label: "Presentasjon", parent: null, inNav: false, inFooter: false },
   { path: "/verdivurdering", label: "Få verdivurdering", parent: null, inNav: false, inFooter: false },
+  { path: "/eiernotat", label: "Eiernotat", parent: null, inNav: false, inFooter: false },
   { path: "/landing/verdivurdering", label: "Verdivurdering landingsside", parent: null, inNav: false, inFooter: false },
   { path: "/sjekkliste-verdivurdering", label: "Sjekkliste verdivurdering", parent: null, inNav: false, inFooter: false },
 

--- a/src/lib/supabase/leads.ts
+++ b/src/lib/supabase/leads.ts
@@ -16,6 +16,7 @@ type RecordSignupArgs = {
 // Everything else lands in the lightweight web_signups table.
 const HIGH_INTENT: SubscribeSource[] = [
   "verdivurdering-intake",
+  "eiernotat",
   "service-modal",
   "kontakt",
   "eiendommer",
@@ -45,6 +46,7 @@ function intakeString(
 
 const SOURCE_LABEL: Partial<Record<SubscribeSource, string>> = {
   "verdivurdering-intake": "Verdivurdering-intake (skjema)",
+  eiernotat: "Eiernotat — 48t beslutningsnotat (skjema)",
   "service-modal": "Tjeneste-modal (CTA på tjenesteside)",
   kontakt: "Kontaktskjema",
   eiendommer: "Eiendommer (varslingsskjema for nye oppdrag)",
@@ -170,6 +172,10 @@ export function buildActivitySummary(
   if (args.source === "verdivurdering-intake") {
     lines.push(
       "Lead bestilte verdivurdering via skjema på /tjenester/verdivurdering.",
+    )
+  } else if (args.source === "eiernotat") {
+    lines.push(
+      "Lead ba om eiernotat (48t partner-vurdert beslutningsnotat: selge / refinansiere / holde / leie ut / reposisjonere).",
     )
   } else if (args.source === "kontakt") {
     lines.push("Henvendelse via kontaktskjema.")

--- a/src/lib/supabase/leads.ts
+++ b/src/lib/supabase/leads.ts
@@ -16,6 +16,7 @@ type RecordSignupArgs = {
 // Everything else lands in the lightweight web_signups table.
 const HIGH_INTENT: SubscribeSource[] = [
   "verdivurdering-intake",
+  "service-modal",
   "kontakt",
   "eiendommer",
   "naringsmegler",
@@ -44,6 +45,7 @@ function intakeString(
 
 const SOURCE_LABEL: Partial<Record<SubscribeSource, string>> = {
   "verdivurdering-intake": "Verdivurdering-intake (skjema)",
+  "service-modal": "Tjeneste-modal (CTA på tjenesteside)",
   kontakt: "Kontaktskjema",
   eiendommer: "Eiendommer (varslingsskjema for nye oppdrag)",
 }
@@ -174,6 +176,13 @@ export function buildActivitySummary(
   } else if (args.source === "eiendommer") {
     lines.push(
       "Saved-search-signup på /eiendommer — vil bli varslet om nye oppdrag som matcher.",
+    )
+  } else if (args.source === "service-modal") {
+    const ctaType = intakeString(intake, "Type")
+    lines.push(
+      ctaType
+        ? `Forespørsel via CTA-modal på tjenesteside (${ctaType}).`
+        : "Forespørsel via CTA-modal på tjenesteside.",
     )
   } else {
     lines.push(`Web-skjemainnsending (${args.source}).`)

--- a/tests/unit/leads.test.ts
+++ b/tests/unit/leads.test.ts
@@ -71,6 +71,14 @@ describe("buildActivitySummary", () => {
     )
     expect(summary).toContain("Henvendelse via kontaktskjema.")
   })
+
+  it("includes the CTA type for source='service-modal'", () => {
+    const summary = buildActivitySummary(
+      { email: "a@b.no", source: "service-modal" },
+      { Type: "Verdsettelse" },
+    )
+    expect(summary).toContain("CTA-modal på tjenesteside (Verdsettelse)")
+  })
 })
 
 // ---------------------------------------------------------------------------
@@ -94,5 +102,17 @@ describe("recordSignup routing", () => {
     expect(ok).toBe(true)
     expect(inserted).toHaveLength(1)
     expect(inserted[0]?.table).toBe("web_signups")
+  })
+
+  it("routes HIGH_INTENT 'service-modal' → crm_leads (not web_signups)", async () => {
+    const ok = await recordSignup({
+      email: "a@b.no",
+      source: "service-modal",
+      firstName: "Ola Nordmann",
+      intake: { Type: "Verdsettelse", Telefon: "999 88 777" },
+    })
+    expect(ok).toBe(true)
+    expect(inserted[0]?.table).toBe("crm_leads")
+    expect(inserted[1]?.table).toBe("crm_activities")
   })
 })

--- a/tests/unit/leads.test.ts
+++ b/tests/unit/leads.test.ts
@@ -104,6 +104,18 @@ describe("recordSignup routing", () => {
     expect(inserted[0]?.table).toBe("web_signups")
   })
 
+  it("routes HIGH_INTENT 'eiernotat' → crm_leads then crm_activities", async () => {
+    const ok = await recordSignup({
+      email: "owner@example.no",
+      source: "eiernotat",
+      firstName: "Ola Nordmann",
+      intake: { Eiendomstype: "Kontor", Sted: "Bodø" },
+    })
+    expect(ok).toBe(true)
+    expect(inserted[0]?.table).toBe("crm_leads")
+    expect(inserted[1]?.table).toBe("crm_activities")
+  })
+
   it("routes HIGH_INTENT 'service-modal' → crm_leads (not web_signups)", async () => {
     const ok = await recordSignup({
       email: "a@b.no",

--- a/tests/unit/subscribe.test.ts
+++ b/tests/unit/subscribe.test.ts
@@ -81,6 +81,21 @@ describe("subscribe", () => {
     expect(recordSignupMock).toHaveBeenCalledTimes(1)
   })
 
+  it("treats 'service-modal' as a contact request, not a newsletter opt-in", async () => {
+    const result = await subscribe({
+      email: "modal-lead@example.no",
+      source: "service-modal",
+      firstName: "Ola Nordmann",
+      intake: { Type: "Verdsettelse", Telefon: "999 88 777" },
+    })
+
+    expect(result).toEqual({ ok: true, alreadySubscribed: false })
+    expect(contactsCreateMock).not.toHaveBeenCalled()
+    expect(emailsSendMock).not.toHaveBeenCalled()
+    expect(notifyLeadMock).toHaveBeenCalledTimes(1)
+    expect(recordSignupMock).toHaveBeenCalledTimes(1)
+  })
+
   it("returns an error when every configured destination fails", async () => {
     contactsCreateMock.mockResolvedValue({
       error: { message: "provider unavailable" },

--- a/tests/unit/verdivurdering-intake.test.ts
+++ b/tests/unit/verdivurdering-intake.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+// Mock the two collaborators before importing the action so vi.mock hoisting
+// puts them in place. We assert on the `source` passed to subscribe().
+const subscribeMock = vi.fn()
+const checkRateLimitMock = vi.fn()
+
+vi.mock("@/lib/email/subscribe", () => ({
+  subscribe: subscribeMock,
+}))
+
+vi.mock("@/lib/rate-limit", () => ({
+  checkRateLimit: checkRateLimitMock,
+}))
+
+const { subscribeVerdivurderingIntake } = await import(
+  "@/app/actions/verdivurdering-intake"
+)
+
+// Minimal valid intake: email + property type + location + purpose are the
+// hard-intent minimum the action enforces.
+function intakeFormData(extra: Record<string, string> = {}): FormData {
+  const fd = new FormData()
+  fd.set("email", "owner@example.no")
+  fd.set("firstName", "Ola Nordmann")
+  fd.set("propertyType", "Kontor")
+  fd.set("location", "Bodø")
+  fd.set("purpose", "Vurderer salg")
+  for (const [k, v] of Object.entries(extra)) fd.set(k, v)
+  return fd
+}
+
+describe("subscribeVerdivurderingIntake — intakeSource whitelist", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    checkRateLimitMock.mockResolvedValue(true)
+    subscribeMock.mockResolvedValue({ ok: true, alreadySubscribed: false })
+  })
+
+  it("uses the eiernotat source when the form requests it", async () => {
+    const result = await subscribeVerdivurderingIntake(
+      intakeFormData({ intakeSource: "eiernotat" }),
+    )
+    expect(result).toEqual({ ok: true })
+    expect(subscribeMock).toHaveBeenCalledTimes(1)
+    expect(subscribeMock.mock.calls[0][0]).toMatchObject({
+      source: "eiernotat",
+    })
+  })
+
+  it("falls back to verdivurdering-intake when intakeSource is absent", async () => {
+    await subscribeVerdivurderingIntake(intakeFormData())
+    expect(subscribeMock.mock.calls[0][0]).toMatchObject({
+      source: "verdivurdering-intake",
+    })
+  })
+
+  it("ignores a non-whitelisted intakeSource (anti-tamper)", async () => {
+    await subscribeVerdivurderingIntake(
+      intakeFormData({ intakeSource: "investorportal" }),
+    )
+    // investorportal is a real SubscribeSource but NOT on this action's
+    // whitelist — must fall back rather than inject it.
+    expect(subscribeMock.mock.calls[0][0]).toMatchObject({
+      source: "verdivurdering-intake",
+    })
+  })
+
+  it("rejects intake missing a required field without calling subscribe", async () => {
+    const fd = intakeFormData()
+    fd.delete("purpose")
+    const result = await subscribeVerdivurderingIntake(fd)
+    expect(result.ok).toBe(false)
+    expect(subscribeMock).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
Lead-engine improvements from the CEO audit (plan: `autoplan-what-more-should-fluttering-crab.md`). Several tracks in one PR.

## Track A — Stop the bleeding ✅
- **A1:** `submitCtaLead` now routes service-page modal CTAs (Verdsettelse, Transaksjon, Utleie, Rådgivning, Strategisk, Konsultasjon) through the shared `subscribe()` pipeline as a new high-intent source `"service-modal"` → Supabase `crm_leads` + `crm_activities` + Discord (high-intent colour stripe), instead of **Discord-only** (where a missed ping lost the lead, no CRM row, uncountable). No `marketingConsent`: a CTA is a contact request, not a newsletter opt-in.
- **A2 (verified):** GDPR/consent exposure (TODO 31) already closed — only `newsletter.ts` sets `marketingConsent: true`.
- **A3 (verified):** `/kontakt` already wired end-to-end to `crm_leads`.

## Track B — Minimal funnel instrumentation ✅
`trackLeadStart` / `trackLeadSubmit` helpers (GA4 dataLayer, reusing `trackEvent`) wired into all 6 CTA modals (`lead_form_submit`) and the two main forms (`lead_form_start` on first focus + `lead_form_submit`). Deliberately minimal: source + start + submit, no abandonment cathedral. Response-time SLA is CRM-side.

## Track C1 — Eiernotat (48h owner decision memo) ✅ (gated)
The audit's one new conversion offer. Instead of an instant auto-valuation (cheapens the advisory brand, draws tyre-kickers), owners request a short written decision memo — sell / refinance / hold / lease / reposition — within 48h. DRY: reuses `VerdivurderingIntakeForm` + its action with a new high-intent source `"eiernotat"` via a whitelisted hidden field. New `/eiernotat` page.
**Shipped `noIndex`** (gated from search like `/verdivurdering`) until the offer copy + 48h memo fulfilment workflow get a human/partner review. Flip `noIndex` off + wire into CTAs at launch.

## Track D — Service×city SEO ⛔ intentionally not auto-expanded
`service-cities.ts` holds ~150 lines of bespoke SEO copy **per service**, and the 6-city allowlist is the deliberate data-complete set (`dynamicParams = false` already refuses thin pages). Adding services/cities needs real per-service content + verified city data (gated on the data-cadence decision + proofstats gate). Auto-generating thin pages here would harm SEO — so this track is correctly blocked on a business decision, not shipped.

## Verification
- `npx tsc --noEmit` → clean
- `npx vitest run` → 159 pass (5 new: service-modal + eiernotat routing, consent)
- `pnpm build` → green, incl. new `/eiernotat` static route

## Reviewer notes
- `/eiernotat` copy is a first draft and is `noIndex` — review before launch.
- Stale comment at `onboarding.ts:150` (claims Resend audience fires for kontakt; it doesn't without consent) left untouched — flag only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Launched Eiernotat (Owner Memo) service page with intake form and step-by-step onboarding timeline
  * Added lead funnel analytics tracking across all service modals to measure form engagement and submission conversion

* **Refactor**
  * Consolidated CTA lead submission through shared pipeline for consistency
  * Enhanced intake form to support multiple source types for improved lead categorization

* **Tests**
  * Added comprehensive coverage for lead routing and intake source validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->