### PR TITLE
refactor(leads): rename Eiernotat → Beslutningsgrunnlag

### DIFF
--- a/src/app/actions/verdivurdering-intake.ts
+++ b/src/app/actions/verdivurdering-intake.ts
@@ -11,7 +11,7 @@ export type IntakeResult = { ok: true } | { ok: false; error: string }
 // — whitelisted here so a tampered form can't inject an arbitrary source.
 const ALLOWED_SOURCES: SubscribeSource[] = [
   "verdivurdering-intake",
-  "eiernotat",
+  "beslutningsgrunnlag",
 ]
 
 /**
@@ -57,7 +57,7 @@ export async function subscribeVerdivurderingIntake(
   // service page for backward compatibility.
   const page = get("page") ?? "/tjenester/verdivurdering"
 
-  // `intakeSource` selects the CRM source (verdivurdering vs eiernotat).
+  // `intakeSource` selects the CRM source (verdivurdering vs beslutningsgrunnlag).
   // Falls back to verdivurdering-intake for every existing form that doesn't
   // send it, and ignores any value not on the whitelist.
   const requested = get("intakeSource") as SubscribeSource | undefined

--- a/src/app/beslutningsgrunnlag/page.tsx
+++ b/src/app/beslutningsgrunnlag/page.tsx
@@ -9,27 +9,27 @@ import {
 } from "@/components/forms/VerdivurderingIntakeForm";
 
 export const metadata = constructMetadata({
-  path: "/eiernotat",
+  path: "/beslutningsgrunnlag",
   // DRAFT conversion surface. noIndex until the partner-facing offer copy and
-  // the 48-hour memo fulfilment workflow have had a human review (see PR #61 /
-  // plan Track C1). Flip to indexed once the offer is signed off.
+  // the 48-hour fulfilment workflow have had a human review (plan Track C1).
+  // Flip to indexed once the offer is signed off.
   noIndex: true,
-  title: "Eiernotat — beslutningsgrunnlag for næringseiendom | Advanti Estate",
+  title: "Beslutningsgrunnlag for næringseiendom | Advanti Estate",
   description:
-    "Bør du selge, refinansiere, holde, leie ut eller reposisjonere? Be om et eiernotat: et kort, partner-vurdert beslutningsnotat for eiendommen din innen 48 timer.",
+    "Bør du selge, refinansiere, holde, leie ut eller reposisjonere? Be om et beslutningsgrunnlag: en kort, partner-vurdert vurdering av eiendommen din innen 48 timer.",
 });
 
-export default function EiernotatPage() {
-  // The eiernotat reuses the verdivurdering intake form (same fields), but
-  // lands under its own CRM/analytics source and frames a different offer:
-  // a written decision memo rather than a value estimate.
+export default function BeslutningsgrunnlagPage() {
+  // Reuses the verdivurdering intake form (same fields), but lands under its
+  // own CRM/analytics source and frames a different offer: a written decision
+  // basis (sell / refinance / hold) rather than a value estimate.
   const prefill: VerdivurderingPrefill = {};
 
   return (
     <>
       <SubHero
-        breadcrumbs={<Breadcrumbs path="/eiernotat" />}
-        eyebrow="Eiernotat · Partner-vurdert · 48 timer"
+        breadcrumbs={<Breadcrumbs path="/beslutningsgrunnlag" />}
+        eyebrow="Beslutningsgrunnlag · Partner-vurdert · 48 timer"
         title={
           <>
             Bør du selge, refinansiere
@@ -37,7 +37,7 @@ export default function EiernotatPage() {
             eller <span className="italic">holde</span>?
           </>
         }
-        lede="Et eiernotat er et kort, skriftlig beslutningsgrunnlag fra en av partnerne våre — ikke en automatisk takst. Du får en indikativ yield-range, et bilde av hvem de sannsynlige kjøperne er, mulig leieoppside, og en konkret anbefaling om neste steg. Innen 48 timer, uforpliktende."
+        lede="Dette er en kort, skriftlig vurdering fra en av partnerne våre — ikke en automatisk takst. Du får en indikativ yield-range, et bilde av hvem de sannsynlige kjøperne er, mulig leieoppside, og en konkret anbefaling om neste steg. Innen 48 timer, uforpliktende."
       >
         <p
           style={{
@@ -76,20 +76,20 @@ export default function EiernotatPage() {
       <section className="section section-divider" style={{ paddingTop: 64 }}>
         <div className="wrap">
           <div className="contact-grid">
-            {/* LEFT: shared intake form, eiernotat source */}
+            {/* LEFT: shared intake form, beslutningsgrunnlag source */}
             <VerdivurderingIntakeForm
-              page="/eiernotat"
-              source="eiernotat"
-              intakeSource="eiernotat"
+              page="/beslutningsgrunnlag"
+              source="beslutningsgrunnlag"
+              intakeSource="beslutningsgrunnlag"
               prefill={prefill}
-              headingTitle="Be om et eiernotat."
-              headingSubtitle="Noen få felter om eiendommen. Du får notatet innen 48 timer — uforpliktende."
+              headingTitle="Be om et beslutningsgrunnlag."
+              headingSubtitle="Noen få felter om eiendommen. Du får vurderingen innen 48 timer — uforpliktende."
             />
 
-            {/* RIGHT: what the memo contains + process */}
+            {/* RIGHT: what the assessment contains + process */}
             <aside>
               <div className="vv-aside-card">
-                <div className="pre">Hva notatet inneholder</div>
+                <div className="pre">Hva du får</div>
                 <ul className="vv-gets">
                   <li>
                     <span className="ico" aria-hidden="true">
@@ -148,14 +148,15 @@ export default function EiernotatPage() {
                     <div>
                       <h4>En partner går gjennom den</h4>
                       <p>
-                        Vi vurderer eiendommen mot markedet og skriver notatet.
+                        Vi vurderer eiendommen mot markedet og skriver
+                        vurderingen.
                       </p>
                     </div>
                   </li>
                   <li>
                     <span className="n">03</span>
                     <div>
-                      <h4>Du får notatet innen 48 timer</h4>
+                      <h4>Du får vurderingen innen 48 timer</h4>
                       <p>
                         Skriftlig, uforpliktende. Vil du gå videre, tar vi en
                         samtale.

--- a/src/components/forms/VerdivurderingIntakeForm.tsx
+++ b/src/components/forms/VerdivurderingIntakeForm.tsx
@@ -26,10 +26,10 @@ type Props = {
   source: string
   /**
    * CRM source the lead lands under. Defaults server-side to
-   * "verdivurdering-intake"; the eiernotat surface passes "eiernotat" so the
+   * "verdivurdering-intake"; the beslutningsgrunnlag surface passes "beslutningsgrunnlag" so the
    * same form/action serves both offers without duplication.
    */
-  intakeSource?: "verdivurdering-intake" | "eiernotat"
+  intakeSource?: "verdivurdering-intake" | "beslutningsgrunnlag"
   /** Optional prefill carried from the næringskalkulator via URL params. */
   prefill?: VerdivurderingPrefill
   /**
@@ -39,7 +39,7 @@ type Props = {
   showHeading?: boolean
   /**
    * Heading copy when showHeading is true. Defaults to the verdivurdering
-   * wording; the eiernotat surface overrides it so the reused form doesn't
+   * wording; the beslutningsgrunnlag surface overrides it so the reused form doesn't
    * contradict the page it sits on.
    */
   headingTitle?: string
@@ -93,9 +93,9 @@ export function VerdivurderingIntakeForm({
   headingSubtitle = "Det tar to minutter. Du forplikter deg ikke til noe.",
 }: Props) {
   const [state, setState] = useState<FormStatus>({ status: "idle" })
-  // Human form label for the funnel events — distinguishes eiernotat from the
+  // Human form label for the funnel events — distinguishes beslutningsgrunnlag from the
   // verdivurdering reuse of the same form.
-  const formLabel = intakeSource === "eiernotat" ? "eiernotat" : "verdivurdering"
+  const formLabel = intakeSource === "beslutningsgrunnlag" ? "beslutningsgrunnlag" : "verdivurdering"
   const handleFirstFocus = useLeadStartOnFocus(source, formLabel)
 
   // Fire once when the form is shown so we can measure form-views per surface.

--- a/src/lib/email/discord.ts
+++ b/src/lib/email/discord.ts
@@ -14,7 +14,7 @@ const SOURCE_LABEL: Record<SubscribeSource, string> = {
   "sjekkliste-verdivurdering": "Sjekkliste-PDF (verdivurdering)",
   markedsrapport: "Markedsrapport (lead magnet)",
   "verdivurdering-intake": "Verdivurdering-intake (HØY INTENT)",
-  eiernotat: "Eiernotat — 48t beslutningsnotat (HØY INTENT)",
+  beslutningsgrunnlag: "Beslutningsgrunnlag — 48t (HØY INTENT)",
   kontakt: "Kontakt-skjema",
   eiendommer: "Eiendommer (varsel om nye oppdrag)",
   presserom: "Presserom (pressevarsel — journalist!)",
@@ -27,7 +27,7 @@ const SOURCE_LABEL: Record<SubscribeSource, string> = {
 // brand-neutral; intake forms are light-blue.
 const HIGH_INTENT: SubscribeSource[] = [
   "verdivurdering-intake",
-  "eiernotat",
+  "beslutningsgrunnlag",
   "service-modal",
   "kontakt",
   "eiendommer",

--- a/src/lib/email/subscribe.ts
+++ b/src/lib/email/subscribe.ts
@@ -19,7 +19,7 @@ export type SubscribeSource =
   | "sjekkliste-verdivurdering"
   | "markedsrapport"
   | "verdivurdering-intake"
-  | "eiernotat"
+  | "beslutningsgrunnlag"
   | "kontakt"
   | "eiendommer"
   | "presserom"
@@ -54,7 +54,7 @@ const RESEND_CONFIGURED = () =>
 
 const HIGH_INTENT: SubscribeSource[] = [
   "verdivurdering-intake",
-  "eiernotat",
+  "beslutningsgrunnlag",
   "service-modal",
   "kontakt",
   "eiendommer",

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -274,7 +274,7 @@ export const REGISTRY: NavEntry[] = [
   // ── deliberately outside nav/footer (gated or landing pages) ─────────────
   { path: "/presentasjon", label: "Presentasjon", parent: null, inNav: false, inFooter: false },
   { path: "/verdivurdering", label: "Få verdivurdering", parent: null, inNav: false, inFooter: false },
-  { path: "/eiernotat", label: "Eiernotat", parent: null, inNav: false, inFooter: false },
+  { path: "/beslutningsgrunnlag", label: "Beslutningsgrunnlag", parent: null, inNav: false, inFooter: false },
   { path: "/landing/verdivurdering", label: "Verdivurdering landingsside", parent: null, inNav: false, inFooter: false },
   { path: "/sjekkliste-verdivurdering", label: "Sjekkliste verdivurdering", parent: null, inNav: false, inFooter: false },
 

--- a/src/lib/supabase/leads.ts
+++ b/src/lib/supabase/leads.ts
@@ -16,7 +16,7 @@ type RecordSignupArgs = {
 // Everything else lands in the lightweight web_signups table.
 const HIGH_INTENT: SubscribeSource[] = [
   "verdivurdering-intake",
-  "eiernotat",
+  "beslutningsgrunnlag",
   "service-modal",
   "kontakt",
   "eiendommer",
@@ -46,7 +46,7 @@ function intakeString(
 
 const SOURCE_LABEL: Partial<Record<SubscribeSource, string>> = {
   "verdivurdering-intake": "Verdivurdering-intake (skjema)",
-  eiernotat: "Eiernotat — 48t beslutningsnotat (skjema)",
+  beslutningsgrunnlag: "Beslutningsgrunnlag — 48t (skjema)",
   "service-modal": "Tjeneste-modal (CTA på tjenesteside)",
   kontakt: "Kontaktskjema",
   eiendommer: "Eiendommer (varslingsskjema for nye oppdrag)",
@@ -173,9 +173,9 @@ export function buildActivitySummary(
     lines.push(
       "Lead bestilte verdivurdering via skjema på /tjenester/verdivurdering.",
     )
-  } else if (args.source === "eiernotat") {
+  } else if (args.source === "beslutningsgrunnlag") {
     lines.push(
-      "Lead ba om eiernotat (48t partner-vurdert beslutningsnotat: selge / refinansiere / holde / leie ut / reposisjonere).",
+      "Lead ba om beslutningsgrunnlag (48t partner-vurdert: selge / refinansiere / holde / leie ut / reposisjonere).",
     )
   } else if (args.source === "kontakt") {
     lines.push("Henvendelse via kontaktskjema.")

--- a/tests/unit/leads.test.ts
+++ b/tests/unit/leads.test.ts
@@ -104,10 +104,10 @@ describe("recordSignup routing", () => {
     expect(inserted[0]?.table).toBe("web_signups")
   })
 
-  it("routes HIGH_INTENT 'eiernotat' → crm_leads then crm_activities", async () => {
+  it("routes HIGH_INTENT 'beslutningsgrunnlag' → crm_leads then crm_activities", async () => {
     const ok = await recordSignup({
       email: "owner@example.no",
-      source: "eiernotat",
+      source: "beslutningsgrunnlag",
       firstName: "Ola Nordmann",
       intake: { Eiendomstype: "Kontor", Sted: "Bodø" },
     })

--- a/tests/unit/verdivurdering-intake.test.ts
+++ b/tests/unit/verdivurdering-intake.test.ts
@@ -37,14 +37,14 @@ describe("subscribeVerdivurderingIntake — intakeSource whitelist", () => {
     subscribeMock.mockResolvedValue({ ok: true, alreadySubscribed: false })
   })
 
-  it("uses the eiernotat source when the form requests it", async () => {
+  it("uses the beslutningsgrunnlag source when the form requests it", async () => {
     const result = await subscribeVerdivurderingIntake(
-      intakeFormData({ intakeSource: "eiernotat" }),
+      intakeFormData({ intakeSource: "beslutningsgrunnlag" }),
     )
     expect(result).toEqual({ ok: true })
     expect(subscribeMock).toHaveBeenCalledTimes(1)
     expect(subscribeMock.mock.calls[0][0]).toMatchObject({
-      source: "eiernotat",
+      source: "beslutningsgrunnlag",
     })
   })
 


### PR DESCRIPTION
Renames the just-merged "Eiernotat" offer to **"Beslutningsgrunnlag"**.

## Why
"Eiernotat" was a coined term — it read as internal/administrative and didn't signal the decision it supports (sell / refinance / hold / lease / reposition). "Beslutningsgrunnlag" is an established Norwegian term (the basis you need to decide) and names the offer by its function.

## What
Full rename while the feature is still unlaunched (page was `noIndex`, no leads yet), so there's no half-renamed split:
- Route `/eiernotat` → `/beslutningsgrunnlag`
- CRM/analytics source slug `eiernotat` → `beslutningsgrunnlag` (subscribe, leads, discord high-intent lists + labels)
- Page copy: title, eyebrow, headings, sidebar, metadata
- Tests updated

**No behaviour change** — same reused intake form/action, same routing to `crm_leads`.

## Verification
- `npx tsc --noEmit` clean
- `npx vitest run` → 163 pass
- `pnpm build` green incl. `/beslutningsgrunnlag`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
