### PR TITLE
feat(seo): /beslutningsgrunnlag production-ready + internally linked

### DIFF
--- a/src/app/beslutningsgrunnlag/page.tsx
+++ b/src/app/beslutningsgrunnlag/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { constructMetadata } from "@/lib/utils";
 import { SubHero } from "@/components/site/SubHero";
 import { Breadcrumbs } from "@/components/site/Breadcrumbs";
+import { SeOgsa } from "@/components/site/SeOgsa";
 import {
   VerdivurderingIntakeForm,
   type VerdivurderingPrefill,
@@ -10,10 +11,6 @@ import {
 
 export const metadata = constructMetadata({
   path: "/beslutningsgrunnlag",
-  // DRAFT conversion surface. noIndex until the partner-facing offer copy and
-  // the 48-hour fulfilment workflow have had a human review (plan Track C1).
-  // Flip to indexed once the offer is signed off.
-  noIndex: true,
   title: "Beslutningsgrunnlag for næringseiendom | Advanti Estate",
   description:
     "Bør du selge, refinansiere, holde, leie ut eller reposisjonere? Be om et beslutningsgrunnlag: en kort, partner-vurdert vurdering av eiendommen din innen 48 timer.",
@@ -167,6 +164,32 @@ export default function BeslutningsgrunnlagPage() {
               </div>
             </aside>
           </div>
+        </div>
+      </section>
+
+      <section className="section-tight" style={{ paddingTop: 0 }}>
+        <div className="wrap">
+          <SeOgsa
+            heading="Se også"
+            from="beslutningsgrunnlag"
+            links={[
+              {
+                href: "/tjenester/verdivurdering",
+                label: "Verdivurdering av næringseiendom",
+                note: "Hva eiendommen er verdt — DCF, yield og lokale transaksjoner.",
+              },
+              {
+                href: "/verktoy/naringskalkulator",
+                label: "Næringskalkulator",
+                note: "Regn ut et yield-basert verdianslag selv på et minutt.",
+              },
+              {
+                href: "/markedsinnsikt",
+                label: "Markedsinnsikt",
+                note: "Yield, leie og transaksjoner per by og segment.",
+              },
+            ]}
+          />
         </div>
       </section>
     </>

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -34,6 +34,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     "/tjenester/utleie",
     "/tjenester/transaksjoner",
     "/tjenester/strategisk-radgivning",
+    "/beslutningsgrunnlag",
     "/verktoy",
     "/verktoy/yield-kalkulator",
     "/verktoy/boliglan-kalkulator",

--- a/src/app/tjenester/verdivurdering/page.tsx
+++ b/src/app/tjenester/verdivurdering/page.tsx
@@ -4,6 +4,7 @@ import { PhotoBand } from "@/components/site/PhotoBand";
 import { Faq, type FaqItem } from "@/components/site/Faq";
 import StructuredData from "@/components/StructuredData";
 import { Breadcrumbs } from "@/components/site/Breadcrumbs";
+import { SeOgsa } from "@/components/site/SeOgsa";
 import { VerdivurderingIntake } from "./VerdivurderingIntake";
 
 const LAST_UPDATED = "2026-05-22";
@@ -330,6 +331,27 @@ export default function VerdivurderingPage() {
       <PhotoBand src="/building/pexels-abshky-18567185.jpg" alt="Verdivurdering av næringseiendom" caption="Verdivurdering · Nord-Norge" />
 
       <VerdivurderingIntake />
+
+      <section className="section-tight" style={{ paddingTop: 0 }}>
+        <div className="wrap">
+          <SeOgsa
+            heading="Neste steg"
+            from="tjeneste-verdivurdering"
+            links={[
+              {
+                href: "/beslutningsgrunnlag",
+                label: "Bør du selge, refinansiere eller holde?",
+                note: "Få et partner-vurdert beslutningsgrunnlag på 48 timer.",
+              },
+              {
+                href: "/tjenester/salg",
+                label: "Salg av næringseiendom",
+                note: "Strukturert salgsprosess fra verdivurdering til oppgjør.",
+              },
+            ]}
+          />
+        </div>
+      </section>
 
       <div className="wrap pb-16 text-center">
         <p className="eyebrow no-rule">

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -274,7 +274,9 @@ export const REGISTRY: NavEntry[] = [
   // ── deliberately outside nav/footer (gated or landing pages) ─────────────
   { path: "/presentasjon", label: "Presentasjon", parent: null, inNav: false, inFooter: false },
   { path: "/verdivurdering", label: "Få verdivurdering", parent: null, inNav: false, inFooter: false },
-  { path: "/beslutningsgrunnlag", label: "Beslutningsgrunnlag", parent: null, inNav: false, inFooter: false },
+  // Indexable conversion surface — reached via sitemap + cross-links (SeOgsa),
+  // not primary nav. Parent gives it a Tjenester breadcrumb trail.
+  { path: "/beslutningsgrunnlag", label: "Beslutningsgrunnlag", parent: "/tjenester", inNav: false, inFooter: false },
   { path: "/landing/verdivurdering", label: "Verdivurdering landingsside", parent: null, inNav: false, inFooter: false },
   { path: "/sjekkliste-verdivurdering", label: "Sjekkliste verdivurdering", parent: null, inNav: false, inFooter: false },
 


### PR DESCRIPTION
Takes `/beslutningsgrunnlag` out of draft and wires it into the SEO graph.

## Changes
- **Indexable:** removed `noIndex` — verified the prerendered HTML has no `robots noindex` meta.
- **Sitemap:** added `/beslutningsgrunnlag` to the curated static list in `sitemap.ts` (verified present in build output).
- **Breadcrumb:** gave it a `/tjenester` parent in the IA registry → emits a `BreadcrumbList` trail (Hjem / Tjenester / Beslutningsgrunnlag).
- **Internal linking (both directions):**
  - Inbound "Neste steg" `SeOgsa` block on the strong `/tjenester/verdivurdering` page → `/beslutningsgrunnlag` (passes topical link equity).
  - Outbound "Se også" block on `/beslutningsgrunnlag` → verdivurdering / næringskalkulator / markedsinnsikt.

## Verification
- `npx tsc --noEmit` clean · `npx vitest run` 163 pass · `pnpm build` green
- Confirmed in build output: indexable robots meta, sitemap entry, bidirectional cross-links, breadcrumb trail

## ⚠️ Before merge — operational readiness
The page now publicly promises a **partner-reviewed assessment within 48 hours**. The fulfilment side (memo template + who writes it + the 48h SLA) should be in place before this goes live, since merging makes it discoverable and crawlable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
