### PR TITLE
feat(help): port Kunnskapssenter v2 design (hub + article id-page)

### DIFF
--- a/content-collections.ts
+++ b/content-collections.ts
@@ -227,6 +227,10 @@ export const HelpPost = defineCollection({
     publishedAt: z.string().optional(),
     related: z.array(z.string()).optional(),
     excludeHeadingsFromSearch: z.boolean().optional(),
+    // Optional "Kort fortalt" key points, rendered as a callout box at the top
+    // of the article. Editorial summary, distinct from the lede — keep it short
+    // (typically 3 points). Rendered dynamically, so any count works.
+    takeaways: z.array(z.string()).optional(),
     // Opt-in HowTo schema. Only set on genuine step-by-step procedural
     // articles — the emitted JSON-LD MUST mirror visible page content (Google
     // and schema.org policy), so author the `step` array to match a visible

--- a/plans/009-help-seo-tekniske-fikser.md
+++ b/plans/009-help-seo-tekniske-fikser.md
@@ -1,0 +1,334 @@
+# Plan 009: Tekniske SEO-fikser for kunnskapssenteret (/help)
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report — do not improvise. When done, update the status row for this plan
+> in `plans/README.md`.
+>
+> **Drift check (run first)**:
+> `git diff --stat 5e1c60a..HEAD -- src/app/sitemap.ts "src/app/(help)" content-collections.ts src/content/help/hva-er-naringseiendom.mdx src/content/help/hva-er-yield.mdx src/styles/advanti-design.css`
+> If any in-scope file changed since `5e1c60a`, compare the "Current state"
+> excerpts against the live code before proceeding; on a mismatch, treat it
+> as a STOP condition.
+
+## Status
+
+- **Priority**: P1
+- **Effort**: S–M
+- **Risk**: LOW (additive metadata/gating; no visual redesign)
+- **Depends on**: none
+- **Category**: bug + tech-debt (SEO)
+- **Planned at**: commit `5e1c60a`, 2026-06-12
+
+## Why this matters
+
+Kunnskapssenteret skal være Advantis viktigste organiske trafikk-kanal, men
+fire konkrete feil svekker det i dag: (1) to kategorisider («For Investorer»,
+«Markedsanalyse») har null artikler men er indeksert og ligger i sitemap —
+klassisk tynt innhold som senker crawl-kvaliteten på hele seksjonen; (2) den
+mest populære artikkelen har forfatter-handle `christer` som ikke mapper til
+noe, så siden mister forfatterboks og Person-`@id` i Article-schemaet
+(E-E-A-T-signal); (3) Article-JSON-LD setter alltid `datePublished` lik
+`dateModified` og utelater felter komponenten allerede støtter; (4) det
+finnes ingen FAQ-støtte, så artiklene kan ikke konkurrere om featured
+snippets / AI-overview-sitering. Denne planen fikser alle fire. Plan 010 og
+011 (innhold) bygger på feltene som innføres her.
+
+## Current state
+
+Relevante filer:
+
+- `src/app/sitemap.ts` — genererer sitemap; linje 74–78 mapper ALLE
+  `HELP_CATEGORIES` uten å sjekke artikkelantall:
+  ```ts
+  // Help category pages — `lastModified` omitted (no true modified date).
+  const helpCategories = HELP_CATEGORIES.map((category) => ({
+    url: `${baseUrl}/help/category/${category.slug}`,
+    changeFrequency: "weekly" as const,
+    priority: 0.7,
+  }));
+  ```
+- `src/lib/blog/content.tsx:48–102` — `HELP_CATEGORIES` har 6 kategorier.
+  Per 2026-06-12 har `for-investors` og `analysis` **0 artikler** (verifisert
+  ved frontmatter-skann av `src/content/help/*.mdx`).
+- `src/app/(help)/help/category/[slug]/page.tsx:50–71` — `generateMetadata`
+  kaller `constructMetadata` uten `noIndex`; linje 135–138 rendrer «Ingen
+  artikler i denne kategorien ennå.» for tomme kategorier. `allHelpPosts`
+  er allerede importert i filen (linje 1).
+- `src/lib/utils.ts` — `constructMetadata({ noIndex?: boolean, ... })`
+  støtter allerede `noIndex` (sjekk signaturen rundt linje 132–165).
+- `src/content/help/hva-er-naringseiendom.mdx:6` — `author: "christer"`.
+  `AUTHOR_NAMES`/`AUTHOR_META` i
+  `src/app/(help)/help/article/[slug]/page.tsx:18–37` kjenner bare
+  `codehagen` og `vsoraas`; `AUTHORS` i `src/lib/authors.ts` har `codehagen`
+  med `personSlug: "christer-hagen"`. Begge identiteter er Christer Hagen —
+  riktig handle er `codehagen`.
+- `content-collections.ts:204–238` — `HelpPost`-skjemaet. Har `updatedAt`
+  men IKKE `publishedAt` og IKKE `faq`. NB: `hva-er-naringseiendom.mdx` har
+  allerede `publishedAt: "2024-01-25"` i frontmatter — zod stripper ukjente
+  felter i dag, så verdien er usynlig for koden.
+- `src/app/(help)/help/article/[slug]/page.tsx:148–158` — Article-schema:
+  ```tsx
+  <StructuredData
+    type="article"
+    data={{
+      title: data.title,
+      summary: data.summary,
+      publishedAt: data.updatedAt,   // ← alltid lik dateModified
+      updatedAt: data.updatedAt,
+      author: data.author,
+      url: `/help/article/${data.slug}`,
+    }}
+  />
+  ```
+  `readingTime` (linje 131–133) og `category` (linje 114–116) er beregnet FØR
+  denne JSX-en, så de kan brukes direkte.
+- `src/components/StructuredData.tsx:361–384` — Article-builderen leser
+  valgfritt `data.timeRequired` (minutter → `PT<n>M`) og
+  `data.articleSection`. `case "faq"` (linje 388–404) finnes allerede og tar
+  `data.faqs: {question, answer}[]`.
+- **Repo-konvensjon (viktig)**: JSON-LD skal speile synlig sideinnhold — se
+  HowTo-piloten i `content-collections.ts:227–236` og kommentaren der.
+  FAQ-implementasjonen i steg 5 MÅS følge samme prinsipp: samme
+  frontmatter-array driver både synlig seksjon og JSON-LD.
+- **Designsystem**: Les `DESIGN.md` før steg 5. Semantiske klasser fra
+  `src/styles/advanti-design.css` (mønster: `ks-*`-klassene for
+  kunnskapssenteret) — ikke ad-hoc Tailwind. Norsk copy.
+
+## Commands you will need
+
+| Purpose | Command | Expected on success |
+|---------|---------|---------------------|
+| Typecheck | `pnpm typecheck` | exit 0 |
+| Build (kompilerer også MDX-kolleksjonene) | `pnpm build` | exit 0 |
+| Prod-server for verifikasjon | `pnpm start &` (kjør i bakgrunn, husk å drepe etterpå) | server på :3000 |
+| Lint | — | **N/A: `pnpm lint` er ødelagt repo-vidt** (kjent funn, se plans/README.md «New findings from plan 001 execution») — ikke bruk lint som gate |
+
+## Scope
+
+**In scope** (de eneste filene du endrer):
+- `src/app/sitemap.ts`
+- `src/app/(help)/help/category/[slug]/page.tsx`
+- `src/app/(help)/help/article/[slug]/page.tsx`
+- `content-collections.ts` (kun `HelpPost`-skjemaet)
+- `src/content/help/hva-er-naringseiendom.mdx` (kun `author`-linjen)
+- `src/content/help/hva-er-yield.mdx` (kun ny `faq`-frontmatter)
+- `src/styles/advanti-design.css` (kun hvis steg 5 trenger en ny `ks-faq`-klasse)
+
+**Out of scope** (IKKE rør, selv om det ser relatert ut):
+- `src/components/StructuredData.tsx` — `faq`- og `article`-casene støtter
+  allerede alt vi trenger; ingen endring nødvendig.
+- Blog-, kunde-, person- eller listing-rutene og deres schema.
+- `HELP_CATEGORIES`-definisjonen i `src/lib/blog/content.tsx` — ikke slett
+  de tomme kategoriene; plan 011 fyller dem, og gatingen i steg 1–2 åpner
+  dem automatisk når innhold lander.
+- Innholdet (brødteksten) i eksisterende artikler — det er plan 010/011.
+
+## Git workflow
+
+- Branch: `advisor/009-help-seo-tekniske-fikser`
+- Konvensjon fra `git log`: conventional commits på norsk, f.eks.
+  `fix(seo): noindex + sitemap-gate for tomme help-kategorier`
+- Ikke push / ikke opprett PR uten beskjed fra operatøren.
+
+## Steps
+
+### Steg 1: Gate tomme kategorier ut av sitemap
+
+I `src/app/sitemap.ts`, endre `helpCategories` (linje 74–78) til å filtrere
+bort kategorier uten artikler. `allHelpPosts` er allerede importert:
+
+```ts
+// Help category pages — `lastModified` omitted (no true modified date).
+// Categories with zero articles are excluded until they have content —
+// they render an empty state and would be thin pages in the index.
+const helpCategories = HELP_CATEGORIES.filter((category) =>
+  allHelpPosts.some((post) =>
+    (post.categories as string[]).includes(category.slug),
+  ),
+).map((category) => ({
+  url: `${baseUrl}/help/category/${category.slug}`,
+  changeFrequency: "weekly" as const,
+  priority: 0.7,
+}));
+```
+
+**Verify**: `pnpm typecheck` → exit 0.
+
+### Steg 2: noindex på tomme kategorisider
+
+I `src/app/(help)/help/category/[slug]/page.tsx`, i `generateMetadata`
+(linje 50–71), legg til en tom-sjekk og send `noIndex`:
+
+```ts
+const hasArticles = allHelpPosts.some((post) =>
+  (post.categories as string[]).includes(slug),
+)
+
+return constructMetadata({
+  path: `/help/category/${slug}`,
+  title: `${title} – Advanti Hjelpesenter`,
+  description,
+  image: `/api/og/help?title=${encodeURIComponent(
+    title,
+  )}&summary=${encodeURIComponent(description)}`,
+  noIndex: !hasArticles,
+})
+```
+
+**Verify**: `pnpm typecheck` → exit 0.
+
+### Steg 3: Fiks forfatter-handlen på flaggskipartikkelen
+
+I `src/content/help/hva-er-naringseiendom.mdx` linje 6, endre
+`author: "christer"` → `author: codehagen` (samme stil som de andre
+artiklene, uten anførselstegn).
+
+**Verify**:
+`grep -rn 'author: "christer"' src/content/` → 0 treff.
+`grep -c 'author: codehagen' src/content/help/hva-er-naringseiendom.mdx` → 1.
+
+### Steg 4: Ekte datePublished + rikere Article-schema
+
+1. I `content-collections.ts`, i `HelpPost`-skjemaet (etter `updatedAt` på
+   linje 210), legg til:
+   ```ts
+   // Optional original publish date. When absent, the article page falls
+   // back to updatedAt for schema.org datePublished.
+   publishedAt: z.string().optional(),
+   ```
+2. I `src/app/(help)/help/article/[slug]/page.tsx`, oppdater
+   `StructuredData type="article"`-blokken (linje 148–158) til:
+   ```tsx
+   <StructuredData
+     type="article"
+     data={{
+       title: data.title,
+       summary: data.summary,
+       publishedAt: data.publishedAt ?? data.updatedAt,
+       updatedAt: data.updatedAt,
+       author: data.author,
+       url: `/help/article/${data.slug}`,
+       timeRequired: readingTime ?? undefined,
+       articleSection: category.title,
+     }}
+   />
+   ```
+   NB: `readingTime` og `category` beregnes i dag NEDENFOR JSX-returen
+   starter men FØR denne blokken brukes? Nei — sjekk: `category` beregnes
+   linje 114, `readingTime` linje 131, og `return (` starter linje 138.
+   Begge er altså tilgjengelige. Ikke flytt på noe.
+
+**Verify**: `pnpm typecheck` → exit 0. `pnpm build` → exit 0 (bekrefter at
+`publishedAt`-frontmatter i hva-er-naringseiendom.mdx nå validerer).
+
+### Steg 5: FAQ-felt i kolleksjonen + synlig FAQ-seksjon + JSON-LD
+
+1. I `content-collections.ts`, i `HelpPost`-skjemaet, legg til etter
+   `step`-feltet (linje 236):
+   ```ts
+   // Opt-in FAQ. Same policy as `howto`/`step` above: the emitted FAQPage
+   // JSON-LD MUST mirror a visible FAQ section on the page, so the article
+   // page renders this exact array as visible content AND as schema.
+   faq: z
+     .array(z.object({ question: z.string(), answer: z.string() }))
+     .min(2)
+     .optional(),
+   ```
+2. I `src/app/(help)/help/article/[slug]/page.tsx`:
+   - Etter HowTo-blokken (linje 159–168), legg til:
+     ```tsx
+     {data.faq && data.faq.length >= 2 && (
+       <StructuredData type="faq" data={{ faqs: data.faq }} />
+     )}
+     ```
+   - Rendre synlig FAQ-seksjon inne i `<article className="ks-art-body">`,
+     ETTER `<MDX …/>` (linje 229) og FØR feedback-blokken (linje 232):
+     ```tsx
+     {data.faq && data.faq.length >= 2 && (
+       <div className="ks-faq">
+         <h2 id="ofte-stilte-sporsmal">Ofte stilte spørsmål</h2>
+         {data.faq.map((item) => (
+           <div className="ks-faq-item" key={item.question}>
+             <h3>{item.question}</h3>
+             <p>{item.answer}</p>
+           </div>
+         ))}
+       </div>
+     )}
+     ```
+3. Styling: Les `DESIGN.md` først. Legg til `.ks-faq`-regler i
+   `src/styles/advanti-design.css` ved siden av de eksisterende
+   `ks-*`-reglene (søk etter `.ks-related` som mønster — match dens
+   typografi-skala, spacing-tokens og border-stil; ingen nye farger).
+4. Pilot-innhold: legg FAQ-frontmatter i
+   `src/content/help/hva-er-yield.mdx` (etter `slug`-linjen):
+   ```yaml
+   faq:
+     - question: "Hva er en god yield for næringseiendom?"
+       answer: "Det finnes ikke ett riktig svar — yield reflekterer risiko. Sentralt beliggende kontoreiendom med solide leietakere på lange kontrakter prises med lavere yield enn eldre bygg med korte kontrakter i mindre markeder. Sammenlign alltid mot tilsvarende eiendommer i samme marked."
+     - question: "Hva er forskjellen på brutto- og netto-yield?"
+       answer: "Brutto-yield beregnes av brutto leieinntekter, mens netto-yield (det vanligste i næringseiendom) beregnes av leieinntekter fratrukket eierkostnader. Netto-yield gir det mest presise bildet av faktisk avkastning."
+     - question: "Hvorfor faller verdien når yielden stiger?"
+       answer: "Verdi = netto leieinntekter delt på yield. Når markedet krever høyere avkastning (høyere yield) for samme leieinntekt, må prisen ned. En endring på ett prosentpoeng i yield kan gi store verdiutslag."
+   ```
+
+**Verify**:
+1. `pnpm typecheck` → exit 0.
+2. `pnpm build` → exit 0.
+3. `pnpm start &` deretter:
+   - `curl -s http://localhost:3000/help/article/hva-er-yield | grep -c "FAQPage"` → `1` (eller mer).
+   - `curl -s http://localhost:3000/help/article/hva-er-yield | grep -c "Ofte stilte spørsmål"` → minst `1`.
+   - `curl -s http://localhost:3000/help/category/for-investors | grep -c 'noindex'` → minst `1`.
+   - `curl -s http://localhost:3000/help/category/terms | grep -c 'noindex'` → `0`.
+   - `curl -s http://localhost:3000/sitemap.xml | grep -c "help/category/for-investors"` → `0`.
+   - `curl -s http://localhost:3000/sitemap.xml | grep -c "help/category/terms"` → `1`.
+   - `curl -s http://localhost:3000/help/article/hva-er-naringseiendom | grep -c "2024-01-25"` → minst `1` (datePublished i JSON-LD).
+   - Drep serveren etterpå (`kill %1` eller tilsvarende).
+
+## Test plan
+
+Repoet har Vitest (`pnpm test`, etablert i plan 004) for ren logikk, men
+endringene her er metadata/JSX uten ny ren logikk — curl-gatene over ER
+testplanen. Kjør `pnpm test` én gang til slutt for å bekrefte at ingenting
+brakk: alle eksisterende tester grønne.
+
+## Done criteria
+
+Machine-checkable. ALL must hold:
+
+- [ ] `pnpm typecheck` exit 0
+- [ ] `pnpm build` exit 0
+- [ ] Alle 8 curl-gatene i steg 5 gir forventet resultat
+- [ ] `grep -rn 'author: "christer"' src/content/` → 0 treff
+- [ ] `pnpm test` exit 0
+- [ ] `git status` viser ingen endrede filer utenfor in-scope-listen
+- [ ] Statusrad oppdatert i `plans/README.md`
+
+## STOP conditions
+
+Stopp og rapporter (ikke improviser) hvis:
+
+- Kode-excerpts i «Current state» ikke matcher live kode (drift siden `5e1c60a`).
+- `constructMetadata` i `src/lib/utils.ts` viser seg å IKKE ha `noIndex`-parameter.
+- `pnpm build` feiler på MDX-kompilering etter skjemaendringene i
+  content-collections.ts — IKKE forsøk å «fikse» andre kolleksjoner.
+- En curl-gate feiler to ganger etter rimelig fiksforsøk.
+- `for-investors` eller `analysis` har fått artikler siden planen ble
+  skrevet (da er gate-logikken fortsatt riktig, men verifikasjonene for
+  «tom kategori» må byttes til en kategori som faktisk er tom — rapporter
+  hvilken).
+
+## Maintenance notes
+
+- Gatingen i steg 1–2 er **selvopphevende**: når plan 011 legger første
+  artikkel i `for-investors`/`analysis`, kommer kategorien automatisk inn i
+  sitemap og mister noindex. Ingen oppfølging nødvendig.
+- FAQ-konvensjonen (frontmatter driver både synlig innhold og JSON-LD) må
+  holdes: en reviewer skal avvise PR-er som legger FAQ-schema uten synlig
+  seksjon eller omvendt.
+- Plan 010 og 011 forutsetter `publishedAt`- og `faq`-feltene fra denne
+  planen — denne må lande først.
+- Bevisst utsatt: `wordCount`/`keywords` i Article-schema (lav SEO-verdi,
+  mer rør); FAQ på flere eksisterende artikler (plan 010/011 eier innhold).

--- a/plans/010-utvid-flaggskipartikkel-og-meta.md
+++ b/plans/010-utvid-flaggskipartikkel-og-meta.md
@@ -1,0 +1,243 @@
+# Plan 010: Gjør «Hva er næringseiendom» til en ekte pilarside + skriv om svake meta descriptions
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report — do not improvise. When done, update the status row for this plan
+> in `plans/README.md`.
+>
+> **Drift check (run first)**:
+> `git diff --stat 5e1c60a..HEAD -- src/content/help/`
+> Hvis filer i `src/content/help/` er endret siden `5e1c60a`, sammenlign
+> «Current state»-utdragene mot live kode før du fortsetter; ved avvik er
+> det en STOP-betingelse. NB: plan 009 endrer `author:`-linjen og legger
+> `faq:` i `hva-er-yield.mdx` — DE endringene er forventet drift, ikke STOP.
+
+## Status
+
+- **Priority**: P2
+- **Effort**: M
+- **Risk**: LOW (kun innholdsfiler; ingen kode)
+- **Depends on**: plans/009-help-seo-tekniske-fikser.md (for `faq`- og `publishedAt`-feltene)
+- **Category**: docs/innhold (SEO)
+- **Planned at**: commit `5e1c60a`, 2026-06-12
+
+## Why this matters
+
+`hva-er-naringseiendom` er kuratert som mest populære artikkel
+(`POPULAR_ARTICLES[0]` i `src/lib/blog/content.tsx:40–46`) og har tittelen
+«Hva er næringseiendom? En komplett guide» — men brødteksten er **292 ord**.
+Tittelen lover en komplett guide; Google får tre avsnitt. For søkeordet
+«hva er næringseiendom» konkurrerer siden mot 1500–3000-ords pilarsider hos
+nasjonale aktører. I tillegg starter 5 av 12 artikkel-summaries (som blir
+meta descriptions OG SERP-snippets) med samme formel («En omfattende/
+dyptgående/detaljert guide til …») — utskiftbare snippets uten søkeintensjon.
+Denne planen utvider flaggskipet til en ekte pilarside og gir hver artikkel
+en unik, klikkverdig meta description.
+
+## Current state
+
+- `src/content/help/hva-er-naringseiendom.mdx` — 292 ord brødtekst.
+  Frontmatter i dag (etter plan 009 er `author` rettet til `codehagen`):
+  ```yaml
+  ---
+  title: "Hva er næringseiendom? En komplett guide"
+  slug: "hva-er-naringseiendom"
+  summary: "Lær alt om hva næringseiendom er, de ulike kategoriene, og hva som skiller det fra boligeiendom. En guide for investorer og bedrifter."
+  categories: ["overview"]
+  author: codehagen
+  publishedAt: "2024-01-25"
+  updatedAt: "2024-01-25"
+  images: ["/building/pexels-pixabay-248877.jpg"]
+  ---
+  ```
+  Struktur i dag: intro-avsnitt, «## Hovedkategorier av næringseiendom»
+  med fire korte `###`-underseksjoner (kontor, handel, lager, kombinasjon),
+  og en kort avslutning. Ingen `related:`-frontmatter, ingen MDX-komponenter.
+- Formelaktige summaries (eksakte verdier i dag, fil → summary-start):
+  - `diskontert-kontantstrom.mdx` → «En dyptgående guide til diskontert kontantstrøm-analyse (DCF) …»
+  - `driftskostnader.mdx` → «En omfattende guide til å forstå driftskostnader …»
+  - `felleskostnader.mdx` → «En detaljert guide om felleskostnader …»
+  - `hva-er-yield.mdx` → «En omfattende guide til å forstå yield …»
+  - `kontantstromsanalyse.mdx` → «En omfattende guide til å forstå kontantstrømsanalyse …»
+  - `sensitivitetsanalyse.mdx` → «En omfattende guide til sensitivitetsanalyse …»
+  - `markedsleie-og-leieniva.mdx` → «En grundig gjennomgang av markedsleie …»
+- Stil-eksemplar for help-artikler: `src/content/help/hva-er-yield.mdx` —
+  H2-struktur («Hva er X», «Grunnleggende om X», praksis-seksjoner),
+  `<Math formula="…" description="…" />` for formler, `<Note variant="info">`
+  for tommelfingerregler, interne lenker som `[yield](/help/article/hva-er-yield)`.
+  Tilgjengelige MDX-komponenter (fra `src/components/blog/mdx.tsx`): `Math`,
+  `Note`, `Stepper`, `Prerequisites`, `Example`, `Compare`, `Fact`,
+  `StatStrip`, `ReadMore`. Tabeller via GFM støttes.
+- Språk: norsk bokmål. H2-overskrifter genererer ToC automatisk
+  (`tableOfContents` fra H2 i `content-collections.ts`).
+
+## Commands you will need
+
+| Purpose | Command | Expected on success |
+|---------|---------|---------------------|
+| Build (validerer frontmatter + MDX) | `pnpm build` | exit 0 |
+| Ordtelling | `wc -w src/content/help/hva-er-naringseiendom.mdx` | ≥ 1500 |
+| Formel-grep | `grep -c "En omfattende guide\|En dyptgående guide\|En detaljert guide\|En grundig gjennomgang" src/content/help/*.mdx \| grep -v ":0"` | ingen treff (alle filer :0) |
+| Lint | — | N/A (`pnpm lint` ødelagt repo-vidt, kjent funn) |
+
+## Scope
+
+**In scope** (de eneste filene du endrer):
+- `src/content/help/hva-er-naringseiendom.mdx` (full omskriving av brødtekst + frontmatter-utvidelse)
+- Summary-linjen (KUN den) i: `diskontert-kontantstrom.mdx`,
+  `driftskostnader.mdx`, `felleskostnader.mdx`, `hva-er-yield.mdx`,
+  `kontantstromsanalyse.mdx`, `sensitivitetsanalyse.mdx`,
+  `markedsleie-og-leieniva.mdx`
+
+**Out of scope** (IKKE rør):
+- Brødteksten i de 7 summary-filene — kun frontmatter-summary endres.
+- Alt under `src/app/` og `src/components/` — null kodeendringer i denne planen.
+- `src/content/blog/` — blog/help-overlapp håndteres i plan 012.
+- Nye artikler — det er plan 011.
+
+## Git workflow
+
+- Branch: `advisor/010-flaggskip-pilarside`
+- Commit-stil: `content(help): utvid hva-er-naringseiendom til pilarside` og
+  `content(help): unike meta descriptions for 7 artikler`
+- Ikke push / ikke opprett PR uten beskjed fra operatøren.
+
+## Steps
+
+### Steg 1: Utvid hva-er-naringseiendom.mdx til pilarside (≥1500 ord)
+
+Skriv om brødteksten etter denne disposisjonen. Behold tittel og slug
+uendret. Skriv på norsk bokmål, saklig og konkret — matchende tonen i
+`hva-er-yield.mdx`.
+
+**KRITISK INNHOLDSREGEL**: Ikke oppgi konkrete markedstall (yield-nivåer,
+leiepriser, ledighet, transaksjonsvolum) for noen by. Bedriftens regel er at
+markedstall kun publiseres fra verifiserte kilder bak et internt
+verifikasjonsflagg. Kvalitative utsagn («sentralt beliggende kontoreiendom
+prises med lavere yield enn …») er OK; tall er IKKE OK.
+
+Disposisjon (H2-er blir ToC — bruk disse):
+
+1. **Intro (uten overskrift, 60–90 ord)** — direkte definisjonssvar først
+   (optimalisert for featured snippet): hva næringseiendom er, formålet
+   (huse virksomhet eller generere leieinntekter), kontrast til bolig.
+2. **## Hovedkategorier av næringseiendom** — utvid dagens fire `###` til
+   seks, hver 80–130 ord: Kontoreiendom, Handelseiendom (retail), Lager og
+   logistikk, Kombinasjonseiendom, Hotell og overnatting, Spesialeiendom
+   (industri, parkering, helse/offentlig formålsbygg).
+3. **## Hva skiller næringseiendom fra boligeiendom?** — GFM-tabell med
+   dimensjonene: leiekontraktens lengde (typisk 5–15 år vs 1–3),
+   leiejustering (KPI-regulering), partene (profesjonelle), verdsettelse
+   (yield/kontantstrøm vs sammenlignbare salg), finansiering, MVA
+   (frivillig registrering). Kort prosa rundt tabellen.
+4. **## Hvordan verdsettes næringseiendom?** — kort (150–200 ord), pek
+   videre med lenker: `[yield](/help/article/hva-er-yield)`,
+   `[diskontert kontantstrøm](/help/article/diskontert-kontantstrom)`,
+   `[verdivurdering av næringseiendom](/help/article/verdivurdering-av-naringseiendom)`.
+   Inkluder grunnformelen med `<Math formula="\text{Markedsverdi} = \frac{\text{Netto leieinntekter}}{\text{Yield}}" description="Yield-basert verdsettelse — den vanligste metoden" />`.
+5. **## Hvordan investere i næringseiendom** — 200–250 ord: direktekjøp,
+   kjøp av eiendomsselskap (aksjer vs innmat — nevn kort), syndikat/fond.
+   `<Note variant="info">` om at de fleste transaksjoner i Norge skjer som
+   selskapskjøp.
+6. **## Næringseiendom i Nord-Norge** — 120–180 ord, kvalitativt: mindre og
+   mer konsentrerte markeder, betydningen av lokalkunnskap, Bodø/Tromsø som
+   regionale tyngdepunkt. INGEN tall (se innholdsregelen).
+7. **## Sentrale begreper** — punktliste der hvert punkt lenker til en
+   eksisterende begrepsartikkel: yield, netto leieinntekter,
+   driftskostnader, felleskostnader, markedsleie, kontantstrømsanalyse,
+   sensitivitetsanalyse. (Kun slugs som finnes i `src/content/help/` —
+   verifiser med `ls`.)
+8. Avslutt med ett kort avsnitt som naturlig peker mot
+   `[verdivurdering](/tjenester/verdivurdering)` — IKKE en hard salgspitch;
+   sidemalen har allerede CTA-strip.
+
+Frontmatter-endringer:
+- `summary:` → `"Næringseiendom er eiendom som brukes til virksomhet eller utleie — kontor, handel, lager og mer. Lær kategoriene, verdidriverne og hvordan markedet fungerer."`
+- Behold `publishedAt: "2024-01-25"`, sett `updatedAt:` til dagens dato
+  (`date +%F`).
+- Legg til:
+  ```yaml
+  related:
+    - hva-er-yield
+    - verdivurdering-av-naringseiendom
+    - markedsleie-og-leieniva
+  faq:
+    - question: "Hva regnes som næringseiendom?"
+      answer: "Eiendom som primært brukes til næringsvirksomhet eller utleie til virksomheter: kontorbygg, butikklokaler, lager- og logistikkbygg, hoteller, kombinasjonsbygg og spesialeiendom. Boligutleie i stor skala kan også drives som næring, men selve boligeiendommen kategoriseres normalt ikke som næringseiendom."
+    - question: "Er det lurt å investere i næringseiendom?"
+      answer: "Næringseiendom gir typisk lengre leiekontrakter og mer forutsigbar kontantstrøm enn bolig, men krever større kapital, mer kompetanse og innebærer høyere risiko ved ledighet. En grundig verdivurdering og forståelse av yield og kontantstrøm er forutsetninger for en god investering."
+    - question: "Hva er forskjellen på næringseiendom og boligeiendom?"
+      answer: "De viktigste forskjellene er leiekontraktens lengde og struktur, at partene er profesjonelle, at verdien beregnes ut fra leieinntektene (yield), og at utleie av næringslokaler kan registreres frivillig i MVA-registeret."
+  ```
+  (`faq`-feltet finnes etter plan 009 — verifiser at `faq:` er definert i
+  `HelpPost`-skjemaet i `content-collections.ts` før du bruker det; hvis
+  ikke, STOP.)
+
+**Verify**:
+`pnpm build` → exit 0.
+`wc -w src/content/help/hva-er-naringseiendom.mdx` → ≥ 1500.
+
+### Steg 2: Skriv om de 7 formelaktige summaries
+
+Erstatt KUN `summary:`-verdien i hver fil med teksten under (≤160 tegn,
+unik, med intensjon — verifisert mot artiklenes faktiske innhold):
+
+| Fil | Ny summary |
+|-----|-----------|
+| `hva-er-yield.mdx` | `Yield er forholdet mellom netto leieinntekter og eiendomsverdi. Lær hvordan du beregner yield, tolker nivåene og bruker den til å sammenligne eiendommer.` |
+| `diskontert-kontantstrom.mdx` | `DCF-analyse verdsetter næringseiendom ut fra fremtidige kontantstrømmer. Steg for steg: kontantstrøm, diskonteringsrente, terminalverdi og nåverdi.` |
+| `driftskostnader.mdx` | `Driftskostnader avgjør hva du faktisk sitter igjen med. Se hvilke kostnader som inngår, typiske nivåer, og hvordan de påvirker yield og verdi.` |
+| `felleskostnader.mdx` | `Felleskostnader fordeles mellom leietakerne og påvirker totalprisen på leieforholdet. Slik beregnes, fordeles og optimaliseres de i næringsbygg.` |
+| `kontantstromsanalyse.mdx` | `Kontantstrømsanalyse viser hva en næringseiendom faktisk genererer. Lær oppsettet fra brutto leieinntekter til netto kontantstrøm — med formler.` |
+| `sensitivitetsanalyse.mdx` | `Hvor robust er eiendomsverdien hvis yield eller leie endrer seg? Sensitivitetsanalyse viser hvilke forutsetninger som betyr mest for verdien.` |
+| `markedsleie-og-leieniva.mdx` | `Markedsleie er leien et lokale oppnår ved ny utleie i dagens marked. Lær hva som driver leienivåene og hvordan markedsleie fastsettes i praksis.` |
+
+**Verify**:
+`pnpm build` → exit 0.
+`grep -l "En omfattende guide\|En dyptgående guide\|En detaljert guide\|En grundig gjennomgang" src/content/help/*.mdx` → ingen filer.
+
+## Test plan
+
+Ingen ny kode → ingen nye enhetstester. Innholdsvalidering skjer via
+content-collections-kompileringen i `pnpm build` (frontmatter-skjema +
+MDX-kompilering). Kjør i tillegg `pnpm test` til slutt → alle grønne.
+
+## Done criteria
+
+- [ ] `pnpm build` exit 0
+- [ ] `wc -w src/content/help/hva-er-naringseiendom.mdx` ≥ 1500
+- [ ] Grep-gaten for guide-formuleringer gir 0 filer
+- [ ] Alle interne lenker i den nye pilarteksten peker på slugs som finnes
+      (`ls src/content/help/` + manuell kryssjekk; ingen lenke til
+      ikke-eksisterende artikkel)
+- [ ] Ingen konkrete markedstall (yield-%, kr/kvm, ledighets-%) i ny tekst:
+      `grep -nE "[0-9]+ ?(%|kr/kvm|prosent)" src/content/help/hva-er-naringseiendom.mdx`
+      → gjennomgå hvert treff; kun generiske regneeksempler (åpenbart
+      fiktive, runde tall i formel-kontekst) er tillatt, ingen by-spesifikke
+      markedspåstander
+- [ ] `pnpm test` exit 0
+- [ ] `git status`: ingen endringer utenfor in-scope-listen
+- [ ] Statusrad oppdatert i `plans/README.md`
+
+## STOP conditions
+
+- `faq:`-feltet finnes ikke i `HelpPost`-skjemaet (plan 009 ikke utført) —
+  utfør da steg 1 UTEN faq-blokken, noter det i statusraden, og rapporter.
+- En summary-fil har annen `summary:`-tekst enn den siterte (drift) —
+  rapporter i stedet for å gjette.
+- `pnpm build` feiler to ganger på MDX-kompilering etter rimelige fiksforsøk.
+- Du blir fristet til å oppgi et konkret markedstall for å gjøre teksten
+  bedre — ikke gjør det; det er en forretningsregel, ikke en stilpreferanse.
+
+## Maintenance notes
+
+- Pilarsiden lenker til begrepsklyngen; når plan 011 lander nye
+  begrepsartikler (eierkostnader, exit yield, …), bør «Sentrale begreper»-
+  listen utvides — nevnt i plan 011 som motlenke-steg.
+- Reviewer bør sjekke: norsk språkkvalitet, at FAQ-svarene står faglig på
+  egne ben (de vises som rich results uten kontekst), og at ingen
+  markedstall snek seg inn.
+- Bevisst utsatt: utvidelse av de andre korte artiklene (424–760 ord) — de
+  er begrepsartikler der 600–900 ord er riktig format; lengde for lengdens
+  skyld er ikke målet.

--- a/plans/011-artikkel-veikart-kunnskapssenter.md
+++ b/plans/011-artikkel-veikart-kunnskapssenter.md
@@ -1,0 +1,309 @@
+# Plan 011: Artikkel-veikart — 15 nye kunnskapsartikler i tre klynger
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report — do not improvise. Planen er delt i tre batcher som kan utføres i
+> separate økter — oppdater statusraden i `plans/README.md` med
+> `IN PROGRESS (batch A ferdig)` osv. mellom batcher.
+>
+> **Drift check (run first)**:
+> `git diff --stat 5e1c60a..HEAD -- src/content/help/ src/lib/blog/content.tsx content-collections.ts`
+> Endringer fra plan 009/010 er forventet drift. STOP kun hvis: (a) en av
+> slug-ene i artikkelspesifikasjonene under allerede finnes i
+> `src/content/help/`, eller (b) `HELP_CATEGORIES`-slugs er endret.
+
+## Status
+
+- **Priority**: P1 (kjernen i SEO-målet)
+- **Effort**: L (15 artikler; ~3 batcher)
+- **Risk**: LOW (kun nye innholdsfiler + `related`-frontmatter i eksisterende)
+- **Depends on**: plans/009-help-seo-tekniske-fikser.md (faq/publishedAt-felt,
+  kategori-gating). Anbefalt etter 010 (pilarsiden lenkene peker mot).
+- **Category**: direction/innhold (SEO)
+- **Planned at**: commit `5e1c60a`, 2026-06-12
+
+## Why this matters
+
+Kunnskapssenteret har 12 artikler. To av seks kategorier («For Investorer»,
+«Markedsanalyse») er tomme, begrepsklyngen har hull (to artikler refererer
+en `brutto-leieinntekter`-artikkel som ikke finnes), og det mangler innhold
+for kjøpsnære søk («hvordan kjøpe næringseiendom», «due diligence») der
+Advanti faktisk selger tjenester. Google rangerer tematisk dybde: et nettsted
+som dekker HELE begrepsapparatet rundt næringseiendom signaliserer autoritet
+for alle søkene i klyngen. Denne planen spesifiserer 15 artikler i prioritert
+rekkefølge med søkeord, disposisjon og intern lenking, slik at en utfører kan
+skrive dem én og én uten ytterligere research.
+
+## Current state
+
+- Eksisterende artikler (slugs): `diskontert-kontantstrom`,
+  `driftskostnader`, `felleskostnader`, `hva-er-advanti`,
+  `hva-er-naringseiendom`, `hva-er-yield`, `kontantstromsanalyse`,
+  `markedsleie-og-leieniva`, `netto-leieinntekter`, `sensitivitetsanalyse`,
+  `tjene-mer-pa-naringseiendom`, `verdivurdering-av-naringseiendom`.
+- Manglende referanse: `driftskostnader.mdx` og `netto-leieinntekter.mdx`
+  lister `brutto-leieinntekter` i `related:` — artikkelen finnes ikke og
+  filtreres stille bort (`article/[slug]/page.tsx:125–129`).
+- Kategorier (`src/lib/blog/content.tsx:48–102`): `overview`,
+  `getting-started`, `terms`, `for-investors` (0 artikler), `analysis`
+  (0 artikler), `valuation` (1 artikkel).
+- Frontmatter-mal (fra eksisterende artikler + felter fra plan 009):
+  ```yaml
+  ---
+  title: <tittel>
+  publishedAt: <dagens dato YYYY-MM-DD>
+  updatedAt: <dagens dato YYYY-MM-DD>
+  summary: <unik, ≤160 tegn, med søkeintensjon — IKKE «En omfattende guide til …»>
+  author: codehagen
+  categories:
+    - <kategori-slug>
+  related:
+    - <2–4 eksisterende slugs>
+  slug: <slug>
+  faq:
+    - question: "…"
+      answer: "…"   # 2–3 stk, svar 40–80 ord, står faglig på egne ben
+  ---
+  ```
+- Stil-eksemplar: `src/content/help/hva-er-yield.mdx` (H2-struktur, `<Math>`,
+  `<Note>`, interne lenker `[tekst](/help/article/<slug>)`). Prosedyre-
+  artikler kan bruke `<Stepper>`; hvis Stepper-en er en genuin steg-for-steg-
+  prosedyre kan `howto: true` + `step:`-array legges til (se konvensjonen i
+  `content-collections.ts:227–236` — step-teksten MÅ speile synlig innhold).
+- **Innholdsregel (forretningskrav)**: INGEN konkrete markedstall
+  (yield-nivåer per by, kr/kvm, ledighets-%) — kun kvalitative utsagn og
+  åpenbart generiske regneeksempler i formler. Bedriftens markedstall ligger
+  bak et internt verifikasjonsflagg og publiseres ikke via kunnskapsartikler.
+- **Juridisk forsiktighet**: skatte- og kontraktsartikler (A6, B4, B5) skal
+  ha en `<Note variant="warning">` om at innholdet er generell informasjon,
+  ikke skatte-/juridisk rådgivning, og at leser bør kontakte
+  revisor/advokat for sin konkrete situasjon.
+- Søkeordene under er valgt ut fra domenekunnskap, ikke verktøydata —
+  valider gjerne mot Google Search Console etter publisering (se
+  Maintenance notes).
+
+## Commands you will need
+
+| Purpose | Command | Expected |
+|---------|---------|----------|
+| Build (validerer frontmatter + MDX + genererer sider) | `pnpm build` | exit 0 |
+| Ordtelling | `wc -w src/content/help/<slug>.mdx` | innenfor spennet i spesifikasjonen |
+| Slug-kollisjon | `ls src/content/help/ \| grep <slug>` | 0 treff FØR fila opprettes |
+| Lint | — | N/A (`pnpm lint` ødelagt repo-vidt, kjent funn) |
+
+## Scope
+
+**In scope**:
+- Nye filer i `src/content/help/` (15 stk, slugs i spesifikasjonen)
+- `related:`-frontmatter i eksisterende `src/content/help/*.mdx` (motlenker, steg «Lenkevev» per batch)
+- «Sentrale begreper»-listen i `hva-er-naringseiendom.mdx` (kun nye punkter)
+- `POPULAR_ARTICLES` i `src/lib/blog/content.tsx` — IKKE endre; kuratert liste, eierens valg
+
+**Out of scope**:
+- All kode (ruter, komponenter, schema) — plan 009 eier det
+- `src/content/blog/` — plan 012 eier blog/help-grensen
+- Kategoridefinisjonene i `HELP_CATEGORIES`
+
+## Git workflow
+
+- Branch: `advisor/011-artikkel-veikart` (én branch, én commit per artikkel)
+- Commit-stil: `content(help): ny artikkel — brutto leieinntekter`
+- Ikke push / ikke opprett PR uten beskjed fra operatøren.
+
+## Artikkelspesifikasjoner
+
+Skriv i denne rekkefølgen. Felles for alle: norsk bokmål, intro-avsnittet
+besvarer søket direkte i de første 50 ordene (featured snippet-format),
+2–3 FAQ-poster, summary etter mønsteret i plan 010 steg 2.
+
+### Batch A — fullfør begrepsklyngen (`terms`), 600–900 ord per artikkel
+
+**A1. `brutto-leieinntekter`** — «Brutto leieinntekter»
+Søkeord: *brutto leieinntekter næringseiendom*. Tetter den manglende
+`related`-referansen. Disposisjon: definisjon; hva inngår (kontraktsleie,
+tillegg, parkering/skilt); brutto vs netto med `<Math>`-formel; hvorfor
+skillet betyr noe for yield; vanlige feil (glemme ledighet/leierabatter).
+`related: netto-leieinntekter, driftskostnader, hva-er-yield`.
+
+**A2. `eierkostnader`** — «Eierkostnader i næringseiendom»
+Søkeord: *eierkostnader næringseiendom*. Disposisjon: definisjon; grensen
+mot felleskostnader (hva leietaker dekker vs eier); typiske poster
+(forsikring, eiendomsskatt, utvendig vedlikehold, forvaltning, eierandel
+felleskost ved ledighet); rolle i netto yield; `<Note>` med tommelfingerregel
+uten konkrete tall-påstander per marked. `related: driftskostnader,
+felleskostnader, netto-leieinntekter`.
+
+**A3. `exit-yield`** — «Exit yield og terminalverdi»
+Søkeord: *exit yield*. Disposisjon: definisjon; rollen i DCF
+(terminalverdi-formel med `<Math>`); exit yield vs dagens yield (hvorfor
+den ofte settes høyere); hvor følsom verdien er for valget (pek til
+sensitivitetsanalyse). `related: diskontert-kontantstrom, hva-er-yield,
+sensitivitetsanalyse`. Kategori: `terms` OG `valuation` (begge i
+categories-arrayen — gir valuation-kategorien sårt tiltrengt innhold).
+
+**A4. `yield-gap`** — «Yield gap: eiendomsyield mot rente»
+Søkeord: *yield gap eiendom*. Disposisjon: definisjon (`<Math>`: yield minus
+risikofri rente/swap); hvorfor gapet er risikopremien; hvordan renteendringer
+presser eiendomsverdier (kvalitativt); hva investor bør se på.
+`related: hva-er-yield, exit-yield, diskontert-kontantstrom`.
+
+**A5. `kpi-regulering-av-leie`** — «KPI-regulering av leie»
+Søkeord: *kpi regulering husleie næring*. Disposisjon: hva KPI-justering er;
+hvordan klausulen typisk er formulert (100 % KPI årlig); regneeksempel med
+`<Math>` (generiske tall); hvorfor det betyr mye i kontantstrømsanalyse;
+forhandlingspunkter. `related: markedsleie-og-leieniva,
+kontantstromsanalyse, brutto-leieinntekter`.
+
+**A6. `leiekontrakter-naringseiendom`** — «Leiekontrakter i næringseiendom: typene du møter»
+Søkeord: *leiekontrakt næringslokale*. Disposisjon: standardstruktur
+(meglerstandarden); «bare house»-prinsippet; brutto- vs nettoleie;
+triple net; varighet og opsjoner; hva som er forhandlbart. Juridisk
+`<Note variant="warning">` (se Current state). 900–1200 ord — dette er mer
+guide enn begrep. `related: markedsleie-og-leieniva, kpi-regulering-av-leie,
+felleskostnader`.
+
+**A7. `arealbegreper-bta-bra`** — «Arealbegreper: BTA, BRA og utleibart areal»
+Søkeord: *BTA BRA forskjell*. Disposisjon: definisjonene (BTA, BRA,
+utleibart areal/LFA, fellesarealpåslag); hvorfor leie per kvm er meningsløst
+uten arealbegrep; regneeksempel; vanlige tvister. `related: markedsleie-og-leieniva, felleskostnader`.
+
+**Lenkevev batch A**: legg nye slugs inn i `related:` hos de eksisterende
+artiklene som allerede peker mot temaet (minimum: `driftskostnader` og
+`netto-leieinntekter` får `brutto-leieinntekter` til å faktisk virke —
+referansen står der allerede; `hva-er-yield` får `exit-yield` og
+`yield-gap`; `diskontert-kontantstrom` får `exit-yield`). Utvid «Sentrale
+begreper»-listen i `hva-er-naringseiendom.mdx` med A1–A4.
+
+**Verify batch A**: `pnpm build` → exit 0; `ls src/content/help/ | wc -l`
+→ 19; hver ny fil innenfor ordspennet.
+
+### Batch B — fyll «For Investorer» (`for-investors`), 1000–1500 ord per artikkel
+
+**B1. `kjope-naringseiendom`** — «Hvordan kjøpe næringseiendom: prosessen steg for steg»
+Søkeord: *kjøpe næringseiendom*. Disposisjon: `<Stepper>` med fasene
+(strategi/søk → analyse og verdivurdering → bud og intensjonsavtale → due
+diligence → SPA/oppgjør → overtakelse); typisk tidslinje; hvem som er
+involvert (megler, advokat, takstmann, bank); de vanligste feilene.
+Genuin prosedyre → bruk `howto: true` + `step:`-array som speiler Stepper-en.
+`related: verdivurdering-av-naringseiendom, due-diligence-naringseiendom,
+finansiering-av-naringseiendom`.
+
+**B2. `due-diligence-naringseiendom`** — «Due diligence ved kjøp av næringseiendom»
+Søkeord: *due diligence eiendom*. Disposisjon: hva DD er; de fire sporene
+(teknisk, juridisk, finansiell, miljø) — hver med sjekkpunkt-liste; røde
+flagg; hvordan funn brukes i prisforhandling. `related: kjope-naringseiendom,
+verdivurdering-av-naringseiendom, leiekontrakter-naringseiendom`.
+
+**B3. `finansiering-av-naringseiendom`** — «Finansiering av næringseiendom»
+Søkeord: *finansiering næringseiendom*. Disposisjon: bankfinansiering og
+LTV-begrepet (`<Math>`); rentebinding vs flytende (kvalitativt — INGEN
+rentenivå-tall); bankens krav (kontantstrøm, leietakerkvalitet, WAULT —
+forklar begrepet); alternative kilder (obligasjon, selgerkreditt); hvordan
+gearing påvirker avkastning og risiko. `related: kjope-naringseiendom,
+hva-er-yield, kontantstromsanalyse`.
+
+**B4. `aksjekjop-vs-innmatskjop`** — «Aksjekjøp eller innmatskjøp?»
+Søkeord: *aksjekjøp innmatskjøp eiendom*. Disposisjon: de to strukturene;
+hvorfor de fleste norske transaksjoner er selskapskjøp (dokumentavgift
+2,5 % ved innmat — dette er en offentlig sats, OK å oppgi); skattemessige
+hovedforskjeller (avskrivningsgrunnlag, latent skatt — kvalitativt);
+hva som avtales i praksis (latent skatt-rabatt som forhandlingspunkt,
+uten talleksempler); juridisk `<Note variant="warning">`.
+`related: kjope-naringseiendom, due-diligence-naringseiendom,
+skatt-avskrivninger-naringseiendom`.
+
+**B5. `skatt-avskrivninger-naringseiendom`** — «Skatt og avskrivninger på næringseiendom»
+Søkeord: *avskrivning næringseiendom*. Disposisjon: saldogrupper for bygg
+og tekniske installasjoner (offentlige satser fra skatteetaten er OK å
+oppgi — verifiser gjeldende satser mot skatteetaten.no før skriving, og
+datér påstanden i teksten, f.eks. «per 2026»); skillet tomt/bygg/teknisk;
+hvordan avskrivninger påvirker kontantstrøm etter skatt; formuesskatt
+kvalitativt; juridisk `<Note variant="warning">`.
+`related: aksjekjop-vs-innmatskjop, kontantstromsanalyse, eierkostnader`.
+
+**Lenkevev batch B**: `hva-er-naringseiendom.mdx`-seksjonen «Hvordan
+investere i næringseiendom» (fra plan 010) lenker til B1, B3 og B4.
+`tjene-mer-pa-naringseiendom` får B3 i `related:`.
+
+**Verify batch B**: `pnpm build` → exit 0. Kategorisiden er nå indeksert
+automatisk (gatingen fra plan 009 slipper den inn i sitemap):
+`pnpm start &` + `curl -s http://localhost:3000/sitemap.xml | grep -c "help/category/for-investors"` → `1`. Drep serveren.
+
+### Batch C — fyll «Markedsanalyse» (`analysis`), 700–1000 ord per artikkel
+
+**VIKTIGST HER**: disse artiklene forklarer METODE, ikke markedsstatus.
+Ingen tall for noen by — det er nettopp denne kategorien fristelsen er størst.
+
+**C1. `hvordan-lese-markedsrapport`** — «Hvordan lese en markedsrapport for næringseiendom»
+Søkeord: *markedsrapport næringseiendom*. Disposisjon: nøkkeltallene en
+rapport inneholder (prime yield, markedsleie, ledighet, transaksjonsvolum)
+og hva hvert av dem FORTELLER; fallgruver (små utvalg i små markeder,
+asking vs achieved rents); hvordan bruke rapporten i egen analyse. Lenk til
+`/markedsinnsikt` som intern CTA i teksten. `related: hva-er-yield,
+markedsleie-og-leieniva, prime-yield`.
+
+**C2. `kontorledighet`** — «Kontorledighet: hva tallet betyr»
+Søkeord: *kontorledighet*. Disposisjon: definisjon og måling (`<Math>`:
+ledig areal / total masse); strukturell vs konjunkturell ledighet; hvordan
+ledighet påvirker markedsleie og yield (kvalitativt); hvorfor små markeder
+svinger mer i prosent. `related: markedsleie-og-leieniva,
+hvordan-lese-markedsrapport`.
+
+**C3. `prime-yield`** — «Prime yield vs sekundær yield»
+Søkeord: *prime yield*. Disposisjon: hva «prime» betyr (beste beliggenhet,
+beste standard, lang kontrakt, solid leietaker); hvorfor prime yield er
+markedets referansepunkt; yield-spread mot sekundæreiendom og hva spreaden
+forteller om risikoappetitt; hvordan begrepene brukes i verdivurdering.
+`related: hva-er-yield, exit-yield, hvordan-lese-markedsrapport`.
+
+**Lenkevev batch C**: `hva-er-yield` får `prime-yield` i `related:`.
+
+**Verify batch C**: `pnpm build` → exit 0;
+`ls src/content/help/*.mdx | wc -l` → 27; sitemap-sjekken fra batch B
+gjentatt for `help/category/analysis` → `1`.
+
+## Test plan
+
+Ingen ny kode. `pnpm build` per batch er valideringen (frontmatter-skjema,
+MDX-kompilering, statisk generering av alle nye `/help/article/<slug>`-sider).
+Kjør `pnpm test` etter siste batch → alle grønne.
+
+## Done criteria
+
+- [ ] 15 nye filer finnes i `src/content/help/` med slugs nøyaktig som spesifisert
+- [ ] `pnpm build` exit 0 etter hver batch
+- [ ] Ingen ordtelling utenfor spennene i spesifikasjonene
+- [ ] Hver ny artikkel har: unik summary (≤160 tegn, ikke guide-formelen),
+      `faq:` med 2–3 poster, `related:` med kun eksisterende slugs
+- [ ] Lenkevev-stegene utført (grep-sjekk: `grep -l "brutto-leieinntekter" src/content/help/driftskostnader.mdx src/content/help/netto-leieinntekter.mdx` → begge; artikkelen finnes nå så referansen rendres)
+- [ ] Markedstall-gaten fra plan 010 (samme grep) kjørt mot ALLE nye filer — kun offentlige satser (dokumentavgift, saldosatser) og generiske regneeksempler
+- [ ] `pnpm test` exit 0
+- [ ] Statusrad oppdatert i `plans/README.md`
+
+## STOP conditions
+
+- En spesifisert slug finnes allerede i `src/content/help/` (innhold laget
+  utenom planen) — rapporter hvilken, ikke overskriv.
+- `faq:` eller `publishedAt:` avvises av skjemaet (plan 009 ikke landet) —
+  STOP, denne planen avhenger av 009.
+- Du mangler faglig sikkerhet på en konkret påstand (særlig B4/B5 skatt):
+  utelat påstanden eller formuler den betinget — hvis artikkelen ikke kan
+  stå uten, STOP og rapporter hvilken artikkel og hvilken påstand.
+- Fristelse til å sitere markedstall for Bodø/Tromsø e.l. — forbudt, se
+  innholdsregelen.
+
+## Maintenance notes
+
+- **Etter publisering**: koble Google Search Console-data på artiklene
+  etter 4–8 uker; søkeordsvalgene her er domenebaserte estimater og bør
+  valideres mot faktiske impressions. Artikler som får impressions men lav
+  CTR → juster title/summary. Artikler uten impressions → vurder
+  retittlering.
+- `POPULAR_ARTICLES` i `src/lib/blog/content.tsx` er kuratert — eieren bør
+  vurdere å bytte inn 1–2 av de nye (f.eks. `kjope-naringseiendom`) når
+  trafikkdata foreligger.
+- Når bedriftens markedstall blir verifisert (internt flagg), kan C-klyngen
+  utvides med datadrevne artikler — det er bevisst utenfor denne planen.
+- Reviewer per artikkel: norsk språkkvalitet, faglig presisjon i formler,
+  at FAQ-svar står på egne ben, ingen markedstall.

--- a/plans/012-blog-help-avkannibalisering.md
+++ b/plans/012-blog-help-avkannibalisering.md
@@ -1,0 +1,204 @@
+# Plan 012: Avkannibaliser blog↔help-duplikatene (sensitivitetsanalyse, DCF)
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report — do not improvise. When done, update the status row for this plan
+> in `plans/README.md`.
+>
+> **Drift check (run first)**:
+> `git diff --stat 5e1c60a..HEAD -- src/content/blog/sensitivitetsanalyse-naringseiendom.mdx src/content/blog/dcf-analyse-naringseiendom.mdx src/content/help/sensitivitetsanalyse.mdx src/content/help/diskontert-kontantstrom.mdx`
+> Plan 010 endrer `summary:` i de to help-filene — det er forventet drift.
+> Annen drift: sammenlign «Current state»-utdragene før du fortsetter; ved
+> avvik, STOP.
+
+## Status
+
+- **Priority**: P2
+- **Effort**: S–M
+- **Risk**: LOW–MED (retittlering av en publisert blogpost kan midlertidig
+  påvirke eksisterende rangering — se Why/Maintenance)
+- **Depends on**: none (men kjør etter 010 så summaries ikke redigeres to ganger)
+- **Category**: SEO-arkitektur
+- **Planned at**: commit `5e1c60a`, 2026-06-12
+
+## Why this matters
+
+To temaer har én artikkel i kunnskapssenteret OG én i bloggen som sikter på
+samme søkeord:
+
+1. **Sensitivitetsanalyse**: `help/sensitivitetsanalyse` («Sensitivitetsanalyse
+   i næringseiendom») og `blog/sensitivitetsanalyse-naringseiendom»
+   («Sensitivitetsanalyse: Hvorfor Det Er Kritisk for Eiendomsinvesteringer»).
+   Begge er definisjons-/forklaringsinnhold for *sensitivitetsanalyse
+   (nærings)eiendom* — direkte kannibalisering.
+2. **DCF**: `help/diskontert-kontantstrom» («Diskontert kontantstrøm (DCF) i
+   næringseiendom») og `blog/dcf-analyse-naringseiendom» («DCF-Analyse for
+   Næringseiendom: Slik Beregner Du Nåverdi»). Delvis differensiert
+   (begrep vs how-to), men titlene/summariene overlapper nok til at Google
+   kan rotere mellom dem.
+
+Når to egne URL-er konkurrerer om samme søk, deler de lenkekraft og Google
+velger vilkårlig — ofte rangerer ingen av dem godt. Løsningen er IKKE
+sletting/redirect (begge sider har verdi og mulige innlenker), men
+**rolleavklaring**: help = kanonisk begrepssvar («hva er X»), blog =
+praktisk/aktuelt («slik bruker du X», investorvinkel) — med tydelig
+kryss-lenking så Google forstår hierarkiet.
+
+## Current state
+
+- `src/content/blog/sensitivitetsanalyse-naringseiendom.mdx` frontmatter:
+  ```yaml
+  title: "Sensitivitetsanalyse: Hvorfor Det Er Kritisk for Eiendomsinvesteringer"
+  publishedAt: 2025-11-05
+  summary: Lær hvordan sensitivitetsanalyse hjelper deg forstå risiko og usikkerhet i eiendomsinvesteringer. Praktisk guide med eksempler og tips.
+  related:
+    - sensitivitetsanalyse
+    - dcf-analyse-naringseiendom
+  slug: sensitivitetsanalyse-naringseiendom
+  ```
+- `src/content/blog/dcf-analyse-naringseiendom.mdx` frontmatter:
+  ```yaml
+  title: "DCF-Analyse for Næringseiendom: Slik Beregner Du Nåverdi"
+  publishedAt: 2026-04-15
+  summary: Lær hvordan du utfører DCF-analyse (diskontert kontantstrøm) for næringseiendom. Steg-for-steg guide med eksempler og vanlige feil å unngå.
+  ```
+  Denne har allerede `<ReadMore articles={["diskontert-kontantstrom", "kontantstromsanalyse"]} />`
+  på linje ~386.
+- `src/content/help/sensitivitetsanalyse.mdx` — begrepsartikkel, 707 ord,
+  `<Prerequisites>`-blokk øverst.
+- `src/content/help/diskontert-kontantstrom.mdx` — begrepsartikkel, 1023 ord,
+  HowTo-schema-pilot.
+- Blog-`related:`-slugs kan peke på help-artikler (se sensitivitetsanalyse-
+  bloggens `related: sensitivitetsanalyse`) — sjekk hvordan blog-siden
+  resolver related før du antar at lenken faktisk rendres
+  (`src/app/(blog)/`-rutene; hvis blog-related kun slår opp i
+  `allBlogPosts`, filtreres help-slugs stille bort — i så fall er
+  kryss-lenkingen i brødtekst eneste reelle lenke, noter funnet i
+  statusraden).
+- Konvensjon: interne lenker i MDX-brødtekst skrives
+  `[ankertekst](/help/article/<slug>)`.
+
+## Commands you will need
+
+| Purpose | Command | Expected |
+|---------|---------|----------|
+| Build | `pnpm build` | exit 0 |
+| Kryss-lenke-grep | `grep -c "/help/article/sensitivitetsanalyse" src/content/blog/sensitivitetsanalyse-naringseiendom.mdx` | ≥ 1 etter steg 2 |
+| Lint | — | N/A (`pnpm lint` ødelagt repo-vidt, kjent funn) |
+
+## Scope
+
+**In scope** (de eneste filene du endrer):
+- `src/content/blog/sensitivitetsanalyse-naringseiendom.mdx`
+- `src/content/blog/dcf-analyse-naringseiendom.mdx`
+- `src/content/help/sensitivitetsanalyse.mdx` (kun ett kryss-lenke-avsnitt)
+- `src/content/help/diskontert-kontantstrom.mdx` (kun ett kryss-lenke-avsnitt)
+
+**Out of scope**:
+- Redirects/sletting av noen av de fire sidene — bevisst valgt bort.
+- Andre blogposter (f.eks. `kjope-vs-leie-naringseiendom`) — ingen påvist
+  kannibalisering i dag.
+- Blog-rutenes kode (hvordan `related` resolves) — observer og rapporter,
+  ikke fiks.
+
+## Git workflow
+
+- Branch: `advisor/012-avkannibalisering`
+- Commit-stil: `content(seo): rolleavklaring blog/help — sensitivitetsanalyse + DCF`
+- Ikke push / ikke opprett PR uten beskjed fra operatøren.
+
+## Steps
+
+### Steg 1: Differensier sensitivitetsanalyse-blogposten
+
+I `src/content/blog/sensitivitetsanalyse-naringseiendom.mdx`:
+
+1. Retittler mot investor-/beslutningsintensjon i stedet for
+   begrepsintensjon:
+   - `title:` → `"Slik stressetester du en eiendomsinvestering med sensitivitetsanalyse"`
+   - `summary:` → `"Hva skjer med verdien hvis yield stiger eller leien faller? Slik bruker du sensitivitetsanalyse til å stressteste en eiendomsinvestering før du kjøper."`
+2. Les gjennom innledningen (de første 2–3 avsnittene): hvis den åpner med
+   en «hva er sensitivitetsanalyse»-definisjon, kort den ned til én setning
+   som lenker definisjonen bort: `[sensitivitetsanalyse](/help/article/sensitivitetsanalyse)`
+   — og la blogposten gå rett på den praktiske vinkelen.
+3. Sørg for at brødteksten har minst én lenke til
+   `/help/article/sensitivitetsanalyse` med beskrivende ankertekst.
+
+**NB**: slug-en `sensitivitetsanalyse-naringseiendom` skal IKKE endres
+(URL-en er publisert og kan ha innlenker).
+
+**Verify**: `pnpm build` → exit 0; kryss-lenke-grep → ≥ 1.
+
+### Steg 2: Differensier DCF-blogposten (lettere touch)
+
+I `src/content/blog/dcf-analyse-naringseiendom.mdx`:
+
+1. Tittel/summary er allerede how-to-vinklet — behold tittelen. Juster KUN
+   hvis innledningen åpner med ren definisjon: som i steg 1, én setning +
+   lenke til `[diskontert kontantstrøm](/help/article/diskontert-kontantstrom)`,
+   så videre til det praktiske.
+2. Sørg for minst én brødtekst-lenke til
+   `/help/article/diskontert-kontantstrom` (ReadMore-komponenten nederst
+   finnes, men en kontekstuell lenke tidlig i teksten er sterkere signal).
+
+**Verify**: `grep -c "/help/article/diskontert-kontantstrom" src/content/blog/dcf-analyse-naringseiendom.mdx` → ≥ 1; `pnpm build` → exit 0.
+
+### Steg 3: Motlenker fra help-artiklene
+
+1. I `src/content/help/sensitivitetsanalyse.mdx`: legg til ett kort avsnitt
+   (2–3 setninger) sent i artikkelen, f.eks. under en passende eksisterende
+   H2, som peker til den praktiske blogposten:
+   `Vil du se metoden brukt på en konkret investeringscase? Les [slik stressetester du en eiendomsinvestering](/blog/sensitivitetsanalyse-naringseiendom).`
+2. Tilsvarende i `src/content/help/diskontert-kontantstrom.mdx` →
+   `[steg-for-steg-guiden til DCF-beregning](/blog/dcf-analyse-naringseiendom)`.
+3. Verifiser blog-URL-formatet før du lenker: sjekk én eksisterende
+   blog-lenke i kodebasen (`grep -rn '"/blog/' src/content/ | head -3`) —
+   bruk samme path-form.
+
+**Verify**: `pnpm build` → exit 0;
+`grep -c "/blog/sensitivitetsanalyse-naringseiendom" src/content/help/sensitivitetsanalyse.mdx` → ≥ 1;
+`grep -c "/blog/dcf-analyse-naringseiendom" src/content/help/diskontert-kontantstrom.mdx` → ≥ 1.
+
+### Steg 4: Dokumentér rollegrensen
+
+Ikke rediger `AUTHORING.md` (out of scope). Skriv i stedet rollegrensen som
+en kort note i din statusrad i `plans/README.md`: «Regel etablert: help =
+kanonisk begrep («hva er X»), blog = praktisk/aktuelt — nye temaer skal
+ikke dekkes begge steder uten denne differensieringen.» Eieren kan løfte
+regelen inn i AUTHORING.md senere.
+
+## Test plan
+
+Ingen ny kode. `pnpm build` validerer MDX. `pnpm test` til slutt → grønne.
+
+## Done criteria
+
+- [ ] `pnpm build` exit 0
+- [ ] Ny tittel/summary i sensitivitetsanalyse-blogposten, slug uendret
+      (`grep "slug: sensitivitetsanalyse-naringseiendom" src/content/blog/sensitivitetsanalyse-naringseiendom.mdx` → 1 treff)
+- [ ] Alle fire kryss-lenke-greps (steg 1–3) ≥ 1
+- [ ] `pnpm test` exit 0
+- [ ] `git status`: ingen endringer utenfor in-scope-listen
+- [ ] Statusrad oppdatert i `plans/README.md` med rollegrense-notatet
+
+## STOP conditions
+
+- Frontmatter i blog-filene matcher ikke utdragene i «Current state» (drift).
+- Blogpostens brødtekst viser seg å være noe annet enn antatt (f.eks. en
+  ren duplikat av help-artikkelen) — da er riktig grep kanskje
+  konsolidering/redirect i stedet; rapporter i stedet for å improvisere.
+- Blog-URL-strukturen er ikke `/blog/<slug>` (steg 3.3-sjekken feiler) —
+  rapporter funnet path-format.
+
+## Maintenance notes
+
+- Retittlering av en publisert post kan gi noen ukers rangeringsstøy for
+  den posten — forventet og akseptert; den gamle tittelen konkurrerte
+  uansett med help-artikkelen.
+- Følg med i Search Console: målet er at `/help/article/sensitivitetsanalyse`
+  overtar «hva er»-søkene og blogposten fanger «hvordan/stressteste»-søk.
+  Hvis begge fortsatt roterer på samme søk etter ~8 uker, eskaler til
+  konsolidering (redirect blog → help) som egen beslutning.
+- Plan 011 skriver nye artikler — rollegrensen herfra gjelder dem: ingen ny
+  blogpost skal gjenbruke en help-artikkels «hva er X»-vinkel.

--- a/plans/013-kunnskapssenter-v2-design.md
+++ b/plans/013-kunnskapssenter-v2-design.md
@@ -1,0 +1,465 @@
+# Plan 013: Port «Kunnskapssenter v2»-designet til det MDX-drevne /help-rutegruppen
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving on. If a
+> STOP condition occurs, stop and report — do not improvise. Update the status
+> row for this plan in `plans/README.md` when done.
+>
+> **Drift check (run first)**:
+> `ls src/content/help/*.mdx | wc -l` → forventet **27**. Hvis tallet er lavere,
+> er innholdet endret siden planlegging — bekreft at slug-listen i «Current
+> state» fortsatt stemmer før du lenker reading-paths/FAQ til konkrete slugs.
+
+## Status
+
+- **Priority**: P1 (eksplisitt designoppdrag fra eier)
+- **Effort**: L (hub + artikkel-id-side; ny CSS + 4 klient-overflater + 1 skjemafelt)
+- **Risk**: MED-HØY. Dette er IKKE «3 små komponenter»: det er 4 interaktive
+  klient-overflater (`HelpSearch` combobox med tastaturnav + localStorage,
+  `HelpLibrary` filter/sort/minisøk, `ArticleToc` scroll-spy, `ArticleFeedback`)
+  + responsiv oppførsel. `pnpm build` fanger IKKE ødelagt ARIA, scroll-spy,
+  localStorage-kanttilfeller, CSS-kollisjon eller mobil-layout — de krever
+  browser-QA (Steg 8). Avgrenset til /help-rutegruppen + advanti-design.css +
+  ett valgfritt skjemafelt; ingen taksonomi-migrasjon, ingen endring av
+  eksisterende MDX-brødtekst.
+- **Depends on**: 009–012 (DONE — help har 27 artikler i 6 kategorier)
+- **Category**: design/frontend
+- **Planned at**: commit `45f9e69`, 2026-06-14
+- **Design kilde**: Anthropic design-share `qFJO-yN66tCNTzIfCywT_g`, filene
+  `advanti/kunnskapssenter-v2.html` (hub), `kunnskapssenter-artikkel-v2.html`
+  (artikkel), `hjelpesenter-app.jsx`, `artikkel-app.jsx`,
+  `kunnskapssenter-data.js`, `KUNNSKAPSSENTER-BEST-PRACTICE.md`.
+
+## Why this matters
+
+Eier har bedt om at v2-designet av kunnskapssenteret implementeres — både
+hub-/forsiden (`kunnskapssenter-v2.html`) og artikkel-«id»-siden under den. Den
+eksisterende `/help`-ruten er allerede bygget i samme designspråk (samme
+`ks-*`-klasser, `SubHero`, `CtaStrip`, kursiv-spans), så v2 er en **evolusjon**,
+ikke en omskriving: den legger til (1) «Start her»-leseløp, (2) et filtrerbart
+bibliotek-indeks med kategori-chips, sortering og minisøk, (3) en
+«Hurtigsvar»-FAQ-akkordeon med `FAQPage`-JSON-LD, (4) et rikere søkefelt
+(instant-dropdown + forslags-piller + hero-statistikkstripe), og på
+artikkelsiden (5) venstre-skinne med innholdsfortegnelse (scroll-spy) +
+kategorinavigasjon, (6) «Kort fortalt»-punkter, (7) interaktiv
+tilbakemeldings-widget og (8) forrige/neste-navigasjon.
+
+## Architecture decision (les før du koder)
+
+**Behold innholdsmodellen og taksonomien som finnes.** Designprototypens
+`kunnskapssenter-data.js` har en egen 6-kategori-taksonomi (Grunnleggende,
+Verdivurdering, Yield, Driftsøkonomi, Markedet, Strategi) og egne artikkel-id-er.
+Best-practice-dokumentet i designet sier eksplisitt at produksjonsmålet er
+SSG + ekte URL-er + MDX/CMS — **som dette repoet allerede har** (`/help` via
+content-collections, 27 artikler, per-artikkel statiske URL-er, sitemap,
+JSON-LD). Vi porterer derfor designets **visuelle/UX-mønstre** oppå eksisterende
+MDX-innhold og eksisterende `HELP_CATEGORIES`. Vi **endrer ikke**:
+- `HELP_CATEGORIES`-slugs (`overview`/`getting-started`/`terms`/`for-investors`/`analysis`/`valuation`).
+- Eksisterende MDX-brødtekst eller frontmatter (utover å legge til ett nytt,
+  valgfritt `takeaways`-felt, se Steg 5).
+- Innholdsregelen fra plan 010/011: ingen konkrete markedstall (yield-nivåer,
+  kr/kvm, ledighet) i ny copy.
+
+**Klient/server-grense (load-bearing — eng-review-funn).** `src/lib/blog/content.tsx`
+importerer `content-collections` OG `@remixicon/react` (JSX-ikoner) på toppnivå.
+Klientkomponenter må derfor **ikke** importere fra `content.tsx` — det drar med
+seg hele content-collections + ikon-bundle inn i klient-JS. Regel:
+- Serverkomponentene (`page.tsx`) bygger **plain, serialiserbare DTO-er** og
+  sender dem som props til klientkomponentene. Ingen `JSX.Element`-felt
+  (f.eks. `HELP_CATEGORIES.icon`) krysser server→klient-grensen — send `{slug, title}`.
+- Nye plain-data-konstanter (`HELP_FAQS`, `HELP_PATHS`, kategorimerkelapper,
+  rekkefølge-helper) legges i et **nytt modul `src/lib/blog/help-data.ts`** uten
+  `content-collections`- eller ikon-import, slik at de trygt kan importeres fra
+  både server og klient. `getOrderedHelpPosts()` tar `allHelpPosts` som argument
+  (kalles fra server) i stedet for å importere collections selv.
+
+## Current state
+
+- **Hub** `src/app/(help)/help/page.tsx`: `SubHero` + `<HelpSearch>`, deretter
+  «Populære artikler» (`ks-popular`), kategori-kort (`ks-cats`/`ks-cat` →
+  `/help/category/[slug]`), `CtaStrip`. Server component.
+- **Artikkel** `src/app/(help)/help/article/[slug]/page.tsx`: server component;
+  `Breadcrumbs`, `ks-article`-grid med `ks-art-body` (meta/tittel/lede/forfatter/
+  MDX/`faq`/feedback/related) og HØYRE `ks-toc`-aside (uten scroll-spy). Statisk
+  feedback-widget (knapper uten handler). `relatedArticles` fra `data.related`.
+- **Søk** `src/components/help/HelpSearch.tsx`: klientkomponent, filtrerer
+  tittel/summary, ⌘K-fokus, Enter→toppresultat, dropdown. Ingen forslag, ingen
+  recent, ingen kategori/lesetid i treff.
+- **Data** `src/lib/blog/content.tsx`: `HELP_CATEGORIES` (6), `POPULAR_ARTICLES`
+  (5 slugs, kuratert — IKKE endre listen), `getPopularArticles()`.
+- **Skjema** `content-collections.ts` `HelpPost`: felt `title, updatedAt,
+  summary, author, categories[enum 6], publishedAt?, related?, howto?, step?,
+  faq?, slug?` + computed `mdx, tableOfContents ({slug,title} fra H2), images`.
+  **Ingen `takeaways`-felt.** **Ingen artikkelrekkefølge** (trengs for
+  forrige/neste).
+- **MDX-blokktyper** finnes allerede som komponenter (`src/components/blog/mdx.tsx`:
+  `Math`, `Note`, `Stepper`, `Compare`, `Fact`, `StatStrip`, …) — designets
+  `formula`/`note`/`stepper`-blokker trenger ingen ny renderer; de er allerede
+  dekket av `ks-prose` + MDX.
+- **CSS** `src/styles/advanti-design.css` (importert i `globals.css`): har
+  `ks-article, ks-art-body, ks-art-meta, ks-art-title, ks-art-lede,
+  ks-art-author, ks-prose, ks-faq, ks-feedback, ks-related, ks-related-list,
+  ks-toc, ks-popular*, ks-cats, ks-cat, ks-search*, ribbon-head, head-compact,
+  subhero`. Designtokens (`--warm-grey`, `--warm-grey-85`, `--warm-grey-75`,
+  `--warm-white`, `--accent`, `--accent-soft`, `--accent-faint`, `--accent-ink`,
+  `--font-display`, `--font-body`, `--hairline`) finnes. **Mangler**: alle
+  `hs-*`-hub-klasser og `art-*`-artikkel-klasser fra v2 (definert i designets
+  to HTML-`<style>`-blokker — kopier verdiene derfra, de bruker samme tokens).
+- 27 artikkel-slugs (kategori i parentes): `hva-er-naringseiendom`(overview),
+  `hva-er-advanti`(overview), `verdivurdering-av-naringseiendom`(getting-started),
+  `markedsleie-og-leieniva`(getting-started), `felleskostnader`(getting-started),
+  `tjene-mer-pa-naringseiendom`(getting-started), `hva-er-yield`(terms),
+  `netto-leieinntekter`(terms), `brutto-leieinntekter`(terms),
+  `eierkostnader`(terms), `driftskostnader`(terms), `exit-yield`(terms),
+  `yield-gap`(terms), `kpi-regulering-av-leie`(terms),
+  `leiekontrakter-naringseiendom`(terms), `arealbegreper-bta-bra`(terms),
+  `kontantstromsanalyse`(terms), `sensitivitetsanalyse`(terms),
+  `diskontert-kontantstrom`(valuation), `prime-yield`(analysis),
+  `kontorledighet`(analysis), `hvordan-lese-markedsrapport`(analysis),
+  `kjope-naringseiendom`(for-investors),
+  `due-diligence-naringseiendom`(for-investors),
+  `finansiering-av-naringseiendom`(for-investors),
+  `aksjekjop-vs-innmatskjop`(for-investors),
+  `skatt-avskrivninger-naringseiendom`(for-investors).
+
+## Commands you will need
+
+| Purpose | Command | Expected |
+|---------|---------|----------|
+| Bygg (validerer skjema + MDX + typer; `ignoreBuildErrors:false`) | `pnpm build` | exit 0 |
+| Typecheck (etter at content-collections er generert av build) | `pnpm typecheck` | exit 0 |
+| Lint | — | N/A (`pnpm lint` ødelagt repo-vidt, kjent funn — se README) |
+| QA | `/qa` på `/help` + én artikkel | ingen P0/P1 |
+
+## Scope
+
+**In scope** (filene du endrer/oppretter):
+- `src/app/(help)/help/page.tsx` (hub: nye seksjoner)
+- `src/app/(help)/help/article/[slug]/page.tsx` (artikkel: venstre-skinne, prev/next, kort fortalt)
+- `src/components/help/HelpSearch.tsx` (oppgradert combobox)
+- **Nye** komponenter i `src/components/help/`:
+  `HelpLibrary.tsx` (KLIENT — indeks + chips + sort + minisøk),
+  `ArticleToc.tsx` (KLIENT — scroll-spy venstre-skinne + kategorinav),
+  `ArticleFeedback.tsx` (KLIENT — Ja/Nei → takk).
+  `HelpFaq` rendres som **serverkomponent** (`<details>`/`hs-qa`, ingen klient-JS)
+  + JSON-LD — droppet fra klient-listen for å holde JS nede.
+- **Nytt** `src/lib/blog/help-data.ts` (plain, ingen content-collections/ikon-import):
+  `HELP_FAQS`, `HELP_PATHS`, kategorimerkelapper, `getOrderedHelpPosts(posts)`.
+  `POPULAR_ARTICLES` blir IKKE endret (kuratert, eierens valg).
+- `content-collections.ts` (legg til valgfritt `takeaways: z.array(z.string()).optional()` i `HelpPost`).
+- `src/styles/advanti-design.css` (nye `hs-*`- og `art-*`-klasser fra designet).
+- Valgfritt: `takeaways:`-frontmatter i et lite utvalg flaggskip-MDX (Steg 5).
+
+**Out of scope** (IKKE rør):
+- `HELP_CATEGORIES`-slugs/struktur, taksonomi-migrasjon, designets `kunnskapssenter-data.js`.
+- Eksisterende MDX-brødtekst og eksisterende frontmatter-felter.
+- `/help/category/[slug]` og `/help/layout.tsx` (kategori-sidene består; chips kan dyplenke til dem).
+- `tweaks-panel`/dark mode/density-toggle fra prototypen (prototyp-only; light-only per DESIGN.md).
+- `src/content/blog/`, navigasjon (`lib/navigation.ts`).
+
+## Git workflow
+
+- Branch: `feat/kunnskapssenter-v2-design` (allerede opprettet fra main `45f9e69`).
+- Commit-stil: `feat(help): <del>` per logisk del (CSS, hub-seksjoner, artikkel-skinne, søk).
+- Ikke push / ikke opprett PR uten beskjed fra eier.
+
+## Steps
+
+### Steg 0 — CSS-fundament
+Designprototypens HTML-filer ligger IKKE i repoet — de er hentet fra
+design-share-arkivet (utpakket lokalt). `hs-*`-klassene står i
+`kunnskapssenter-v2.html`s `<style>`-blokk og `art-*`-klassene i
+`kunnskapssenter-artikkel-v2.html`s `<style>`-blokk. Lim inn de faktiske
+CSS-verdiene i `advanti-design.css` under en tydelig
+`/* === Kunnskapssenter v2 === */`-seksjon (ikke bare referér dem). De bruker
+allerede repoets tokens. Behold responsiv- og `prefers-reduced-motion`-reglene.
+Sjekk for navnekollisjon mot eksisterende `ks-*`/`art-*`-klasser før innliming.
+Ikke introduser nye farger/spacing-verdier (DESIGN.md). **Verify**: `pnpm build` exit 0.
+
+### Steg 1 — Hero-søk → combobox (`HelpSearch.tsx`)
+Oppgrader til designets `hs-search`/`hs-searchwrap`/`hs-results`-mønster:
+forslags-piller (`hs-suggest`: Yield, Verdivurdering, DCF, Leiekontrakt, WAULT,
+Bodø → setter query), instant-dropdown med tittel + `{kategori} · {lesetid} min`,
+recent searches (`localStorage` `ks.recent`, maks 5; wrap i try/catch for
+private-mode/quota), populære når tomt, tom-tilstand med «Kontakt en rådgiver
+→»-CTA. **NB**: dagens `HelpSearch` har KUN ⌘K/Enter/Esc — ↑/↓-piltastnavigasjon
+(`aria-activedescendant`) er NY funksjonalitet, ikke «behold». Full ARIA combobox
+(`role=combobox/listbox/option`, `aria-expanded`, `aria-controls`). Input trenger
+lesetid+kategori i `index`-propen — utvid `searchIndex`-map i `page.tsx` (server
+bygger DTO). Legg til hero-statistikkstripe (`hs-herostats`): `{antall} artikler`,
+`6 temaer`, `Gratis`, `Sist oppdatert {nyeste updatedAt}`. Søke-events (om sporet)
+via `trackEvent`-helper (`src/lib/analytics.ts` → `window.dataLayer`), ikke ad-hoc.
+
+### Steg 2 — «Start her»-leseløp (hub)
+Legg til seksjon (`hs-paths`, 3 kort) etter hero. Definer `HELP_PATHS` i
+`content.tsx` med ekte slugs:
+- **01 «Du eier næringseiendom»**: `verdivurdering-av-naringseiendom`, `hva-er-yield`, `sensitivitetsanalyse`.
+- **02 «Du vurderer å investere»**: `hva-er-naringseiendom`, `diskontert-kontantstrom`, `finansiering-av-naringseiendom`.
+- **03 «Du leier ut eller forvalter»**: `leiekontrakter-naringseiendom`, `kpi-regulering-av-leie`, `felleskostnader`.
+Hvert steg lenker til `/help/article/{slug}` med tittel fra `allHelpPosts`.
+STOP hvis en slug ikke finnes (drift) — velg nærmeste eksisterende fra samme kategori og noter det.
+
+### Steg 3 — Bibliotek-indeks (hub, `HelpLibrary.tsx` klient)
+Erstatt `ks-cats`-kortene med designets indeks: toolbar (`hs-toolbar`) med minisøk
+(`hs-minisearch`), kategori-chips (`hs-chips`: «Alle» + 6 kategorier med antall),
+sortering (`hs-sort`), og rader (`hs-row`: `rtag` = `{kategori}` + dot, `rtitle`,
+`rsum`, `rauthor` = forfatter+dato, `rread` = lesetid, pil). Tom-tilstand
+(`hs-empty`) med nullstill + kontakt-CTA.
+- **Determinisitisk sortering** (eng-review-funn — ikke len deg på
+  `allHelpPosts`-rekkefølge): «Mest lest» = `POPULAR_ARTICLES`-indeks først, så
+  resten etter `updatedAt` desc med `slug` som stabil tie-break. «Nyeste» =
+  `updatedAt` desc, `slug` tie-break. «A–Å» = `title` (norsk `localeCompare`).
+  Serverpage sorterer/bygger DTO-listen; klienten filtrerer/re-sorterer på den.
+- Props: plain DTO-liste (slug, title, summary, categorySlug, categoryTitle,
+  author, date, readingTime, popRank). Ingen content-collections-import i klienten.
+- **Prefetch**: sett `prefetch={false}` på rad-`<Link>`-ene. Indeksen rendrer
+  alle 27 ruter; default-viewport-prefetch laster da rute-chunks for hele
+  biblioteket ved sidelast (jf. prior learning `hidden-panels-viewport-prefetch`).
+- Chip kan dyplenke til `/help/category/[slug]` (behold kategorisidene) ELLER
+  filtrere in-place; velg in-place filtrering, med en «se hele kategorien
+  →»-lenke når ett filter er aktivt. URL-state (`?q`/`?kategori`/`?sort`) er
+  nice-to-have via `useSearchParams` + `history.replaceState`, ikke MVP-krav.
+
+### Steg 4 — «Hurtigsvar»-FAQ (hub, server `HelpFaq` + JSON-LD)
+Definer `HELP_FAQS` i `help-data.ts`. **Shape** (eng-review-funn — skill JSON-LD
+og synlig lenke fra hverandre):
+`{ q: string, a: string, rel?: { label: string, href: string } }`.
+`a` er ren tekst (ingen HTML/lenke) og er det `FAQPage`-JSON-LD emitter; `rel`
+er en separat synlig «Les mer»-affordans (`.related`) under svaret. Da kan
+`rel.href` peke på en hvilken som helst intern rute (f.eks. `/naringsmegler`)
+uten å bryte JSON-LD-speilingen. Render `hs-faq-grid` (aside + `hs-acc`-akkordeon
+med `<details>`/`hs-qa`) som **serverkomponent**. Emitter `FAQPage`-JSON-LD via
+eksisterende `StructuredData type="faq"` med `{question: q, answer: a}` — MÅ
+speile synlig FAQ (Google/policy). 6 stk, norsk, basert på designets FAQ-copy.
+Prisspenn for verdivurdering er en tjenestepris (ikke et markedstall), men flagg
+til eier; behold designets copy med mindre eier sier annet.
+
+### Steg 5 — `takeaways`-felt + «Kort fortalt» (skjema + artikkel)
+Legg til `takeaways: z.array(z.string()).optional()` i `HelpPost`-skjemaet (uten
+fast lengde). Render `art-kort`-boks **kun når feltet finnes** — romertall
+utledes dynamisk fra index (I, II, III, …), så boksen tåler et hvilket som helst
+antall punkter (eng-review-funn: ikke hardkod 3).
+**Scope (eng-review-funn — unngå skjult innholdsarbeid + dobbel sannhetskilde)**:
+Selve `takeaways`-populeringen er REDAKSJONELT arbeid, ikke kode. I denne planen
+populeres KUN flaggskipet `verdivurdering-av-naringseiendom` (siden eier
+eksplisitt refererte den) som demonstrasjon. Resten er ute av scope (eget
+innholdsløp, plan-011-stil). Ikke dupliser en eksisterende `<Summary>`/«Kort
+fortalt»-blokk som allerede står i brødteksten — «Kort fortalt» skal være
+redaksjonelt distinkt fra lede-en. Ingen nye markedstall.
+
+### Steg 6 — Artikkel venstre-skinne (`ArticleToc.tsx` klient + page-omlegging)
+Legg om `ks-article`-grid til designets `art-shell` (256px venstre-skinne + 1fr).
+Venstre-skinne (`art-rail`, sticky med `max-height: calc(100vh - 120px);
+overflow-y:auto` — designets CSS; håndterer lange navs som `terms` med 12
+artikler): innholdsfortegnelse (`art-toc`) med scroll-spy via
+`IntersectionObserver` (rootMargin `-100px 0px -65% 0px`, `aria-current`), og
+kategorinavigasjon (`art-nav`) med alle 6 kategorier. **Kun den AKTIVE kategorien
+utvides** med sine artikler (gjeldende uthevet); de andre viser bare tittel+antall.
+TOC bygges fra `data.tableOfContents` (allerede `{slug,title}` fra H2).
+- **Eksplisitt plassering** (eng-review-funn — «behold hvis det passer» er ikke
+  utførbart): «Relaterte tjenester»-lenkeblokken legges nederst i venstre-skinnen
+  under `art-nav` (bevarer intern-lenke/SEO-verdien). «Skrevet av {forfatter}.
+  Fant du en feil? → Si fra» flyttes til under artikkel-brødteksten ved
+  feedback-widgeten.
+- **Prefetch**: `prefetch={false}` på `art-nav`-artikkellenkene (de fleste er i
+  kollapsede kategorier; jf. prior learning `hidden-panels-viewport-prefetch`).
+- **Ikke dupliser breadcrumb-JSON-LD** (prior learning
+  `breadcrumbs-already-exist-partially`): siden bruker allerede `<Breadcrumbs>`
+  som emitter `BreadcrumbList`. Ikke legg til en ny BreadcrumbList.
+- Skip-link (`skip-link` → `#art-main`).
+
+### Steg 7 — Interaktiv feedback + forrige/neste (artikkel)
+- `ArticleFeedback.tsx`: Ja/Nei → «Takk for tilbakemeldingen» (lokal state).
+  Analytics-event via `trackEvent`-helper (`src/lib/analytics.ts` →
+  `window.dataLayer`), IKKE ad-hoc (prior learning `analytics-transport-datalayer`).
+  Erstatt den statiske widgeten (knapper uten handler).
+- `getOrderedHelpPosts(posts)` i `help-data.ts` (tar `allHelpPosts` som arg, så
+  modulen slipper content-collections-import): flat, deterministisk rekkefølge
+  sortert på [kategori-indeks i `HELP_CATEGORIES`, så `title` norsk `localeCompare`].
+  Serverpage utleder `{prev, next}` for gjeldende slug og sender som props.
+  Render `art-prevnext` nederst (kun pilene som finnes; én-kolonne på mobil).
+
+### Steg 8 — Verifikasjon
+`pnpm build` fanger kun kompilering/skjema/typer — IKKE ARIA, scroll-spy,
+localStorage, CSS-kollisjon eller mobil-layout. Derfor kreves browser-QA i tillegg.
+1. `pnpm build` → exit 0 (validerer skjema, MDX, typer; `ignoreBuildErrors:false`).
+2. `pnpm typecheck` → exit 0 (etter at build har generert content-collections-typer).
+3. Eksisterende Playwright-suite må fortsatt være grønn for de relevante gatene:
+   link-integritet (ingen `href="#"` / døde lenker), `mobile-overflow` (375px),
+   `perf-budget` (mål i PRODBYGG — drep gammel server på :3105 først, jf. prior
+   learning; sjekk at indeksens `prefetch={false}` holder JS-budsjettet).
+4. Browser-QA (`/qa`) på `/help` + én artikkel (f.eks.
+   `/help/article/verdivurdering-av-naringseiendom`), konkrete sjekker:
+   - Combobox: ⌘K fokuserer; skriving viser dropdown med kategori+lesetid;
+     ↑/↓ flytter `aria-activedescendant`; Enter åpner; Esc lukker; piller fyller
+     query; recent vises når tomt (og overlever reload); tom-tilstand viser
+     kontakt-CTA.
+   - Bibliotek: chips filtrerer + viser antall; tre sorteringer gir stabil,
+     deterministisk rekkefølge; minisøk filtrerer; tom-tilstand nullstiller.
+   - FAQ: `<details>` åpner/lukker; `FAQPage`-JSON-LD validerer (Rich Results)
+     og speiler synlig tekst; `rel`-lenker peker riktig.
+   - Artikkel: venstre-TOC scroll-spy markerer aktiv seksjon; kun aktiv kategori
+     utvidet; «Kort fortalt» vises der `takeaways` finnes; feedback toggler til
+     takk + pusher dataLayer-event; prev/next lenker til riktige naboer.
+   - Mobil (<980px): skinne stables (`order:2`), TOC skjules, rader kollapser.
+   - Tvers over: light-only, ingen layout-shift, `:focus-visible`-ringer synlige,
+     `prefers-reduced-motion` slår av animasjon.
+
+## STOP conditions
+
+- En hardkodet reading-path-slug (Steg 2) eller en FAQ-`rel` som peker på en
+  help-artikkel finnes IKKE i `src/content/help/` → **STOP og rapportér**. Ikke
+  improviser en erstatning (eng-review-funn: en STOP-betingelse og en
+  «velg-nærmeste»-regel kan ikke være samme punkt). FAQ-`rel` som peker på ikke-help-ruter
+  (f.eks. `/naringsmegler`) er unntatt — verifiser kun at ruten finnes i `navigation.ts`.
+- `HelpPost`-kategori-enum eller `POPULAR_ARTICLES` er endret siden planlegging → bekreft mot live før du fortsetter.
+- `pnpm build` feiler på MDX/skjema → ikke commit; fiks først.
+- Et krav vil tvinge endring av eksisterende MDX-brødtekst eller taksonomi → STOP, det er utenfor scope.
+
+## NOT in scope (vurdert og bevisst utsatt)
+
+- **Taksonomi-migrasjon til prototypens 6 læringskategorier**
+  (Grunnleggende/Verdivurdering/Yield/Driftsøkonomi/Markedet/Strategi). Codex
+  flagget at dagens `HELP_CATEGORIES` («Om Advanti», «Kom i gang») er mindre
+  «lærings-orientert» enn prototypen, så et polert bibliotek over support-/
+  produktkategorier kan føles litt inkoherent. Men en retaksonomi rører enum-et,
+  all MDX-frontmatter, kategorisidene og sitemap — stor innholdsmigrasjon, ikke
+  et design-port. Beholder eksisterende taksonomi; se TODO.
+- **Full `takeaways`-populering for alle 27 artikler** — redaksjonelt løp (plan-011-stil), ikke kode.
+- **URL-state-synk for biblioteket** (`?q`/`?kategori`/`?sort`) — nice-to-have, ikke MVP.
+- **Hostet søk (Algolia/Meilisearch), søkelogging, dark mode/density-tweaks** — prototyp/fremtid (best-practice §3, §6).
+
+## What already exists (gjenbrukes, ikke gjenbygges)
+
+- `ks-*`-designspråket, `SubHero`, `CtaStrip`, `Breadcrumbs` (+BreadcrumbList),
+  `StructuredData` (article/faq/howto), `ks-toc`/`ks-related`/`ks-feedback`,
+  `MDX`-komponenter (`Math`/`Note`/`Stepper` = designets formula/note/stepper),
+  `calculateReadingTime`, `getPopularArticles`, `trackEvent`/`dataLayer`-analytics,
+  `/help/category/[slug]`-sider. Planen utvider disse i stedet for å bygge nytt.
+
+## TODO (utenfor denne planen)
+
+- Vurder å gjøre kunnskaps-taksonomien mer lærings-orientert (slå sammen/omdøp
+  «Om Advanti»/«Kom i gang» mot prototypens modell). Krever innholdsmigrasjon +
+  redirect-strategi; ta som egen plan hvis eier ønsker.
+
+## Design-spesifikasjon (fra /plan-design-review)
+
+### Informasjonsarkitektur (seksjonsrekkefølge)
+
+```
+HUB /help                              ARTIKKEL /help/article/[slug]
+┌─────────────────────────────┐       ┌───────────────┬───────────────────┐
+│ Hero: H1 + lede              │       │ art-rail 256px│ art-body 1fr      │
+│  └ combobox-søk (primær)     │       │ ┌───────────┐ │ Breadcrumbs       │
+│  └ forslags-piller           │       │ │ TOC       │ │ meta · lesetid ·  │
+│  └ hero-statistikkstripe     │       │ │ (scroll-  │ │   sist oppdatert  │
+├─────────────────────────────┤       │ │  spy)     │ │ H1 + lede         │
+│ «Start her» 3 leseløp        │       │ ├───────────┤ │ forfatter         │
+├─────────────────────────────┤       │ │ kategori- │ │ «Kort fortalt»*   │
+│ Bibliotek (primær browse)    │       │ │ nav (kun  │ │ MDX-brødtekst     │
+│  toolbar: minisøk·chips·sort │       │ │ aktiv     │ │ FAQ (hvis faq)    │
+│  index-rader (27)            │       │ │ utvidet)  │ │ feedback (interakt)│
+├─────────────────────────────┤       │ ├───────────┤ │ + «Skrevet av/feil»│
+│ «Hurtigsvar» FAQ-akkordeon   │       │ │ relaterte │ │ prev/next         │
+├─────────────────────────────┤       │ │ tjenester │ │ relaterte artikler│
+│ CtaStrip                     │       │ └───────────┘ │                   │
+└─────────────────────────────┘       └───────────────┴───────────────────┘
+Visuell prioritet hub: søk > bibliotek > leseløp > FAQ.   *kun når takeaways finnes
+```
+
+### Interaksjonstilstander (hva brukeren SER)
+
+| Flate | Tom / førstegang | Aktiv / treff | Ingen treff | Suksess |
+|-------|------------------|---------------|-------------|---------|
+| Combobox-søk | Recent (localStorage) + populære artikler | Dropdown: tittel + `{kategori} · {lesetid} min`, aktiv rad uthevet | «Ingen treff på «q»» + «Kontakt en rådgiver →» | Enter/klikk → artikkel |
+| Bibliotek | Alle 27 rader, «Mest lest»-sortering | Filtrert liste + antall (aria-live) | `hs-empty`: nullstill-knapp + kontakt-CTA | — |
+| FAQ-akkordeon | Første åpen, resten lukket | `<details>` toggler; `rel`-«Les mer» under svar | — | — |
+| Feedback | «Var dette til hjelp?» Ja/Nei | — | — | «Takk for tilbakemeldingen» + dataLayer-event |
+| Artikkel-TOC | Første seksjon aktiv | Scroll-spy markerer gjeldende (`aria-current`) | — | — |
+
+Ingen ekte lastetilstand: hub/artikkel er statisk SSG, søk/filter kjører på
+in-memory-indeks (instant). Skeleton/spinner ikke nødvendig.
+
+### A11y / responsiv (utover Steg 8)
+
+- Touch-mål: chips, piller og sort-knapper må ha ≥40px effektiv tappehøyde på
+  mobil (designets `padding: 7px 14px` gir ~32px — øk vertikal padding eller
+  min-height i `@media (max-width:760px)`).
+- `<mark>`-treff bruker fast mørk tekst på accent (designet er allerede
+  kontrast-fikset — behold).
+- Combobox: `aria-label` på input + listbox; `role=option` + `id` per rad for
+  `aria-activedescendant`.
+
+### AI-slop-noter (dokumentert, ikke endring)
+
+- `art-kort` bruker `border-left: 3px solid var(--accent)` (slop-blacklist #8),
+  men er ÉN bevisst redaksjonell «Kort fortalt»-callout i tråd med
+  designsystemets eksisterende accent-kantbruk — ikke et dekorativt kortrutenett.
+  Beholdes med vilje.
+- 3-kolonners `hs-paths` er innholdsrike leseløp (nummererte steg-lister), ikke
+  ikon+tittel+2-linjers slop-grid. OK.
+- Type: Newsreader (display) + Inter (body) er etablert merkevaretype per
+  DESIGN.md, ikke lat system-default.
+
+## Maintenance notes
+
+- Designets prototyp-data (`kunnskapssenter-data.js`) brukes IKKE i prod — den er
+  referanse for layout/copy. URL-state-søk og hostet søk (Algolia o.l.) er
+  fremtidig arbeid (best-practice §3), ikke denne planen.
+- Hvis `takeaways` senere ønskes for alle artikler, er det innholdsarbeid (plan
+  011-stil), ikke kode.
+
+## GSTACK REVIEW REPORT
+
+| Review | Trigger | Why | Runs | Status | Findings |
+|--------|---------|-----|------|--------|----------|
+| CEO Review | `/plan-ceo-review` | Scope & strategy | 0 | — | — |
+| Eng Review | `/plan-eng-review` | Architecture & tests (required) | 1 | issues_open→folded | 13 issues, 0 critical gaps; all folded into plan |
+| Design Review | `/plan-design-review` | UI/UX gaps | 1 | clean | score 7/10 → 9/10, 3 tillegg |
+| Outside Voice | `/codex review` | Independent 2nd opinion | 1 | issues_found | 13 funn, alle absorbert |
+
+**DESIGN:** 7-pass-review, ingen hard-rejections. Initial 7/10 (manglet
+IA-diagram, samlet tilstandstabell, eksplisitte touch-mål). Etter tillegg 9/10:
+IA-/layout-diagram, interaksjonstilstand-tabell, og a11y/touch-mål-spesifikasjon
+lagt til. `art-kort` accent-kant + 3-kol leseløp vurdert mot slop-blacklist og
+dokumentert som bevisste, ikke slop. Uløst (flagg, ikke blokkerer): FAQ-prisspenn
+(15–40k kr) — eier bekrefter copy.
+
+**Scope:** akseptert som spesifisert — eier ba eksplisitt om både hub
+(`kunnskapssenter-v2.html`) og artikkel-«id»-siden. Kompleksitetsgaten (12+
+filer / 4 klient-overflater) er reell, men scope er forhåndsbestemt av eier; en
+klient-overflate (`HelpFaq`) ble flyttet til server for å dempe JS.
+
+**Architecture review (2 funn):** (1) Klient/server-grense — `content.tsx` drar
+content-collections + ikoner; klientkomponenter må bruke plain DTO-props + nytt
+`help-data.ts`. (2) Ikke dupliser BreadcrumbList-JSON-LD (prior learning).
+
+**Code quality (4):** FAQ-shape splittet i ren-tekst `a` (JSON-LD) + separat
+`rel`-lenke; «behold høyre-aside hvis det passer» erstattet med eksplisitt
+plassering; ↑/↓-tastenav er NY (ikke «behold»); `takeaways` rendres dynamisk
+(ikke hardkodet 3).
+
+**Test review:** ingen unit-testbar ren logikk av betydning (sortering er
+deterministisk og bør få en liten Vitest om harness brukes); de reelle risikoene
+(ARIA-combobox, scroll-spy, localStorage, mobil) er browser-flate → dekkes av
+`/qa` + eksisterende Playwright-gater (link-integritet, mobile-overflow,
+perf-budget). Ingen regresjoner identifisert; statisk feedback-widget → interaktiv
+er additiv. Coverage-strategi: 3 Playwright-gater + `/qa`-økt (Steg 8).
+
+**Performance (1):** `prefetch={false}` på bibliotek-rader + kollapsede
+`art-nav`-lenker — ellers prefetcher Next.js rute-chunks for alle 27 ruter ved
+sidelast (prior learning `hidden-panels-viewport-prefetch`, +93KB-klassen).
+Mål i prodbygg.
+
+**CODEX:** 13 funn, alle absorbert i planen (ingen avvist). Sterkeste:
+klient/server-grense, FAQ JSON-LD-drift, ikke-deterministisk «Mest lest»,
+takeaways-scope-creep, selvmotsigende STOP-betingelse.
+
+**CROSS-MODEL:** Claude (prior learnings) + Codex enige om at dette bygges oppå
+eksisterende /help, ikke som parallell. Eneste strategiske spenning — taksonomi
+(behold vs. retaksonomi) — er løst som NOT-in-scope + TODO; eier kan overstyre.
+
+**VERDICT:** ENG + DESIGN CLEARED (alle funn foldet inn) — klar for implementering.
+
+NO UNRESOLVED DECISIONS

--- a/plans/README.md
+++ b/plans/README.md
@@ -17,6 +17,11 @@ done.
 | 006  | Parallelize the five sequential Supabase fetches on /eiendommer/[slug] | P3 | S | — | DONE (merged `53a894e`, 2026-06-10) |
 | 007  | Spike: quarterly market data out of TypeScript — design doc only | P3 | M | — | DONE (doc at docs/market-data-collection-design.md; recommendation: Option C, keep TS + guardrails; merged `1b61b06`, 2026-06-10) |
 | 008  | Scrub ekte transaksjonsfakta fra offentlig repo (case study-kommentarer) | P1 | S | — | DONE (merged 076582e, 2026-06-12; leak-grep 0 på tracked HEAD — historikk-beslutning gjenstår hos eier) |
+| 009  | Tekniske SEO-fikser for kunnskapssenteret (tomme kategorier, author-fiks, datePublished, FAQ-infrastruktur) | P1 | S–M | — | DONE (APPROVED @ c103ff0; merget til main via PR #45 `63d3a4e`, 2026-06-12) |
+| 010  | Gjør «Hva er næringseiendom» til pilarside + unike meta descriptions | P2 | M | 009 | DONE (APPROVED @ ff935d2 etter 1 revisjonsrunde; 1542 ord; merget til main via PR #45 `63d3a4e`, 2026-06-12) |
+| 011  | Artikkel-veikart: 15 nye kunnskapsartikler i tre klynger (terms / for-investors / analysis) | P1 | L | 009 (anbefalt etter 010) | DONE (15 artikler i 3 batcher, APPROVED @ c4f3cab etter 3 korrektur-/speilingsrevisjoner; help 12→27 artikler; merget til main via PR #45 `63d3a4e`, 2026-06-12) |
+| 012  | Avkannibaliser blog↔help-duplikatene (sensitivitetsanalyse, DCF) | P2 | S–M | — (anbefalt etter 010) | DONE (APPROVED @ 706e6bf etter 1 terminologirevisjon; rolleregel etablert: help = kanonisk begrep («hva er X»), blog = praktisk/aktuelt; merget til main via PR #45 `63d3a4e`, 2026-06-12) |
+| 013  | Port «Kunnskapssenter v2»-designet (hub + artikkel-id-side) til /help | P1 | L | 009–012 | IN PROGRESS (ENG+DESIGN CLEARED @ 45f9e69; eng 13 funn foldet, design 7→9/10; implementeres på `feat/kunnskapssenter-v2-design`) |
 
 Status values: TODO | IN PROGRESS | DONE | BLOCKED (with one-line reason) | REJECTED (with one-line rationale)
 
@@ -25,6 +30,9 @@ Status values: TODO | IN PROGRESS | DONE | BLOCKED (with one-line reason) | REJE
 - **003 after 001**: both edit `src/app/actions/onboarding/onboarding.ts` (001 adds a rate-limit guard at the top of `submitContactInquiry`; 003 rewrites its body and expects the guard to be present). Executing in the other order forces a manual merge.
 - 001 and 003 list optional unit tests that only become possible once 004's Vitest harness exists; they are written to skip those gracefully, so 004's position in the order is a recommendation, not a hard dependency.
 - 002 touches only `package.json`/lockfile and can run in parallel with anything.
+- **010 og 011 etter 009**: begge bruker `faq:`- og `publishedAt:`-feltene som 009 legger til i `HelpPost`-skjemaet; 011 forutsetter også kategori-gatingen fra 009 (kategorier slipper automatisk inn i sitemap når første artikkel lander). 010 har en eksplisitt fallback hvis 009 mangler, men rekkefølgen sparer arbeid.
+- **012 etter 010**: 010 og 012 redigerer summary-/innholdsfelter i overlappende help-filer; rekkefølgen unngår dobbeltredigering. 012 kan ellers kjøre uavhengig.
+- **011 batch B/C-verifikasjon** bruker sitemap-gates som bare gir mening etter 009.
 
 ## Key audit facts (context for executors)
 
@@ -53,3 +61,11 @@ Status values: TODO | IN PROGRESS | DONE | BLOCKED (with one-line reason) | REJE
 - **AI-citation baseline first run (markedsfoering/ai-citation-baseline.md, due 2026-06-01, overdue)**: a 30-minute marketing task, not a code plan — flagged to the maintainer in the audit report.
 - **Publish the 5 exemplar blog articles (TODOS.md TODO 20)**: blocked on an editorial slug-collision decision, not engineering. Not plannable until the maintainer decides merge-vs-rename.
 - **Eiendom-varsel/newsletter single Resend audience (unsubscribe granularity)**: real product gap, M effort, needs a second Resend audience + backfill — maintainer should weigh it; can become a plan on request.
+
+### Fra help/SEO-granskningen 2026-06-12 (planene 009–012)
+
+- **Slette de tomme kategoriene «For Investorer»/«Markedsanalyse»**: avvist — plan 011 fyller dem; 009 gater dem midlertidig ut av indeksen i stedet.
+- **wordCount/keywords i Article-JSON-LD**: lav SEO-verdi, mer rørlegging (rå-ordtelling må beregnes i content-collections-transformen). Bevisst utelatt fra 009.
+- **Redirect/konsolidering av blog-duplikatene**: avvist som førstegrep — begge URL-er har verdi; 012 differensierer i stedet, med eskalering til konsolidering som dokumentert exit hvis Search Console fortsatt viser rotasjon etter ~8 uker.
+- **Legacy-slugs i `generateStaticParams`** (`hva-er-næringseiendom-en-komplett-guide`-aliasene i `article/[slug]/page.tsx:62–74`): fungerer via `HELP_ARTICLE_ALIASES` i `src/lib/content.ts`, ikke et SEO-problem (alias-sidene er ikke i sitemap). Ikke verdt en plan.
+- **Omfang ikke granska denne runden**: dette var en fokusert help/SEO-granskning — correctness/security/perf/test-kategoriene ble ikke re-auditert (sist dekket 2026-06-10 ved `3c71295`).

--- a/plans/README.md
+++ b/plans/README.md
@@ -21,7 +21,7 @@ done.
 | 010  | Gjør «Hva er næringseiendom» til pilarside + unike meta descriptions | P2 | M | 009 | DONE (APPROVED @ ff935d2 etter 1 revisjonsrunde; 1542 ord; merget til main via PR #45 `63d3a4e`, 2026-06-12) |
 | 011  | Artikkel-veikart: 15 nye kunnskapsartikler i tre klynger (terms / for-investors / analysis) | P1 | L | 009 (anbefalt etter 010) | DONE (15 artikler i 3 batcher, APPROVED @ c4f3cab etter 3 korrektur-/speilingsrevisjoner; help 12→27 artikler; merget til main via PR #45 `63d3a4e`, 2026-06-12) |
 | 012  | Avkannibaliser blog↔help-duplikatene (sensitivitetsanalyse, DCF) | P2 | S–M | — (anbefalt etter 010) | DONE (APPROVED @ 706e6bf etter 1 terminologirevisjon; rolleregel etablert: help = kanonisk begrep («hva er X»), blog = praktisk/aktuelt; merget til main via PR #45 `63d3a4e`, 2026-06-12) |
-| 013  | Port «Kunnskapssenter v2»-designet (hub + artikkel-id-side) til /help | P1 | L | 009–012 | IN PROGRESS (ENG+DESIGN CLEARED @ 45f9e69; eng 13 funn foldet, design 7→9/10; implementeres på `feat/kunnskapssenter-v2-design`) |
+| 013  | Port «Kunnskapssenter v2»-designet (hub + artikkel-id-side) til /help | P1 | L | 009–012 | DONE (impl @ 3022e5b på `feat/kunnskapssenter-v2-design`; ENG+DESIGN CLEARED; build+typecheck grønt; /qa grønt — 0 konsollfeil, 0 bugs på hub+artikkel, alle nye interaksjoner + mobil verifisert. Ikke pushet/PR-et) |
 
 Status values: TODO | IN PROGRESS | DONE | BLOCKED (with one-line reason) | REJECTED (with one-line rationale)
 

--- a/src/app/(help)/help/article/[slug]/page.tsx
+++ b/src/app/(help)/help/article/[slug]/page.tsx
@@ -11,7 +11,9 @@ import { MDX } from "@/components/blog/mdx"
 import { HELP_CATEGORIES } from "@/lib/blog/content"
 import {
   getOrderedHelpPosts,
+  HELP_AUTHORS,
   HELP_CATEGORY_META,
+  helpAuthorName,
   helpNeighbours,
 } from "@/lib/blog/help-data"
 import { getBlurDataURL } from "@/lib/blog/images"
@@ -20,27 +22,6 @@ import { constructMetadata } from "@/lib/utils"
 import { getHelpPost } from "@/lib/content"
 import StructuredData from "@/components/StructuredData"
 import { Breadcrumbs } from "@/components/site/Breadcrumbs"
-
-const AUTHOR_NAMES: Record<string, string> = {
-  codehagen: "Christer Hagen",
-  vsoraas: "Vegard Søraas",
-}
-
-const AUTHOR_META: Record<string, { name: string; role: string; image: string }> =
-  {
-    codehagen: {
-      name: "Christer Hagen",
-      role: "Partner & daglig leder · Advanti Estate",
-      image:
-        "https://kukzjreikqbgbolxvqaj.supabase.co/storage/v1/object/public/press/christer-hagen-web.jpg",
-    },
-    vsoraas: {
-      name: "Vegard Søraas",
-      role: "Partner · Advanti Estate",
-      image:
-        "https://imagedelivery.net/r-6-yk-gGPtjfbIST9-8uA/76037f97-384f-4681-176e-5b8a0ba71300/public",
-    },
-  }
 
 const MONTHS_SHORT = [
   "JAN", "FEB", "MAR", "APR", "MAI", "JUN",
@@ -93,7 +74,7 @@ export async function generateMetadata({
     path: `/help/article/${post.slug}`,
     ogType: "article",
     modifiedTime: post.updatedAt,
-    authors: [AUTHOR_NAMES[post.author] || post.author],
+    authors: [helpAuthorName(post.author)],
   })
 }
 
@@ -127,8 +108,8 @@ export default async function HelpArticle({
         .filter(Boolean)) as HelpPost[]) || []
 
   const readingTime = data.mdx ? calculateReadingTime(data.mdx) : null
-  const authorMeta = AUTHOR_META[data.author]
-  const authorName = AUTHOR_NAMES[data.author] || data.author
+  const authorMeta = HELP_AUTHORS[data.author]
+  const authorName = helpAuthorName(data.author)
   const toc = data.tableOfContents ?? []
   const takeaways = data.takeaways ?? []
 

--- a/src/app/(help)/help/article/[slug]/page.tsx
+++ b/src/app/(help)/help/article/[slug]/page.tsx
@@ -134,12 +134,13 @@ export default async function HelpArticle({
 
   // Left-rail category nav: all categories with counts; active category's
   // articles (ordered) expanded.
+  // Count by PRIMARY category (categories[0]) so the number matches both the
+  // expanded article list below and the hub library — multi-category articles
+  // (e.g. exit-yield = terms+valuation) belong to their primary category only.
   const navCategories = HELP_CATEGORY_META.map((c) => ({
     slug: c.slug,
     title: c.title,
-    count: allHelpPosts.filter((p) =>
-      (p.categories as string[]).includes(c.slug),
-    ).length,
+    count: allHelpPosts.filter((p) => p.categories[0] === c.slug).length,
   }))
   const categoryArticles = getOrderedHelpPosts(
     allHelpPosts.filter((p) => p.categories[0] === category.slug),

--- a/src/app/(help)/help/article/[slug]/page.tsx
+++ b/src/app/(help)/help/article/[slug]/page.tsx
@@ -3,10 +3,17 @@ import { Metadata } from "next"
 import Link from "next/link"
 import { notFound } from "next/navigation"
 
+import { ArticleFeedback } from "@/components/help/ArticleFeedback"
+import { ArticleToc } from "@/components/help/ArticleToc"
 import { CtaStrip } from "@/components/site/CtaStrip"
 import { NewsletterSection } from "@/components/site/NewsletterSection"
 import { MDX } from "@/components/blog/mdx"
 import { HELP_CATEGORIES } from "@/lib/blog/content"
+import {
+  getOrderedHelpPosts,
+  HELP_CATEGORY_META,
+  helpNeighbours,
+} from "@/lib/blog/help-data"
 import { getBlurDataURL } from "@/lib/blog/images"
 import { calculateReadingTime } from "@/lib/blog/utils"
 import { constructMetadata } from "@/lib/utils"
@@ -36,26 +43,18 @@ const AUTHOR_META: Record<string, { name: string; role: string; image: string }>
   }
 
 const MONTHS_SHORT = [
-  "JAN",
-  "FEB",
-  "MAR",
-  "APR",
-  "MAI",
-  "JUN",
-  "JUL",
-  "AUG",
-  "SEP",
-  "OKT",
-  "NOV",
-  "DES",
+  "JAN", "FEB", "MAR", "APR", "MAI", "JUN",
+  "JUL", "AUG", "SEP", "OKT", "NOV", "DES",
 ]
 
-/** Formats a date string as e.g. "14. JAN 2026". */
+const ROMAN = ["I", "II", "III", "IV", "V", "VI", "VII", "VIII", "IX", "X"]
+
+/** Formats a date string as e.g. "14. jan 2026". */
 function editorialDate(date: string) {
   const d = new Date(date.includes("T") ? date : `${date}T00:00:00`)
   if (Number.isNaN(d.getTime())) return date
-  const day = String(d.getDate()).padStart(2, "0")
-  return `${day}. ${MONTHS_SHORT[d.getMonth()]} ${d.getFullYear()}`
+  const day = String(d.getDate())
+  return `${day}. ${MONTHS_SHORT[d.getMonth()].toLowerCase()} ${d.getFullYear()}`
 }
 
 export async function generateStaticParams() {
@@ -127,12 +126,34 @@ export default async function HelpArticle({
         .map((slug) => allHelpPosts.find((post) => post.slug === slug))
         .filter(Boolean)) as HelpPost[]) || []
 
-  const readingTime = data.mdx
-    ? calculateReadingTime(data.mdx)
-    : null
+  const readingTime = data.mdx ? calculateReadingTime(data.mdx) : null
   const authorMeta = AUTHOR_META[data.author]
   const authorName = AUTHOR_NAMES[data.author] || data.author
   const toc = data.tableOfContents ?? []
+  const takeaways = data.takeaways ?? []
+
+  // Left-rail category nav: all categories with counts; active category's
+  // articles (ordered) expanded.
+  const navCategories = HELP_CATEGORY_META.map((c) => ({
+    slug: c.slug,
+    title: c.title,
+    count: allHelpPosts.filter((p) =>
+      (p.categories as string[]).includes(c.slug),
+    ).length,
+  }))
+  const categoryArticles = getOrderedHelpPosts(
+    allHelpPosts.filter((p) => p.categories[0] === category.slug),
+  ).map((p) => ({ slug: p.slug ?? "", title: p.title }))
+
+  // Prev/next across the full deterministic ordering.
+  const { prev, next } = helpNeighbours(
+    allHelpPosts.map((p) => ({
+      slug: p.slug,
+      title: p.title,
+      categories: p.categories,
+    })),
+    data.slug ?? slug,
+  )
 
   return (
     <>
@@ -163,10 +184,14 @@ export default async function HelpArticle({
         <StructuredData type="faq" data={{ faqs: data.faq }} />
       )}
 
+      <a href="#art-main" className="skip-link">
+        Hopp til innhold
+      </a>
+
       <div className="page-pad" />
 
-      {/* HERO — breadcrumb only */}
-      <section className="subhero" style={{ paddingBottom: 24 }}>
+      {/* HERO — breadcrumb only (emits BreadcrumbList JSON-LD) */}
+      <section className="subhero" style={{ paddingBottom: 16 }}>
         <div className="wrap">
           <Breadcrumbs
             path={`/help/article/${data.slug}`}
@@ -178,8 +203,16 @@ export default async function HelpArticle({
       {/* ARTICLE */}
       <section className="section-tight" style={{ paddingTop: 0 }}>
         <div className="wrap">
-          <div className="ks-article">
-            <article className="ks-art-body">
+          <div className="art-shell">
+            <ArticleToc
+              toc={toc}
+              categories={navCategories}
+              activeCategory={category.slug}
+              categoryArticles={categoryArticles}
+              currentSlug={data.slug ?? slug}
+            />
+
+            <article className="ks-art-body" id="art-main">
               <div className="ks-art-meta">
                 <Link
                   href={`/help/category/${category.slug}`}
@@ -188,14 +221,17 @@ export default async function HelpArticle({
                 >
                   {category.title}
                 </Link>
-                <span className="sep">·</span>
-                <span>{editorialDate(data.updatedAt)}</span>
                 {readingTime && (
                   <>
                     <span className="sep">·</span>
                     <span>{readingTime} min lesing</span>
                   </>
                 )}
+                <span className="sep">·</span>
+                <span className="art-updated">
+                  <span className="pip" aria-hidden="true" />
+                  Sist oppdatert {editorialDate(data.updatedAt)}
+                </span>
               </div>
 
               <h1 className="ks-art-title">{data.title}</h1>
@@ -215,6 +251,22 @@ export default async function HelpArticle({
                 </div>
               )}
 
+              {takeaways.length > 0 && (
+                <div className="art-kort">
+                  <div className="lbl">Kort fortalt</div>
+                  <ul>
+                    {takeaways.map((point, i) => (
+                      <li key={i}>
+                        <span className="n" aria-hidden="true">
+                          {ROMAN[i] ?? String(i + 1)}
+                        </span>
+                        <span>{point}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+
               <MDX code={data.mdx} images={images} />
 
               {data.faq && data.faq.length >= 2 && (
@@ -229,30 +281,37 @@ export default async function HelpArticle({
                 </div>
               )}
 
-              {/* Feedback */}
-              <div className="ks-feedback">
-                <p>
-                  Var denne artikkelen{" "}
-                  <span
-                    style={{
-                      fontStyle: "italic",
-                      fontWeight: 300,
-                      color: "var(--warm-grey-85)",
-                    }}
-                  >
-                    til hjelp?
-                  </span>
-                </p>
-                <div className="btn-row">
-                  <button type="button">Ja</button>
-                  <button type="button">Nei</button>
-                </div>
-              </div>
+              <ArticleFeedback slug={data.slug ?? slug} />
 
-              {/* Related */}
+              {(prev || next) && (
+                <nav className="art-prevnext" aria-label="Forrige og neste artikkel">
+                  {prev ? (
+                    <Link href={`/help/article/${prev.slug}`} className="prev">
+                      <span className="dir">← Forrige</span>
+                      <span className="ti">{prev.title}</span>
+                    </Link>
+                  ) : (
+                    <span />
+                  )}
+                  {next ? (
+                    <Link href={`/help/article/${next.slug}`} className="next">
+                      <span className="dir">Neste →</span>
+                      <span className="ti">{next.title}</span>
+                    </Link>
+                  ) : (
+                    <span />
+                  )}
+                </nav>
+              )}
+
               {relatedArticles.length > 0 && (
                 <div className="ks-related">
-                  <h3>Les videre.</h3>
+                  <h3>
+                    Les videre{" "}
+                    <span className="italic">
+                      i {category.title.toLowerCase()}.
+                    </span>
+                  </h3>
                   <div className="ks-related-list">
                     {relatedArticles.map((article) => {
                       const relCat = HELP_CATEGORIES.find(
@@ -266,6 +325,7 @@ export default async function HelpArticle({
                           key={article.slug}
                           className="item"
                           href={`/help/article/${article.slug}`}
+                          prefetch={false}
                         >
                           <span className="pre">
                             {relCat?.title ?? "Kunnskap"}
@@ -278,44 +338,12 @@ export default async function HelpArticle({
                   </div>
                 </div>
               )}
+
+              <p className="art-overview-note" style={{ marginTop: 40 }}>
+                Skrevet av {authorName}. Fant du en feil?{" "}
+                <Link href="/kontakt">Si fra →</Link>
+              </p>
             </article>
-
-            {/* TOC sidebar */}
-            <aside className="ks-toc">
-              <div className="toc-label">På denne siden</div>
-              {toc.map((item: { slug: string; title: string }) => (
-                <Link key={item.slug} href={`#${item.slug}`}>
-                  {item.title}
-                </Link>
-              ))}
-
-              <div className="toc-related">
-                <div className="toc-label">Relaterte tjenester</div>
-                <Link href="/tjenester/verdivurdering">
-                  Verdivurdering av næringseiendom
-                </Link>
-                <Link href="/tjenester/salg">Salg av næringseiendom</Link>
-                <Link href="/tjenester/utleie">Utleie av næringseiendom</Link>
-                <Link href="/naringsmegler/bodo">Næringsmegler i Bodø</Link>
-                <Link href="/naringsmegler">Alle markeder i Nord-Norge</Link>
-              </div>
-
-              <div className="toc-meta">
-                Skrevet av {authorName}.
-                <br />
-                <br />
-                Fant du en feil?{" "}
-                <Link
-                  href="/kontakt"
-                  style={{
-                    color: "var(--warm-grey)",
-                    borderBottom: "1px solid",
-                  }}
-                >
-                  Si fra →
-                </Link>
-              </div>
-            </aside>
           </div>
         </div>
       </section>

--- a/src/app/(help)/help/page.tsx
+++ b/src/app/(help)/help/page.tsx
@@ -11,6 +11,7 @@ import {
   HELP_CATEGORY_META,
   HELP_PATHS,
   HELP_SEARCH_SUGGESTIONS,
+  helpAuthorName,
   helpCategoryTitle,
 } from "@/lib/blog/help-data"
 import { calculateReadingTime } from "@/lib/blog/utils"
@@ -23,11 +24,6 @@ export const metadata = constructMetadata({
     "Et åpent kunnskapssenter om næringseiendom i Nord-Norge: yield, verdivurdering, DCF, leiekontrakter og markedet — forklart av rådgivere som gjør det til daglig.",
 })
 
-const AUTHOR_NAMES: Record<string, string> = {
-  codehagen: "Christer Hagen",
-  vsoraas: "Vegard Søraas",
-}
-
 const MONTHS_SHORT = [
   "jan", "feb", "mar", "apr", "mai", "jun",
   "jul", "aug", "sep", "okt", "nov", "des",
@@ -37,10 +33,6 @@ function shortDate(date: string) {
   const d = new Date(date.includes("T") ? date : `${date}T00:00:00`)
   if (Number.isNaN(d.getTime())) return date
   return `${d.getDate()}. ${MONTHS_SHORT[d.getMonth()]} ${d.getFullYear()}`
-}
-
-function authorName(key: string) {
-  return AUTHOR_NAMES[key] ?? key
 }
 
 export default function HelpCenter() {
@@ -71,7 +63,7 @@ export default function HelpCenter() {
       summary: post.summary,
       category: helpCategoryTitle(post.categories[0]),
       categorySlug: post.categories[0],
-      author: authorName(post.author),
+      author: helpAuthorName(post.author),
       dateLabel: shortDate(post.updatedAt),
       updated: post.updatedAt,
       readingTime: post.mdx ? calculateReadingTime(post.mdx) : null,

--- a/src/app/(help)/help/page.tsx
+++ b/src/app/(help)/help/page.tsx
@@ -1,10 +1,18 @@
 import { allHelpPosts } from "content-collections"
 import Link from "next/link"
 
-import { HelpSearch } from "@/components/help/HelpSearch"
+import { HelpFaq } from "@/components/help/HelpFaq"
+import { HelpLibrary, type LibraryItem } from "@/components/help/HelpLibrary"
+import { HelpSearch, type HelpSearchItem } from "@/components/help/HelpSearch"
 import { CtaStrip } from "@/components/site/CtaStrip"
 import { SubHero } from "@/components/site/SubHero"
-import { getPopularArticles, HELP_CATEGORIES } from "@/lib/blog/content"
+import { getPopularArticles, POPULAR_ARTICLES } from "@/lib/blog/content"
+import {
+  HELP_CATEGORY_META,
+  HELP_PATHS,
+  HELP_SEARCH_SUGGESTIONS,
+  helpCategoryTitle,
+} from "@/lib/blog/help-data"
 import { calculateReadingTime } from "@/lib/blog/utils"
 import { constructMetadata } from "@/lib/utils"
 
@@ -12,132 +20,186 @@ export const metadata = constructMetadata({
   path: "/help",
   title: "Kunnskapssenter – Advanti",
   description:
-    "Et sentralt knutepunkt for alle dine næringseiendoms-relaterte spørsmål. Finn svar på vanlige spørsmål, lær hvordan du bruker plattformen, og få ekspertråd.",
+    "Et åpent kunnskapssenter om næringseiendom i Nord-Norge: yield, verdivurdering, DCF, leiekontrakter og markedet — forklart av rådgivere som gjør det til daglig.",
 })
 
-function categoryTitle(slug?: string) {
-  return HELP_CATEGORIES.find((c) => c.slug === slug)?.title ?? "Artikkel"
+const AUTHOR_NAMES: Record<string, string> = {
+  codehagen: "Christer Hagen",
+  vsoraas: "Vegard Søraas",
+}
+
+const MONTHS_SHORT = [
+  "jan", "feb", "mar", "apr", "mai", "jun",
+  "jul", "aug", "sep", "okt", "nov", "des",
+]
+
+function shortDate(date: string) {
+  const d = new Date(date.includes("T") ? date : `${date}T00:00:00`)
+  if (Number.isNaN(d.getTime())) return date
+  return `${d.getDate()}. ${MONTHS_SHORT[d.getMonth()]} ${d.getFullYear()}`
+}
+
+function authorName(key: string) {
+  return AUTHOR_NAMES[key] ?? key
 }
 
 export default function HelpCenter() {
   const popularArticles = getPopularArticles()
 
-  // Lightweight client-side search index — title/summary/category only, so the
-  // compiled MDX never ships to the browser.
-  const searchIndex = allHelpPosts.map((post) => ({
+  // Plain serialisable DTOs for the client components (the client/server
+  // boundary rule: never import content-collections into a client component).
+  const searchIndex: HelpSearchItem[] = allHelpPosts.map((post) => ({
     slug: post.slug ?? "",
     title: post.title,
     summary: post.summary,
-    category: categoryTitle(post.categories[0]),
+    category: helpCategoryTitle(post.categories[0]),
+    readingTime: post.mdx ? calculateReadingTime(post.mdx) : null,
+  }))
+
+  const popularDto = popularArticles.map((post) => ({
+    slug: post.slug ?? "",
+    title: post.title,
+    category: helpCategoryTitle(post.categories[0]),
+  }))
+
+  const libraryItems: LibraryItem[] = allHelpPosts.map((post) => {
+    const slug = post.slug ?? ""
+    const popRank = POPULAR_ARTICLES.indexOf(slug)
+    return {
+      slug,
+      title: post.title,
+      summary: post.summary,
+      category: helpCategoryTitle(post.categories[0]),
+      categorySlug: post.categories[0],
+      author: authorName(post.author),
+      dateLabel: shortDate(post.updatedAt),
+      updated: post.updatedAt,
+      readingTime: post.mdx ? calculateReadingTime(post.mdx) : null,
+      popRank: popRank === -1 ? null : popRank,
+    }
+  })
+
+  const latestUpdated = allHelpPosts
+    .map((p) => p.updatedAt)
+    .sort((a, b) => Date.parse(b) - Date.parse(a))[0]
+  const latestLabel = latestUpdated
+    ? `${MONTHS_SHORT[new Date(`${latestUpdated}T00:00:00`).getMonth()]} ${new Date(`${latestUpdated}T00:00:00`).getFullYear()}`
+    : ""
+
+  // Resolve reading-path step slugs to titles.
+  const bySlug = new Map(allHelpPosts.map((p) => [p.slug ?? "", p]))
+  const paths = HELP_PATHS.map((path) => ({
+    ...path,
+    steps: path.steps
+      .map((slug) => {
+        const post = bySlug.get(slug)
+        return post ? { slug, title: post.title } : null
+      })
+      .filter((s): s is { slug: string; title: string } => s !== null),
   }))
 
   return (
     <>
       <SubHero
         crumb={[{ label: "Hjem", href: "/" }, { label: "Kunnskapssenter" }]}
-        eyebrow="Lær næringseiendom"
+        eyebrow="Hjelp & kunnskap om næringseiendom"
         title={
           <>
             Forstå næringseiendom — <br />
             <span className="italic">begrep, metode, marked.</span>
           </>
         }
-        lede="Et åpent kunnskapssenter for alle som jobber med næringseiendom i Nord-Norge. Konkrete forklaringer av yield, verdivurdering, DCF og leiemarkedet — uten faglig støy."
+        lede="Søk i hele biblioteket, eller bla deg gjennom. Konkrete forklaringer av yield, verdivurdering, DCF, leiekontrakter og markedet i Nord-Norge — skrevet av folk som gjør det til daglig."
       >
-        <HelpSearch index={searchIndex} />
+        <HelpSearch
+          index={searchIndex}
+          popular={popularDto}
+          suggestions={HELP_SEARCH_SUGGESTIONS}
+        />
+
+        <div className="hs-herostats">
+          <div className="s">
+            <span className="v">
+              {allHelpPosts.length}
+              <span className="unit"> stk</span>
+            </span>
+            <span className="l">Artikler &amp; guider</span>
+          </div>
+          <div className="s">
+            <span className="v">{HELP_CATEGORY_META.length}</span>
+            <span className="l">Temaer</span>
+          </div>
+          <div className="s">
+            <span className="v">Gratis</span>
+            <span className="l">Åpent for alle</span>
+          </div>
+          {latestLabel && (
+            <div className="s">
+              <span className="v" style={{ textTransform: "capitalize" }}>
+                {latestLabel}
+              </span>
+              <span className="l">Sist oppdatert</span>
+            </div>
+          )}
+        </div>
       </SubHero>
 
-      {/* POPULAR ARTICLES */}
-      <section
-        className="section-tight"
-        style={{ paddingTop: 16, paddingBottom: 48 }}
-      >
+      {/* START HER — reading paths */}
+      <section className="section-tight" style={{ paddingTop: 16, paddingBottom: 48 }}>
         <div className="wrap">
-          <div className="ks-popular">
-            <div className="ribbon-head">
-              <h2>
-                Populære artikler <span className="italic">akkurat nå.</span>
-              </h2>
-              <span className="eyebrow" style={{ fontSize: 11 }}>
-                Mest leste
-              </span>
-            </div>
-
-            <div className="ks-popular-grid">
-              {popularArticles.map((article, idx) => {
-                const readingTime = article.mdx
-                  ? calculateReadingTime(article.mdx)
-                  : null
-                return (
-                  <Link
-                    key={article.slug}
-                    className="ks-popular-item"
-                    href={`/help/article/${article.slug}`}
-                  >
-                    <span className="num">
-                      {String(idx + 1).padStart(2, "0")}
-                    </span>
-                    <div>
-                      <h4>{article.title}</h4>
-                      <div className="meta">
-                        {categoryTitle(article.categories[0])}
-                        {readingTime ? ` · ${readingTime} min lesing` : ""}
-                      </div>
-                    </div>
-                    <span className="arrow">→</span>
-                  </Link>
-                )
-              })}
-            </div>
-          </div>
-        </div>
-      </section>
-
-      {/* CATEGORIES */}
-      <section className="section" style={{ paddingTop: 48 }}>
-        <div className="wrap">
-          <div className="head-compact">
-            <span className="eyebrow">Kategorier</span>
+          <div className="head-compact" style={{ marginBottom: 28 }}>
+            <span className="eyebrow">Start her</span>
             <div>
               <h2>
-                Utforsk etter <span className="italic">tema.</span>
+                Hvor vil du <span className="italic">begynne?</span>
               </h2>
               <p>
-                Vi har samlet alt vi vet om næringseiendom i tematiske
-                kategorier — fra grunnleggende begreper til avanserte
-                analysemetoder.
+                Tre korte løp som tar deg fra null til oversikt — avhengig av
+                hvor du står.
               </p>
             </div>
           </div>
 
-          <div className="ks-cats">
-            {HELP_CATEGORIES.map((category, idx) => {
-              const count = allHelpPosts.filter((post) =>
-                (post.categories as string[]).includes(category.slug),
-              ).length
-              return (
-                <Link
-                  key={category.slug}
-                  className="ks-cat"
-                  href={`/help/category/${category.slug}`}
-                >
-                  <span className="pre">
-                    Kategori · {String(idx + 1).padStart(2, "0")}
-                  </span>
-                  <h3>{category.title}</h3>
-                  <p>{category.description}</p>
-                  <div className="cfoot">
-                    <span className="count">
-                      {count} {count === 1 ? "artikkel" : "artikler"}
-                    </span>
-                    <span className="more">
-                      Utforsk <span>→</span>
-                    </span>
-                  </div>
-                </Link>
-              )
-            })}
+          <div className="hs-paths">
+            {paths.map((path) => (
+              <div className="hs-path" key={path.num}>
+                <span className="pre">Løp · {path.num}</span>
+                <h3>
+                  {path.title} <span className="italic">{path.italic}</span>
+                </h3>
+                <p>{path.desc}</p>
+                <ul className="steps">
+                  {path.steps.map((step, i) => (
+                    <li key={step.slug}>
+                      <Link href={`/help/article/${step.slug}`}>
+                        <span className="sn">
+                          {String(i + 1).padStart(2, "0")}
+                        </span>
+                        <span className="st">{step.title}</span>
+                        <span className="sa" aria-hidden="true">
+                          →
+                        </span>
+                      </Link>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))}
           </div>
+        </div>
+      </section>
+
+      {/* LIBRARY */}
+      <section id="bibliotek" className="section" style={{ paddingTop: 24 }}>
+        <div className="wrap">
+          <HelpLibrary items={libraryItems} categories={HELP_CATEGORY_META} />
+        </div>
+      </section>
+
+      {/* QUICK ANSWERS */}
+      <section className="section" style={{ paddingTop: 8 }}>
+        <div className="wrap">
+          <HelpFaq />
         </div>
       </section>
 

--- a/src/components/help/ArticleFeedback.tsx
+++ b/src/components/help/ArticleFeedback.tsx
@@ -1,0 +1,67 @@
+"use client"
+
+import { useState } from "react"
+
+import { trackEvent } from "@/lib/analytics"
+
+/**
+ * Article feedback widget. "Var denne til hjelp?" → Ja/Nei, then a thank-you.
+ * Pushes a help_feedback event to dataLayer via the shared analytics helper.
+ */
+export function ArticleFeedback({ slug }: { slug: string }) {
+  const [done, setDone] = useState<"yes" | "no" | null>(null)
+
+  const submit = (helpful: "yes" | "no") => {
+    setDone(helpful)
+    trackEvent("help_feedback", { slug, helpful: helpful === "yes" })
+  }
+
+  if (done) {
+    return (
+      <div className="ks-feedback">
+        <p>
+          Takk for{" "}
+          <span
+            style={{
+              fontStyle: "italic",
+              fontWeight: 300,
+              color: "var(--warm-grey-85)",
+            }}
+          >
+            tilbakemeldingen.
+          </span>
+        </p>
+        <span className="art-feedback-done">
+          {done === "yes"
+            ? "Så bra at den var nyttig."
+            : "Vi tar det med i forbedringen."}
+        </span>
+      </div>
+    )
+  }
+
+  return (
+    <div className="ks-feedback">
+      <p>
+        Var denne artikkelen{" "}
+        <span
+          style={{
+            fontStyle: "italic",
+            fontWeight: 300,
+            color: "var(--warm-grey-85)",
+          }}
+        >
+          til hjelp?
+        </span>
+      </p>
+      <div className="btn-row">
+        <button type="button" onClick={() => submit("yes")}>
+          Ja
+        </button>
+        <button type="button" onClick={() => submit("no")}>
+          Nei
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/help/ArticleFeedback.tsx
+++ b/src/components/help/ArticleFeedback.tsx
@@ -18,7 +18,7 @@ export function ArticleFeedback({ slug }: { slug: string }) {
 
   if (done) {
     return (
-      <div className="ks-feedback">
+      <div className="ks-feedback" role="status" aria-live="polite">
         <p>
           Takk for{" "}
           <span

--- a/src/components/help/ArticleToc.tsx
+++ b/src/components/help/ArticleToc.tsx
@@ -1,0 +1,118 @@
+"use client"
+
+import Link from "next/link"
+import { useEffect, useState } from "react"
+
+interface TocItem {
+  slug: string
+  title: string
+}
+
+interface NavCategory {
+  slug: string
+  title: string
+  count: number
+}
+
+/**
+ * Article left rail: table of contents with scroll-spy, category navigation
+ * (only the active category is expanded with its articles), and related
+ * services. The TOC ids come from data.tableOfContents (H2 slugs added by
+ * rehype-slug), so they match the rendered heading ids.
+ */
+export function ArticleToc({
+  toc,
+  categories,
+  activeCategory,
+  categoryArticles,
+  currentSlug,
+}: {
+  toc: TocItem[]
+  categories: NavCategory[]
+  activeCategory: string
+  categoryArticles: { slug: string; title: string }[]
+  currentSlug: string
+}) {
+  const [activeId, setActiveId] = useState<string>(toc[0]?.slug ?? "")
+
+  useEffect(() => {
+    if (toc.length === 0) return
+    const headings = toc
+      .map((t) => document.getElementById(t.slug))
+      .filter((el): el is HTMLElement => el !== null)
+    if (headings.length === 0) return
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const visible = entries
+          .filter((e) => e.isIntersecting)
+          .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top)
+        if (visible[0]?.target.id) setActiveId(visible[0].target.id)
+      },
+      { rootMargin: "-100px 0px -65% 0px" },
+    )
+    headings.forEach((h) => observer.observe(h))
+    return () => observer.disconnect()
+  }, [toc])
+
+  return (
+    <aside className="art-rail">
+      {toc.length > 0 && (
+        <nav className="art-toc" aria-label="På denne siden">
+          <div className="lbl">På denne siden</div>
+          {toc.map((item) => (
+            <Link
+              key={item.slug}
+              href={`#${item.slug}`}
+              className={activeId === item.slug ? "active" : undefined}
+              aria-current={activeId === item.slug ? "location" : undefined}
+            >
+              {item.title}
+            </Link>
+          ))}
+        </nav>
+      )}
+
+      <nav className="art-nav" aria-label="Kunnskapssenter">
+        <div className="lbl">Kunnskapssenter</div>
+        {categories.map((c) => {
+          const isActive = c.slug === activeCategory
+          return (
+            <div key={c.slug} className={`cat${isActive ? " active" : ""}`}>
+              <Link href={`/help/category/${c.slug}`} className="ct">
+                <span>{c.title}</span>
+                <span className="cc">{c.count}</span>
+              </Link>
+              {isActive && categoryArticles.length > 0 && (
+                <div className="arts">
+                  {categoryArticles.map((a) => (
+                    <Link
+                      key={a.slug}
+                      href={`/help/article/${a.slug}`}
+                      className={a.slug === currentSlug ? "current" : undefined}
+                      aria-current={a.slug === currentSlug ? "page" : undefined}
+                      prefetch={false}
+                    >
+                      {a.title}
+                    </Link>
+                  ))}
+                </div>
+              )}
+            </div>
+          )
+        })}
+      </nav>
+
+      <div className="art-rail-services">
+        <div className="lbl">Relaterte tjenester</div>
+        <Link href="/tjenester/verdivurdering">
+          Verdivurdering av næringseiendom
+        </Link>
+        <Link href="/tjenester/salg">Salg av næringseiendom</Link>
+        <Link href="/tjenester/utleie">Utleie av næringseiendom</Link>
+        <Link href="/naringsmegler/bodo">Næringsmegler i Bodø</Link>
+        <Link href="/naringsmegler">Alle markeder i Nord-Norge</Link>
+      </div>
+    </aside>
+  )
+}

--- a/src/components/help/HelpFaq.tsx
+++ b/src/components/help/HelpFaq.tsx
@@ -1,0 +1,55 @@
+import Link from "next/link"
+
+import StructuredData from "@/components/StructuredData"
+import { HELP_FAQS } from "@/lib/blog/help-data"
+
+/**
+ * Hub "Hurtigsvar" FAQ. Server component — uses native <details> so it needs no
+ * client JS. The visible answer text is also emitted verbatim as FAQPage JSON-LD
+ * (Google/schema.org policy: structured data must mirror visible content). The
+ * "Les mer" link is a separate visible affordance and is NOT part of the JSON-LD.
+ */
+export function HelpFaq() {
+  return (
+    <div className="hs-faq-grid">
+      <StructuredData
+        type="faq"
+        data={{
+          faqs: HELP_FAQS.map((f) => ({
+            question: f.question,
+            answer: f.answer,
+          })),
+        }}
+      />
+      <div className="hs-faq-aside">
+        <span className="eyebrow">Hurtigsvar</span>
+        <h2>
+          Spørsmål vi <span className="italic">ofte får.</span>
+        </h2>
+        <p>
+          De vanligste tingene folk lurer på — besvart med en gang, uten å
+          forlate siden.
+        </p>
+        <Link className="askmore" href="/kontakt">
+          Still ditt eget spørsmål <span aria-hidden="true">→</span>
+        </Link>
+      </div>
+
+      <div className="hs-acc">
+        {HELP_FAQS.map((f, i) => (
+          <details className="hs-qa" key={f.question} open={i === 0}>
+            <summary>{f.question}</summary>
+            <div className="a">
+              <p>{f.answer}</p>
+              {f.rel && (
+                <Link className="related" href={f.rel.href}>
+                  {f.rel.label} <span aria-hidden="true">→</span>
+                </Link>
+              )}
+            </div>
+          </details>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/components/help/HelpLibrary.tsx
+++ b/src/components/help/HelpLibrary.tsx
@@ -125,12 +125,11 @@ export function HelpLibrary({
           />
         </div>
 
-        <div className="hs-chips" role="tablist" aria-label="Filtrer på kategori">
+        <div className="hs-chips" role="group" aria-label="Filtrer på kategori">
           <button
             type="button"
             className="hs-chip"
-            role="tab"
-            aria-selected={cat === "all"}
+            aria-pressed={cat === "all"}
             data-on={cat === "all" ? "1" : undefined}
             onClick={() => setCat("all")}
           >
@@ -141,8 +140,7 @@ export function HelpLibrary({
               key={c.slug}
               type="button"
               className="hs-chip"
-              role="tab"
-              aria-selected={cat === c.slug}
+              aria-pressed={cat === c.slug}
               data-on={cat === c.slug ? "1" : undefined}
               onClick={() => setCat(c.slug)}
             >

--- a/src/components/help/HelpLibrary.tsx
+++ b/src/components/help/HelpLibrary.tsx
@@ -1,0 +1,239 @@
+"use client"
+
+import Link from "next/link"
+import { useMemo, useState } from "react"
+
+export interface LibraryItem {
+  slug: string
+  title: string
+  summary: string
+  category: string
+  categorySlug: string
+  author: string
+  dateLabel: string
+  updated: string
+  readingTime: number | null
+  popRank: number | null
+}
+
+type SortKey = "popular" | "new" | "az"
+
+const SORTS: { key: SortKey; label: string }[] = [
+  { key: "popular", label: "Mest lest" },
+  { key: "new", label: "Nyeste" },
+  { key: "az", label: "A–Å" },
+]
+
+function highlight(text: string, q: string) {
+  if (!q) return text
+  const i = text.toLowerCase().indexOf(q.toLowerCase())
+  if (i === -1) return text
+  return (
+    <>
+      {text.slice(0, i)}
+      <mark>{text.slice(i, i + q.length)}</mark>
+      {text.slice(i + q.length)}
+    </>
+  )
+}
+
+/** Deterministic sorting — never relies on incoming array order. */
+function sortItems(items: LibraryItem[], sort: SortKey): LibraryItem[] {
+  const byNew = (a: LibraryItem, b: LibraryItem) => {
+    const d = Date.parse(b.updated) - Date.parse(a.updated)
+    return d !== 0 ? d : a.slug.localeCompare(b.slug)
+  }
+  const copy = [...items]
+  if (sort === "az") {
+    copy.sort((a, b) => a.title.localeCompare(b.title, "nb"))
+  } else if (sort === "new") {
+    copy.sort(byNew)
+  } else {
+    // "Mest lest": curated popRank first (asc), then newest, slug tiebreak.
+    copy.sort((a, b) => {
+      const ra = a.popRank ?? Infinity
+      const rb = b.popRank ?? Infinity
+      if (ra !== rb) return ra - rb
+      return byNew(a, b)
+    })
+  }
+  return copy
+}
+
+export function HelpLibrary({
+  items,
+  categories,
+}: {
+  items: LibraryItem[]
+  categories: { slug: string; title: string }[]
+}) {
+  const [cat, setCat] = useState<string>("all")
+  const [filter, setFilter] = useState("")
+  const [sort, setSort] = useState<SortKey>("popular")
+
+  const counts = useMemo(() => {
+    const map: Record<string, number> = {}
+    for (const it of items) map[it.categorySlug] = (map[it.categorySlug] ?? 0) + 1
+    return map
+  }, [items])
+
+  const q = filter.trim().toLowerCase()
+  const list = useMemo(() => {
+    const filtered = items.filter((it) => {
+      if (cat !== "all" && it.categorySlug !== cat) return false
+      if (q.length === 0) return true
+      return (
+        it.title.toLowerCase().includes(q) ||
+        it.summary.toLowerCase().includes(q) ||
+        it.category.toLowerCase().includes(q)
+      )
+    })
+    return sortItems(filtered, q ? "popular" : sort)
+  }, [items, cat, q, sort])
+
+  const reset = () => {
+    setCat("all")
+    setFilter("")
+    setSort("popular")
+  }
+
+  const activeCat = categories.find((c) => c.slug === cat)
+
+  return (
+    <>
+      <div className="hs-lib-head">
+        <h2>
+          Hele <span className="italic">biblioteket.</span>
+        </h2>
+        <span className="hs-count" aria-live="polite">
+          <strong>{list.length}</strong>{" "}
+          {list.length === 1 ? "artikkel" : "artikler"}
+        </span>
+      </div>
+
+      <div className="hs-toolbar">
+        <div className="hs-minisearch">
+          <span className="ic" aria-hidden="true">
+            ⌕
+          </span>
+          <input
+            type="text"
+            placeholder="Filtrer biblioteket…"
+            aria-label="Filtrer biblioteket"
+            value={filter}
+            onChange={(e) => setFilter(e.target.value)}
+          />
+        </div>
+
+        <div className="hs-chips" role="tablist" aria-label="Filtrer på kategori">
+          <button
+            type="button"
+            className="hs-chip"
+            role="tab"
+            aria-selected={cat === "all"}
+            data-on={cat === "all" ? "1" : undefined}
+            onClick={() => setCat("all")}
+          >
+            Alle <span className="cn">{items.length}</span>
+          </button>
+          {categories.map((c) => (
+            <button
+              key={c.slug}
+              type="button"
+              className="hs-chip"
+              role="tab"
+              aria-selected={cat === c.slug}
+              data-on={cat === c.slug ? "1" : undefined}
+              onClick={() => setCat(c.slug)}
+            >
+              {c.title} <span className="cn">{counts[c.slug] ?? 0}</span>
+            </button>
+          ))}
+        </div>
+
+        {q.length === 0 && (
+          <div className="hs-sort">
+            <span className="lbl">Sorter</span>
+            {SORTS.map((s) => (
+              <button
+                key={s.key}
+                type="button"
+                className="hs-sortbtn"
+                data-on={sort === s.key ? "1" : undefined}
+                onClick={() => setSort(s.key)}
+              >
+                {s.label}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {list.length > 0 ? (
+        <div className="hs-index">
+          {list.map((it) => (
+            <Link
+              key={it.slug}
+              className="hs-row"
+              href={`/help/article/${it.slug}`}
+              prefetch={false}
+            >
+              <div className="rmain">
+                <div className="rtag">
+                  <span className="dot" aria-hidden="true" />
+                  {it.category}
+                </div>
+                <div className="rtitle">{highlight(it.title, q)}</div>
+                <div className="rsum">{it.summary}</div>
+              </div>
+              <div className="rauthor">{it.author}<br />{it.dateLabel}</div>
+              <div className="rread">
+                {it.readingTime ? `${it.readingTime} min` : ""}
+              </div>
+              <span className="rarrow" aria-hidden="true">
+                →
+              </span>
+            </Link>
+          ))}
+        </div>
+      ) : (
+        <div className="hs-empty">
+          <div className="em-mark" aria-hidden="true">
+            ⌕
+          </div>
+          <h4>
+            Ingen treff <span className="q">her.</span>
+          </h4>
+          <p>
+            Vi fant ingen artikler som matcher
+            {q ? ` «${filter.trim()}»` : " filteret"}
+            {activeCat ? ` i ${activeCat.title}` : ""}. Prøv et bredere søk —
+            eller spør oss direkte.
+          </p>
+          <div className="hs-empty-actions">
+            <button type="button" className="clearbtn" onClick={reset}>
+              Nullstill søk &amp; filter
+            </button>
+            <Link className="ghostbtn" href="/kontakt">
+              Kontakt en rådgiver <span aria-hidden="true">→</span>
+            </Link>
+          </div>
+        </div>
+      )}
+
+      {cat !== "all" && activeCat && (
+        <p style={{ marginTop: 20, fontSize: 13.5 }}>
+          <Link
+            href={`/help/category/${activeCat.slug}`}
+            style={{
+              color: "var(--warm-grey)",
+              borderBottom: "1px solid var(--warm-grey-75)",
+            }}
+          >
+            Se hele kategorien {activeCat.title} →
+          </Link>
+        </p>
+      )}
+    </>
+  )
+}

--- a/src/components/help/HelpLibrary.tsx
+++ b/src/components/help/HelpLibrary.tsx
@@ -3,6 +3,8 @@
 import Link from "next/link"
 import { useMemo, useState } from "react"
 
+import { foldNo } from "@/lib/blog/help-data"
+
 export interface LibraryItem {
   slug: string
   title: string
@@ -77,15 +79,15 @@ export function HelpLibrary({
     return map
   }, [items])
 
-  const q = filter.trim().toLowerCase()
+  const q = foldNo(filter.trim())
   const list = useMemo(() => {
     const filtered = items.filter((it) => {
       if (cat !== "all" && it.categorySlug !== cat) return false
       if (q.length === 0) return true
       return (
-        it.title.toLowerCase().includes(q) ||
-        it.summary.toLowerCase().includes(q) ||
-        it.category.toLowerCase().includes(q)
+        foldNo(it.title).includes(q) ||
+        foldNo(it.summary).includes(q) ||
+        foldNo(it.category).includes(q)
       )
     })
     return sortItems(filtered, q ? "popular" : sort)

--- a/src/components/help/HelpSearch.tsx
+++ b/src/components/help/HelpSearch.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 
 import { trackEvent } from "@/lib/analytics"
+import { foldNo } from "@/lib/blog/help-data"
 
 export interface HelpSearchItem {
   slug: string
@@ -94,13 +95,13 @@ export function HelpSearch({
   const q = query.trim()
   const results = useMemo(() => {
     if (q.length === 0) return []
-    const needle = q.toLowerCase()
+    const needle = foldNo(q)
     return index
       .filter(
         (item) =>
-          item.title.toLowerCase().includes(needle) ||
-          item.summary.toLowerCase().includes(needle) ||
-          item.category.toLowerCase().includes(needle),
+          foldNo(item.title).includes(needle) ||
+          foldNo(item.summary).includes(needle) ||
+          foldNo(item.category).includes(needle),
       )
       .slice(0, MAX_RESULTS)
   }, [index, q])

--- a/src/components/help/HelpSearch.tsx
+++ b/src/components/help/HelpSearch.tsx
@@ -119,14 +119,25 @@ export function HelpSearch({
     })
   }, [])
 
-  const goTo = useCallback(
+  // Side effects for a selected result (record recent + analytics + close).
+  // Used by the result <Link> onClick — the Link itself handles navigation,
+  // so we must NOT also router.push or the page navigates twice.
+  const recordSelect = useCallback(
     (slug: string, term: string) => {
       pushRecent(term)
       trackEvent("help_search_select", { query: term, slug })
       setOpen(false)
+    },
+    [pushRecent],
+  )
+
+  // Keyboard-Enter path has no <Link> click, so it navigates programmatically.
+  const goTo = useCallback(
+    (slug: string, term: string) => {
+      recordSelect(slug, term)
       router.push(`/help/article/${slug}`)
     },
-    [pushRecent, router],
+    [recordSelect, router],
   )
 
   const clearRecent = () => {
@@ -169,7 +180,7 @@ export function HelpSearch({
         role="combobox"
         aria-expanded={open}
         aria-haspopup="listbox"
-        aria-controls="hs-listbox"
+        aria-controls={open ? "hs-listbox" : undefined}
       >
         <span className="ic" aria-hidden="true">
           ⌕
@@ -180,7 +191,7 @@ export function HelpSearch({
           placeholder="Søk — f.eks. «yield», «leiekontrakt», «Bodø»…"
           aria-label="Søk i kunnskapssenteret"
           aria-autocomplete="list"
-          aria-controls="hs-listbox"
+          aria-controls={open ? "hs-listbox" : undefined}
           aria-activedescendant={
             showResults && active >= 0 ? `hs-opt-${active}` : undefined
           }
@@ -230,7 +241,7 @@ export function HelpSearch({
                   aria-selected={i === active}
                   prefetch={false}
                   onMouseEnter={() => setActive(i)}
-                  onClick={() => goTo(item.slug, q)}
+                  onClick={() => recordSelect(item.slug, q)}
                 >
                   <div>
                     <div className="rt">{highlight(item.title, q)}</div>

--- a/src/components/help/HelpSearch.tsx
+++ b/src/components/help/HelpSearch.tsx
@@ -2,28 +2,71 @@
 
 import Link from "next/link"
 import { useRouter } from "next/navigation"
-import { useEffect, useRef, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+
+import { trackEvent } from "@/lib/analytics"
 
 export interface HelpSearchItem {
   slug: string
   title: string
   summary: string
   category: string
+  readingTime: number | null
+}
+
+const RECENT_KEY = "ks.recent"
+const MAX_RESULTS = 6
+
+function readRecent(): string[] {
+  try {
+    const raw = window.localStorage.getItem(RECENT_KEY)
+    if (!raw) return []
+    const parsed = JSON.parse(raw)
+    return Array.isArray(parsed) ? parsed.slice(0, 5) : []
+  } catch {
+    return []
+  }
+}
+
+/** Highlights the query inside a title without dangerouslySetInnerHTML. */
+function highlight(text: string, q: string) {
+  if (!q) return text
+  const i = text.toLowerCase().indexOf(q.toLowerCase())
+  if (i === -1) return text
+  return (
+    <>
+      {text.slice(0, i)}
+      <mark>{text.slice(i, i + q.length)}</mark>
+      {text.slice(i + q.length)}
+    </>
+  )
 }
 
 /**
- * Knowledge-base search. Filters help articles client-side by title and
- * summary, shows a results panel, supports ⌘K / Ctrl+K to focus, Enter to
- * jump to the top hit, and Escape to dismiss.
+ * Kunnskapssenter search combobox. Instant results over an in-memory index,
+ * suggestion pills, recent searches (localStorage), popular articles when
+ * empty, full keyboard support (⌘K focus, ↑/↓ navigate, Enter open, Esc close)
+ * and an ARIA combobox contract.
  */
-export function HelpSearch({ index }: { index: HelpSearchItem[] }) {
+export function HelpSearch({
+  index,
+  popular,
+  suggestions,
+}: {
+  index: HelpSearchItem[]
+  popular: { slug: string; title: string; category: string }[]
+  suggestions: string[]
+}) {
   const router = useRouter()
   const [query, setQuery] = useState("")
   const [open, setOpen] = useState(false)
+  const [active, setActive] = useState(-1)
+  const [recent, setRecent] = useState<string[]>([])
   const inputRef = useRef<HTMLInputElement>(null)
   const containerRef = useRef<HTMLDivElement>(null)
 
-  // ⌘K / Ctrl+K focuses the search field from anywhere on the page.
+  useEffect(() => setRecent(readRecent()), [])
+
   useEffect(() => {
     const onKey = (event: KeyboardEvent) => {
       if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "k") {
@@ -35,7 +78,6 @@ export function HelpSearch({ index }: { index: HelpSearchItem[] }) {
     return () => window.removeEventListener("keydown", onKey)
   }, [])
 
-  // Dismiss the results panel when clicking outside the search box.
   useEffect(() => {
     const onClick = (event: MouseEvent) => {
       if (
@@ -49,71 +91,255 @@ export function HelpSearch({ index }: { index: HelpSearchItem[] }) {
     return () => document.removeEventListener("mousedown", onClick)
   }, [])
 
-  const q = query.trim().toLowerCase()
-  const results =
-    q.length > 0
-      ? index
-          .filter(
-            (item) =>
-              item.title.toLowerCase().includes(q) ||
-              item.summary.toLowerCase().includes(q),
-          )
-          .slice(0, 6)
-      : []
+  const q = query.trim()
+  const results = useMemo(() => {
+    if (q.length === 0) return []
+    const needle = q.toLowerCase()
+    return index
+      .filter(
+        (item) =>
+          item.title.toLowerCase().includes(needle) ||
+          item.summary.toLowerCase().includes(needle) ||
+          item.category.toLowerCase().includes(needle),
+      )
+      .slice(0, MAX_RESULTS)
+  }, [index, q])
+
+  const pushRecent = useCallback((term: string) => {
+    const trimmed = term.trim()
+    if (!trimmed) return
+    setRecent((prev) => {
+      const next = [trimmed, ...prev.filter((t) => t !== trimmed)].slice(0, 5)
+      try {
+        window.localStorage.setItem(RECENT_KEY, JSON.stringify(next))
+      } catch {
+        /* private mode / quota — ignore */
+      }
+      return next
+    })
+  }, [])
+
+  const goTo = useCallback(
+    (slug: string, term: string) => {
+      pushRecent(term)
+      trackEvent("help_search_select", { query: term, slug })
+      setOpen(false)
+      router.push(`/help/article/${slug}`)
+    },
+    [pushRecent, router],
+  )
+
+  const clearRecent = () => {
+    setRecent([])
+    try {
+      window.localStorage.removeItem(RECENT_KEY)
+    } catch {
+      /* ignore */
+    }
+  }
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
     if (event.key === "Escape") {
       setOpen(false)
+      setActive(-1)
       inputRef.current?.blur()
+      return
     }
-    if (event.key === "Enter" && results.length > 0) {
-      router.push(`/help/article/${results[0].slug}`)
-      setOpen(false)
+    if (results.length === 0) return
+    if (event.key === "ArrowDown") {
+      event.preventDefault()
+      setOpen(true)
+      setActive((i) => (i + 1) % results.length)
+    } else if (event.key === "ArrowUp") {
+      event.preventDefault()
+      setActive((i) => (i <= 0 ? results.length - 1 : i - 1))
+    } else if (event.key === "Enter") {
+      const hit = active >= 0 ? results[active] : results[0]
+      if (hit) goTo(hit.slug, q)
     }
   }
 
-  return (
-    <div className="ks-search" ref={containerRef}>
-      <span className="ks-search-icon" aria-hidden="true">
-        ⌕
-      </span>
-      <input
-        ref={inputRef}
-        type="search"
-        placeholder="Søk i kunnskapssenteret — yield, DCF, leiekontrakt…"
-        aria-label="Søk i kunnskapssenteret"
-        value={query}
-        onChange={(event) => {
-          setQuery(event.target.value)
-          setOpen(true)
-        }}
-        onFocus={() => setOpen(true)}
-        onKeyDown={handleKeyDown}
-      />
-      <kbd className="kbd">⌘ K</kbd>
+  const showResults = open && q.length > 0
+  const showRecent = open && q.length === 0
 
-      {open && q.length > 0 && (
-        <div className="ks-search-results" role="listbox">
+  return (
+    <div className="hs-searchwrap" ref={containerRef}>
+      <div
+        className="hs-search"
+        role="combobox"
+        aria-expanded={open}
+        aria-haspopup="listbox"
+        aria-controls="hs-listbox"
+      >
+        <span className="ic" aria-hidden="true">
+          ⌕
+        </span>
+        <input
+          ref={inputRef}
+          type="text"
+          placeholder="Søk — f.eks. «yield», «leiekontrakt», «Bodø»…"
+          aria-label="Søk i kunnskapssenteret"
+          aria-autocomplete="list"
+          aria-controls="hs-listbox"
+          aria-activedescendant={
+            showResults && active >= 0 ? `hs-opt-${active}` : undefined
+          }
+          value={query}
+          onChange={(event) => {
+            setQuery(event.target.value)
+            setActive(-1)
+            setOpen(true)
+          }}
+          onFocus={() => setOpen(true)}
+          onKeyDown={handleKeyDown}
+        />
+        {q.length > 0 ? (
+          <button
+            type="button"
+            className="clr"
+            onClick={() => {
+              setQuery("")
+              setActive(-1)
+              inputRef.current?.focus()
+            }}
+          >
+            Tøm ✕
+          </button>
+        ) : (
+          <kbd className="kbd">⌘ K</kbd>
+        )}
+      </div>
+
+      {showResults && (
+        <div className="hs-results" id="hs-listbox" role="listbox">
           {results.length > 0 ? (
-            results.map((item) => (
-              <Link
-                key={item.slug}
-                href={`/help/article/${item.slug}`}
-                className="ks-search-result"
-                role="option"
-                onClick={() => setOpen(false)}
-              >
-                <span className="r-title">{item.title}</span>
-                <span className="r-cat">{item.category}</span>
-              </Link>
-            ))
+            <>
+              <div className="rhead">
+                <span>Forslag</span>
+                <span aria-live="polite">
+                  {results.length} treff
+                </span>
+              </div>
+              {results.map((item, i) => (
+                <Link
+                  key={item.slug}
+                  id={`hs-opt-${i}`}
+                  href={`/help/article/${item.slug}`}
+                  className={`hs-res${i === active ? " active" : ""}`}
+                  role="option"
+                  aria-selected={i === active}
+                  prefetch={false}
+                  onMouseEnter={() => setActive(i)}
+                  onClick={() => goTo(item.slug, q)}
+                >
+                  <div>
+                    <div className="rt">{highlight(item.title, q)}</div>
+                    <div className="rm">
+                      {item.category}
+                      {item.readingTime ? ` · ${item.readingTime} min lesing` : ""}
+                    </div>
+                  </div>
+                  <span className="rarrow" aria-hidden="true">
+                    →
+                  </span>
+                </Link>
+              ))}
+            </>
           ) : (
-            <div className="ks-search-empty">
-              Ingen treff på «{query.trim()}». Prøv et annet søkeord.
+            <div className="hs-res-empty">
+              <p>
+                Ingen treff på <strong>«{q}»</strong>.
+              </p>
+              <p className="sub">
+                Prøv et bredere ord — eller spør oss direkte, så svarer en
+                rådgiver.
+              </p>
+              <Link className="hs-res-cta" href="/kontakt">
+                Kontakt en rådgiver <span aria-hidden="true">→</span>
+              </Link>
             </div>
           )}
         </div>
       )}
+
+      {showRecent && (recent.length > 0 || popular.length > 0) && (
+        <div className="hs-results" id="hs-listbox" role="listbox">
+          {recent.length > 0 && (
+            <>
+              <div className="rhead">
+                <span>Nylige søk</span>
+                <button type="button" className="rclear" onClick={clearRecent}>
+                  Fjern
+                </button>
+              </div>
+              {recent.map((term) => (
+                <button
+                  key={term}
+                  type="button"
+                  className="hs-res-recent"
+                  onClick={() => {
+                    setQuery(term)
+                    setOpen(true)
+                    inputRef.current?.focus()
+                  }}
+                >
+                  <span className="ric" aria-hidden="true">
+                    ↺
+                  </span>
+                  <span className="rt-plain">{term}</span>
+                  <span className="rarrow" aria-hidden="true">
+                    →
+                  </span>
+                </button>
+              ))}
+            </>
+          )}
+          {popular.length > 0 && (
+            <>
+              <div className="rhead">
+                <span>Populære artikler</span>
+              </div>
+              {popular.slice(0, 4).map((item) => (
+                <Link
+                  key={item.slug}
+                  href={`/help/article/${item.slug}`}
+                  className="hs-res"
+                  role="option"
+                  prefetch={false}
+                  onClick={() => setOpen(false)}
+                >
+                  <div>
+                    <div className="rt">{item.title}</div>
+                    <div className="rm">{item.category}</div>
+                  </div>
+                  <span className="rarrow" aria-hidden="true">
+                    →
+                  </span>
+                </Link>
+              ))}
+            </>
+          )}
+        </div>
+      )}
+
+      <div className="hs-suggest">
+        <span className="lbl">Populært</span>
+        {suggestions.map((s) => (
+          <button
+            key={s}
+            type="button"
+            className="hs-pill"
+            onClick={() => {
+              setQuery(s)
+              setActive(-1)
+              setOpen(true)
+              inputRef.current?.focus()
+            }}
+          >
+            {s}
+          </button>
+        ))}
+      </div>
     </div>
   )
 }

--- a/src/components/help/HelpSearch.tsx
+++ b/src/components/help/HelpSearch.tsx
@@ -189,6 +189,7 @@ export function HelpSearch({
         <input
           ref={inputRef}
           type="text"
+          enterKeyHint="search"
           placeholder="Søk — f.eks. «yield», «leiekontrakt», «Bodø»…"
           aria-label="Søk i kunnskapssenteret"
           aria-autocomplete="list"

--- a/src/content/help/verdivurdering-av-naringseiendom.mdx
+++ b/src/content/help/verdivurdering-av-naringseiendom.mdx
@@ -9,6 +9,10 @@ related:
   - hva-er-yield
   - kontantstromsanalyse
   - markedsleie-og-leieniva
+takeaways:
+  - Tre metoder dominerer — yield-basert, kontantstrømsanalyse (DCF) og sammenlignbare transaksjoner — og de utfyller hverandre.
+  - Yield-metoden er rask for stabilt utleide eiendommer; DCF fanger opp ledighet, reforhandling og verdiutvikling over tid.
+  - Et tall som tåler bankens kontroll krever dokumentert underlag — leiekontrakter, drifts- og felleskostnader, areal og regnskap.
 slug: verdivurdering-av-naringseiendom
 ---
 

--- a/src/lib/blog/help-data.ts
+++ b/src/lib/blog/help-data.ts
@@ -38,6 +38,22 @@ export function helpCategoryTitle(slug?: string): string {
   return HELP_CATEGORY_META.find((c) => c.slug === slug)?.title ?? "Artikkel"
 }
 
+/**
+ * Norwegian-aware fold for search matching: lowercases and reduces æ/ø/å (and
+ * other diacritics via NFD) to base letters, so a user typing ASCII ("naring",
+ * "bodo", "drift") still matches "næring", "Bodø", etc. Used by both the hero
+ * search and the library minisøk so their matching behaves identically.
+ */
+export function foldNo(s: string): string {
+  return s
+    .toLowerCase()
+    .replace(/æ/g, "a")
+    .replace(/ø/g, "o")
+    .replace(/å/g, "a")
+    .normalize("NFD")
+    .replace(/[̀-ͯ]/g, "")
+}
+
 /** Search-suggestion pills shown under the hero search field. */
 export const HELP_SEARCH_SUGGESTIONS = [
   "Yield",

--- a/src/lib/blog/help-data.ts
+++ b/src/lib/blog/help-data.ts
@@ -54,6 +54,35 @@ export function foldNo(s: string): string {
     .replace(/[̀-ͯ]/g, "")
 }
 
+/**
+ * Help-article authors — single source of truth for display name, role and
+ * avatar, shared by the hub library, article byline and article metadata so
+ * adding an author is a one-place edit (this repo has been bitten by the
+ * "update N parallel lists, forget one" drift before).
+ */
+export const HELP_AUTHORS: Record<
+  string,
+  { name: string; role: string; image: string }
+> = {
+  codehagen: {
+    name: "Christer Hagen",
+    role: "Partner & daglig leder · Advanti Estate",
+    image:
+      "https://kukzjreikqbgbolxvqaj.supabase.co/storage/v1/object/public/press/christer-hagen-web.jpg",
+  },
+  vsoraas: {
+    name: "Vegard Søraas",
+    role: "Partner · Advanti Estate",
+    image:
+      "https://imagedelivery.net/r-6-yk-gGPtjfbIST9-8uA/76037f97-384f-4681-176e-5b8a0ba71300/public",
+  },
+}
+
+/** Author display name, falling back to the raw key for unknown authors. */
+export function helpAuthorName(key: string): string {
+  return HELP_AUTHORS[key]?.name ?? key
+}
+
 /** Search-suggestion pills shown under the hero search field. */
 export const HELP_SEARCH_SUGGESTIONS = [
   "Yield",

--- a/src/lib/blog/help-data.ts
+++ b/src/lib/blog/help-data.ts
@@ -1,0 +1,188 @@
+/**
+ * Plain, serialisable data for the Kunnskapssenter (knowledge center).
+ *
+ * IMPORTANT: this module must stay free of `content-collections` and JSX/icon
+ * imports so it is safe to import from BOTH server and client components.
+ * `src/lib/blog/content.tsx` pulls in content-collections + Remix icons, so it
+ * must never be imported into a client component — use this module instead, and
+ * pass MDX-derived data in as plain props/arguments.
+ */
+
+export type HelpCategorySlug =
+  | "overview"
+  | "getting-started"
+  | "terms"
+  | "for-investors"
+  | "analysis"
+  | "valuation"
+
+/**
+ * Canonical category order + labels, mirrored from HELP_CATEGORIES in
+ * content.tsx (minus the JSX icons). Drives the library chips, the article
+ * category nav, and the deterministic article ordering for prev/next.
+ */
+export const HELP_CATEGORY_META: { slug: HelpCategorySlug; title: string }[] = [
+  { slug: "overview", title: "Om Advanti" },
+  { slug: "getting-started", title: "Kom i gang" },
+  { slug: "terms", title: "Begreper" },
+  { slug: "for-investors", title: "For Investorer" },
+  { slug: "analysis", title: "Markedsanalyse" },
+  { slug: "valuation", title: "Verdivurdering" },
+]
+
+const CATEGORY_INDEX: Record<string, number> = Object.fromEntries(
+  HELP_CATEGORY_META.map((c, i) => [c.slug, i]),
+)
+
+export function helpCategoryTitle(slug?: string): string {
+  return HELP_CATEGORY_META.find((c) => c.slug === slug)?.title ?? "Artikkel"
+}
+
+/** Search-suggestion pills shown under the hero search field. */
+export const HELP_SEARCH_SUGGESTIONS = [
+  "Yield",
+  "Verdivurdering",
+  "DCF",
+  "Leiekontrakt",
+  "WAULT",
+  "Bodø",
+]
+
+/**
+ * "Start her" reading paths. Each step is an existing help-article slug.
+ * STOP and report (do not silently substitute) if a slug here no longer
+ * exists in src/content/help/.
+ */
+export const HELP_PATHS: {
+  num: string
+  title: string
+  italic: string
+  desc: string
+  steps: string[]
+}[] = [
+  {
+    num: "01",
+    title: "Du eier",
+    italic: "næringseiendom",
+    desc: "Forstå hva eiendommen er verdt og hva som driver tallet.",
+    steps: [
+      "verdivurdering-av-naringseiendom",
+      "hva-er-yield",
+      "sensitivitetsanalyse",
+    ],
+  },
+  {
+    num: "02",
+    title: "Du vurderer",
+    italic: "å investere",
+    desc: "Fra første yield-betraktning til finansiering og analyse.",
+    steps: [
+      "hva-er-naringseiendom",
+      "diskontert-kontantstrom",
+      "finansiering-av-naringseiendom",
+    ],
+  },
+  {
+    num: "03",
+    title: "Du leier ut",
+    italic: "eller forvalter",
+    desc: "Kontrakter, kostnader og leie som faktisk holder verdi.",
+    steps: [
+      "leiekontrakter-naringseiendom",
+      "kpi-regulering-av-leie",
+      "felleskostnader",
+    ],
+  },
+]
+
+/**
+ * Hub-level "Hurtigsvar" FAQs. `answer` is plain text and is what the FAQPage
+ * JSON-LD emits — it must mirror the visible answer (Google/schema.org policy).
+ * `rel` is a separate visible "Les mer" link and may point at any internal
+ * route (help article OR e.g. /naringsmegler), so it never breaks JSON-LD.
+ */
+export const HELP_FAQS: {
+  question: string
+  answer: string
+  rel?: { label: string; href: string }
+}[] = [
+  {
+    question: "Hva koster en verdivurdering hos Advanti?",
+    answer:
+      "En innledende verdivurdering er gratis og uforpliktende. For en full rapport med dokumentert metode — den banken og kjøper kan lene seg på — avtaler vi pris ut fra eiendommens kompleksitet. De fleste ligger mellom 15 000 og 40 000 kr.",
+    rel: {
+      label: "Verdivurdering — komplett guide",
+      href: "/help/article/verdivurdering-av-naringseiendom",
+    },
+  },
+  {
+    question: "Hvor lang tid tar en verdivurdering?",
+    answer:
+      "Med komplett underlag leverer vi normalt innen 5–10 virkedager. Mangler du dokumentasjon, hjelper vi deg å hente inn det som trengs.",
+    rel: {
+      label: "Slik fungerer en verdivurdering",
+      href: "/help/article/verdivurdering-av-naringseiendom",
+    },
+  },
+  {
+    question: "Hva er forskjellen på yield og avkastning?",
+    answer:
+      "Yield (direkteavkastning) er forholdet mellom netto leieinntekt og eiendomsverdi i ett år. Totalavkastning inkluderer i tillegg verdiendring over tid. Yield er øyeblikksbildet; avkastning er hele reisen.",
+    rel: {
+      label: "Hva er yield i næringseiendom?",
+      href: "/help/article/hva-er-yield",
+    },
+  },
+  {
+    question: "Hvilken informasjon trenger dere for å vurdere eiendommen min?",
+    answer:
+      "Leiekontrakter, oversikt over drifts- og felleskostnader, areal/BTA, og gjerne siste års regnskap. Jo bedre grunnlag, jo mer presist tall — men vi kommer i gang med det du har.",
+    rel: {
+      label: "Leiekontrakter i næringseiendom",
+      href: "/help/article/leiekontrakter-naringseiendom",
+    },
+  },
+  {
+    question: "Dekker dere hele Nord-Norge?",
+    answer:
+      "Ja. Vi har kontor i Bodø og Alta og jobber i hele landsdelen — Tromsø, Mo i Rana, Narvik, Harstad og resten av regionen. Markedsdataene våre er bygget by for by.",
+    rel: {
+      label: "Næringsmegler i Nord-Norge",
+      href: "/naringsmegler",
+    },
+  },
+  {
+    question: "Kan jeg bruke kunnskapssenteret uten å være kunde?",
+    answer:
+      "Absolutt. Alt innholdet her er åpent og gratis. Vi deler metodene vi faktisk bruker — fordi en opplyst eier og investor er en bedre samarbeidspartner.",
+  },
+]
+
+/**
+ * Deterministic flat ordering for prev/next navigation: by category order
+ * (HELP_CATEGORY_META), then title (Norwegian collation). Takes the posts as an
+ * argument so this module stays free of content-collections.
+ */
+export function getOrderedHelpPosts<
+  T extends { slug?: string; title: string; categories: readonly string[] },
+>(posts: readonly T[]): T[] {
+  return [...posts].sort((a, b) => {
+    const ca = CATEGORY_INDEX[a.categories[0]] ?? 99
+    const cb = CATEGORY_INDEX[b.categories[0]] ?? 99
+    if (ca !== cb) return ca - cb
+    return a.title.localeCompare(b.title, "nb")
+  })
+}
+
+/** {prev, next} neighbours for a slug within the deterministic ordering. */
+export function helpNeighbours<
+  T extends { slug?: string; title: string; categories: readonly string[] },
+>(posts: readonly T[], slug: string): { prev: T | null; next: T | null } {
+  const ordered = getOrderedHelpPosts(posts)
+  const i = ordered.findIndex((p) => p.slug === slug)
+  if (i === -1) return { prev: null, next: null }
+  return {
+    prev: i > 0 ? ordered[i - 1] : null,
+    next: i < ordered.length - 1 ? ordered[i + 1] : null,
+  }
+}

--- a/src/lib/blog/help-data.ts
+++ b/src/lib/blog/help-data.ts
@@ -84,13 +84,15 @@ export function helpAuthorName(key: string): string {
 }
 
 /** Search-suggestion pills shown under the hero search field. */
+// Every pill must return results — a "Populært" suggestion that lands on an
+// empty state is a dead end. Verified against current help content.
 export const HELP_SEARCH_SUGGESTIONS = [
   "Yield",
   "Verdivurdering",
   "DCF",
   "Leiekontrakt",
-  "WAULT",
-  "Bodø",
+  "Felleskostnader",
+  "Markedsleie",
 ]
 
 /**

--- a/src/styles/advanti-design.css
+++ b/src/styles/advanti-design.css
@@ -10087,3 +10087,14 @@ h1, h2, h3 {
   .hs-sort { width: 100%; margin-left: 0; }
   .hs-herostats { gap: 32px; }
 }
+/* Honour reduce-motion for the v2 hover nudges + FAQ marker rotation. */
+@media (prefers-reduced-motion: reduce) {
+  .hs-path, .hs-path .steps a .sa, .hs-row, .hs-row .rarrow, .hs-res,
+  .hs-res .rarrow, .hs-pill, .hs-chip, .hs-sortbtn, .hs-search, .hs-minisearch,
+  .hs-faq-aside .askmore, .hs-qa summary::after, .art-toc a, .art-nav .cat .arts a,
+  .art-prevnext a, .ks-art-author .av {
+    transition: none !important;
+  }
+  .hs-row:hover { padding-left: 14px; padding-right: 14px; }
+  .hs-row:hover .rarrow, .hs-path .steps a:hover .sa { transform: none; }
+}

--- a/src/styles/advanti-design.css
+++ b/src/styles/advanti-design.css
@@ -9801,3 +9801,289 @@ h1, h2, h3 {
 @media print {
   .nav, .chk-progress .p-cta, .chk-progress .p-actions, .chk-progress .p-capture, .cta-strip, .footer, #tweaks-root { display: none !important; }
 }
+
+/* ============================================================
+   === Kunnskapssenter v2 ===
+   Hub (hs-*) + article docs-layout (art-*) ported from the
+   design prototype. Builds on existing tokens: --warm-grey,
+   --warm-white, --warm-grey-85, --warm-grey-75, --accent,
+   --accent-soft, --accent-faint, --font-display, --font-body,
+   --hairline. (--accent-ink falls back to #2c2825 inline.)
+   ============================================================ */
+
+/* ---- Big hero search + instant results ---- */
+.hs-searchwrap { position: relative; max-width: 760px; }
+.hs-search {
+  display: flex; align-items: center; gap: 16px;
+  background: var(--warm-white);
+  border: 1px solid var(--warm-grey);
+  border-radius: 4px; padding: 0 20px; height: 68px;
+  transition: box-shadow 0.2s, border-color 0.2s;
+}
+.hs-search:focus-within { border-color: var(--warm-grey); box-shadow: 0 0 0 4px var(--accent-soft); outline: none; }
+.hs-search .ic { width: 22px; height: 22px; flex-shrink: 0; color: var(--warm-grey-85); }
+.hs-search input {
+  flex: 1; min-width: 0; font-family: var(--font-body);
+  font-size: 19px; color: var(--warm-grey);
+  background: transparent; border: none; outline: none;
+}
+.hs-search input::placeholder { color: var(--warm-grey-85); }
+.hs-search .clr {
+  appearance: none; border: none; background: transparent;
+  color: var(--warm-grey-85); cursor: pointer;
+  font-size: 13px; letter-spacing: 0.04em;
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 6px 8px; border-radius: 4px;
+}
+.hs-search .clr:hover { color: var(--warm-grey); background: var(--accent-faint); }
+.hs-search .kbd {
+  font-family: var(--font-body); font-size: 11px; letter-spacing: 0.04em;
+  color: var(--warm-grey-85); border: 1px solid var(--warm-grey-75);
+  border-radius: 4px; padding: 4px 8px; white-space: nowrap;
+}
+
+.hs-results {
+  position: absolute; left: 0; right: 0; top: calc(100% + 10px);
+  z-index: 40; background: var(--warm-white);
+  border: 1px solid var(--warm-grey-75); border-radius: 6px;
+  box-shadow: 0 24px 60px -20px rgba(44,40,37,0.30), 0 4px 14px -8px rgba(44,40,37,0.2);
+  overflow: hidden;
+}
+.hs-results .rhead {
+  display: flex; justify-content: space-between; align-items: center;
+  padding: 14px 20px; border-bottom: var(--hairline);
+  font-size: 11px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--warm-grey-85);
+}
+.hs-res {
+  display: grid; grid-template-columns: 1fr auto; align-items: center; gap: 18px;
+  padding: 14px 20px; border-bottom: 1px solid rgba(215,208,200,0.5);
+  cursor: pointer; text-decoration: none; transition: background 0.12s;
+}
+.hs-res:last-child { border-bottom: none; }
+.hs-res.active, .hs-res:hover { background: var(--accent-faint); }
+.hs-res .rt {
+  font-family: var(--font-display); font-size: 17px; font-weight: 400;
+  letter-spacing: -0.01em; color: var(--warm-grey); line-height: 1.25;
+}
+.hs-res .rt mark { background: var(--accent); color: #2c2825; padding: 0 1px; border-radius: 2px; }
+.hs-res .rm { font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--warm-grey-85); margin-top: 4px; }
+.hs-res .rarrow { color: var(--warm-grey-85); font-size: 15px; }
+.hs-res.active .rarrow { color: var(--warm-grey); }
+.hs-res-empty { padding: 24px 20px; color: var(--warm-grey-85); font-size: 14.5px; }
+.hs-res-empty p { margin: 0; }
+.hs-res-empty strong { color: var(--warm-grey); font-weight: 600; }
+.hs-res-empty .sub { margin-top: 6px; font-size: 13.5px; line-height: 1.5; }
+.hs-res-cta {
+  display: inline-flex; align-items: center; gap: 7px; margin-top: 14px;
+  font-size: 13.5px; color: var(--warm-grey); text-decoration: none;
+  border: 1px solid var(--warm-grey); border-radius: 4px; padding: 9px 14px;
+  transition: background 0.15s, color 0.15s;
+}
+.hs-res-cta:hover { background: var(--warm-grey); color: var(--warm-white); }
+.hs-res-recent {
+  display: grid; grid-template-columns: 20px 1fr 16px; align-items: center; gap: 14px;
+  width: 100%; appearance: none; background: transparent; border: none; cursor: pointer;
+  text-align: left; font-family: var(--font-body); padding: 14px 20px;
+  border-bottom: 1px solid rgba(215,208,200,0.5);
+}
+.hs-res-recent:hover { background: var(--accent-faint); }
+.hs-res-recent .ric { color: var(--warm-grey-85); font-size: 14px; }
+.hs-res-recent .rt-plain { font-size: 15px; color: var(--warm-grey); }
+.hs-results .rclear { cursor: pointer; color: var(--warm-grey-85); appearance: none; background: none; border: none; font-size: 11px; letter-spacing: 0.08em; text-transform: uppercase; }
+.hs-results .rclear:hover { color: var(--warm-grey); }
+.hs-res-foot {
+  display: flex; justify-content: space-between; align-items: center;
+  padding: 12px 20px; background: var(--accent-faint);
+  font-size: 12px; color: var(--warm-grey-85);
+}
+.hs-res-foot kbd { font-family: var(--font-body); border: 1px solid var(--warm-grey-75); border-radius: 3px; padding: 1px 5px; margin: 0 2px; }
+
+.hs-suggest { display: flex; flex-wrap: wrap; align-items: center; gap: 10px; margin-top: 22px; }
+.hs-suggest .lbl { font-size: 11px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--warm-grey-85); margin-right: 4px; }
+.hs-pill {
+  appearance: none; cursor: pointer; font-family: var(--font-body); font-size: 13px;
+  color: var(--warm-grey-85); background: transparent;
+  border: 1px solid var(--warm-grey-75); border-radius: 999px; padding: 7px 14px;
+  transition: color 0.15s, border-color 0.15s, background 0.15s;
+}
+.hs-pill:hover { color: var(--warm-grey); border-color: var(--warm-grey); background: var(--accent-faint); }
+
+.hs-herostats { display: flex; gap: 48px; margin-top: 52px; border-top: var(--hairline); padding-top: 26px; flex-wrap: wrap; }
+.hs-herostats .s { display: flex; flex-direction: column; gap: 4px; }
+.hs-herostats .v { font-family: var(--font-display); font-size: 30px; font-weight: 400; letter-spacing: -0.02em; font-variant-numeric: tabular-nums; }
+.hs-herostats .v .unit { color: var(--accent); font-style: italic; font-weight: 300; font-size: 0.6em; margin-left: 2px; }
+.hs-herostats .l { font-size: 11px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--warm-grey-85); }
+
+/* ---- Start her: reading paths ---- */
+.hs-paths { display: grid; grid-template-columns: repeat(3, 1fr); border-top: var(--hairline); border-left: var(--hairline); }
+.hs-path { border-right: var(--hairline); border-bottom: var(--hairline); padding: 32px 30px 30px; display: flex; flex-direction: column; transition: background 0.3s; }
+.hs-path .pre { font-size: 11px; letter-spacing: 0.16em; text-transform: uppercase; color: var(--warm-grey-85); font-variant-numeric: tabular-nums; }
+.hs-path h3 { font-size: 25px; font-weight: 400; letter-spacing: -0.02em; line-height: 1.08; margin: 14px 0 8px; }
+.hs-path h3 .italic { font-style: italic; font-weight: 300; color: var(--warm-grey-85); }
+.hs-path > p { font-size: 14px; color: var(--warm-grey-85); line-height: 1.5; max-width: 34ch; margin-bottom: 22px; }
+.hs-path .steps { list-style: none; margin-top: auto; border-top: 1px solid rgba(215,208,200,0.6); }
+.hs-path .steps a { display: grid; grid-template-columns: 22px 1fr 16px; align-items: center; gap: 12px; padding: 12px 0; border-bottom: 1px solid rgba(215,208,200,0.6); text-decoration: none; color: var(--warm-grey); }
+.hs-path .steps a:last-child { border-bottom: none; }
+.hs-path .steps .sn { font-size: 11px; color: var(--warm-grey-85); font-variant-numeric: tabular-nums; }
+.hs-path .steps .st { font-size: 14px; line-height: 1.3; transition: color 0.15s; }
+.hs-path .steps .sa { color: var(--warm-grey-85); font-size: 13px; transition: transform 0.15s; }
+@media (hover: hover) {
+  .hs-path:hover { background: var(--accent-faint); }
+  .hs-path .steps a:hover .st { color: var(--warm-grey-85); }
+  .hs-path .steps a:hover .sa { transform: translateX(3px); color: var(--warm-grey); }
+}
+
+/* ---- Library: toolbar + index ---- */
+.hs-lib-head { display: flex; justify-content: space-between; align-items: flex-end; gap: 24px; flex-wrap: wrap; margin-bottom: 28px; }
+.hs-lib-head h2 { font-size: clamp(30px, 3.4vw, 46px); font-weight: 400; letter-spacing: -0.02em; line-height: 1.04; }
+.hs-lib-head h2 .italic { font-style: italic; font-weight: 300; color: var(--warm-grey-85); }
+.hs-count { font-size: 13px; color: var(--warm-grey-85); font-variant-numeric: tabular-nums; letter-spacing: 0.02em; white-space: nowrap; }
+.hs-count strong { color: var(--warm-grey); font-weight: 500; }
+
+.hs-toolbar { display: flex; gap: 16px; align-items: center; flex-wrap: wrap; padding-bottom: 18px; border-bottom: var(--hairline); margin-bottom: 4px; }
+.hs-minisearch { display: flex; align-items: center; gap: 10px; border: 1px solid var(--warm-grey-75); border-radius: 4px; padding: 0 12px; height: 44px; min-width: 230px; flex: 0 1 280px; transition: border-color 0.2s; }
+.hs-minisearch:focus-within { border-color: var(--warm-grey); }
+.hs-minisearch .ic { width: 16px; height: 16px; color: var(--warm-grey-85); flex-shrink: 0; }
+.hs-minisearch input { flex: 1; min-width: 0; border: none; outline: none; background: transparent; font-family: var(--font-body); font-size: 16px; color: var(--warm-grey); }
+.hs-minisearch input::placeholder { color: var(--warm-grey-85); }
+
+.hs-chips { display: flex; flex-wrap: wrap; gap: 8px; }
+.hs-chip {
+  appearance: none; cursor: pointer; font-family: var(--font-body); font-size: 12.5px; letter-spacing: 0.01em;
+  color: var(--warm-grey-85); background: transparent;
+  border: 1px solid var(--warm-grey-75); border-radius: 999px; padding: 9px 14px; min-height: 40px;
+  display: inline-flex; align-items: center; gap: 7px; transition: color 0.15s, border-color 0.15s, background 0.15s;
+}
+.hs-chip:hover { color: var(--warm-grey); border-color: var(--warm-grey); }
+.hs-chip .cn { font-variant-numeric: tabular-nums; font-size: 11px; color: var(--warm-grey-85); }
+.hs-chip[data-on="1"] { background: var(--warm-grey); border-color: var(--warm-grey); color: var(--warm-white); }
+.hs-chip[data-on="1"] .cn { color: rgba(243,241,239,0.6); }
+
+.hs-sort { margin-left: auto; display: inline-flex; align-items: center; gap: 4px; flex-wrap: wrap; }
+.hs-sort .lbl { font-size: 11px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--warm-grey-85); margin-right: 8px; }
+.hs-sortbtn { appearance: none; cursor: pointer; background: transparent; border: none; font-family: var(--font-body); font-size: 12.5px; color: var(--warm-grey-85); padding: 9px 10px; min-height: 40px; border-radius: 4px; transition: color 0.15s, background 0.15s; }
+.hs-sortbtn[data-on="1"] { color: var(--warm-grey); background: var(--accent-faint); font-weight: 500; }
+.hs-sortbtn:hover { color: var(--warm-grey); }
+
+.hs-index { display: flex; flex-direction: column; }
+.hs-row {
+  display: grid; grid-template-columns: 1fr 168px 64px 20px; align-items: center; gap: 28px;
+  padding: 22px 14px; border-bottom: var(--hairline);
+  text-decoration: none; color: var(--warm-grey); transition: background 0.15s, padding 0.15s;
+}
+.hs-row:first-child { border-top: var(--hairline); }
+.hs-row .rmain { min-width: 0; }
+.hs-row .rtag { font-size: 10.5px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--warm-grey-85); display: inline-flex; align-items: center; gap: 8px; margin-bottom: 9px; }
+.hs-row .rtag .dot { width: 4px; height: 4px; border-radius: 50%; background: var(--accent); display: inline-block; }
+.hs-row .rtitle { font-family: var(--font-display); font-size: 21px; font-weight: 400; letter-spacing: -0.015em; line-height: 1.18; color: var(--warm-grey); }
+.hs-row .rtitle mark { background: var(--accent); color: #2c2825; padding: 0 1px; border-radius: 2px; }
+.hs-row .rsum { font-size: 13.5px; color: var(--warm-grey-85); line-height: 1.5; margin-top: 7px; max-width: 70ch; }
+.hs-row .rauthor { font-size: 11px; letter-spacing: 0.06em; text-transform: uppercase; color: var(--warm-grey-85); text-align: right; line-height: 1.5; }
+.hs-row .rread { font-size: 12px; color: var(--warm-grey-85); text-align: right; font-variant-numeric: tabular-nums; white-space: nowrap; }
+.hs-row .rarrow { color: var(--warm-grey-85); justify-self: end; transition: transform 0.15s; }
+@media (hover: hover) {
+  .hs-row:hover { background: var(--accent-faint); padding-left: 22px; padding-right: 6px; }
+  .hs-row:hover .rarrow { color: var(--warm-grey); transform: translateX(3px); }
+}
+
+.hs-empty { padding: 64px 14px; text-align: center; border-bottom: var(--hairline); }
+.hs-empty .em-mark { font-family: var(--font-display); font-size: 44px; color: var(--warm-grey-75); }
+.hs-empty h4 { font-family: var(--font-display); font-size: 24px; font-weight: 400; margin: 12px 0 8px; }
+.hs-empty h4 .q { font-style: italic; color: var(--warm-grey-85); }
+.hs-empty p { font-size: 14.5px; color: var(--warm-grey-85); max-width: 44ch; margin: 0 auto 22px; line-height: 1.55; }
+.hs-empty-actions { display: inline-flex; gap: 12px; flex-wrap: wrap; justify-content: center; }
+.hs-empty .clearbtn { appearance: none; cursor: pointer; font-family: var(--font-body); font-size: 13.5px; background: var(--warm-grey); color: var(--warm-white); border: none; padding: 11px 20px; border-radius: 4px; }
+.hs-empty .clearbtn:hover { background: #0f0e0c; }
+.hs-empty .ghostbtn { appearance: none; cursor: pointer; font-family: var(--font-body); font-size: 13.5px; display: inline-flex; align-items: center; gap: 7px; background: transparent; color: var(--warm-grey); text-decoration: none; border: 1px solid var(--warm-grey); padding: 11px 20px; border-radius: 4px; }
+.hs-empty .ghostbtn:hover { background: var(--warm-grey); color: var(--warm-white); }
+
+/* ---- Quick answers (FAQ) ---- */
+.hs-faq-grid { display: grid; grid-template-columns: 0.9fr 1.5fr; gap: 64px; align-items: start; }
+.hs-faq-aside .eyebrow { margin-bottom: 24px; display: inline-flex; }
+.hs-faq-aside h2 { font-size: clamp(30px, 3.2vw, 44px); font-weight: 400; letter-spacing: -0.02em; line-height: 1.05; }
+.hs-faq-aside h2 .italic { font-style: italic; font-weight: 300; color: var(--warm-grey-85); }
+.hs-faq-aside p { font-size: 14.5px; color: var(--warm-grey-85); line-height: 1.6; margin-top: 20px; max-width: 38ch; }
+.hs-faq-aside .askmore { margin-top: 26px; display: inline-flex; align-items: center; gap: 8px; font-size: 14px; color: var(--warm-grey); text-decoration: none; border-bottom: 1px solid var(--warm-grey); padding-bottom: 2px; width: fit-content; transition: gap 0.15s; }
+.hs-faq-aside .askmore:hover { gap: 12px; }
+.hs-acc { border-top: var(--hairline); }
+.hs-qa { border-bottom: var(--hairline); }
+.hs-qa summary { list-style: none; cursor: pointer; display: flex; align-items: center; justify-content: space-between; gap: 24px; padding: 24px 0; font-family: var(--font-display); font-size: 20px; font-weight: 400; letter-spacing: -0.01em; color: var(--warm-grey); transition: color 0.2s; }
+.hs-qa summary::-webkit-details-marker { display: none; }
+.hs-qa summary::after { content: "+"; font-family: var(--font-display); font-size: 24px; font-weight: 300; color: var(--warm-grey-85); flex-shrink: 0; transition: transform 0.25s ease; }
+.hs-qa[open] summary::after { content: "−"; }
+.hs-qa summary:hover { color: var(--warm-grey-85); }
+.hs-qa .a { padding: 0 48px 28px 0; font-size: 15.5px; color: var(--warm-grey-85); line-height: 1.65; max-width: 64ch; }
+.hs-qa .a a { color: var(--warm-grey); border-bottom: 1px solid var(--warm-grey-75); }
+.hs-qa .a a:hover { border-color: var(--warm-grey); }
+.hs-qa .a .related { margin-top: 16px; display: inline-flex; align-items: center; gap: 8px; font-size: 13px; color: var(--warm-grey); border-bottom: 1px solid var(--warm-grey); padding-bottom: 2px; }
+
+/* ---- Article: docs-style left rail + body ---- */
+.art-shell { display: grid; grid-template-columns: 256px 1fr; gap: 72px; padding-top: 8px; }
+.art-rail { position: sticky; top: 100px; align-self: start; max-height: calc(100vh - 120px); overflow-y: auto; padding-bottom: 24px; }
+.art-rail::-webkit-scrollbar { width: 6px; }
+.art-rail::-webkit-scrollbar-thumb { background: var(--warm-grey-75); border-radius: 3px; }
+.art-toc { margin-bottom: 36px; }
+.art-toc .lbl, .art-nav .lbl { font-size: 11px; letter-spacing: 0.18em; text-transform: uppercase; color: var(--warm-grey-85); font-weight: 500; margin-bottom: 14px; padding-bottom: 12px; border-bottom: var(--hairline); }
+.art-toc a { display: block; padding: 7px 0 7px 14px; margin-left: -1px; font-size: 13.5px; color: var(--warm-grey-85); line-height: 1.4; border-left: 1px solid var(--warm-grey-75); transition: color 0.2s, border-color 0.2s; }
+.art-toc a.l3 { padding-left: 28px; font-size: 12.5px; }
+.art-toc a:hover { color: var(--warm-grey); }
+.art-toc a.active { color: var(--warm-grey); border-left-color: var(--accent); font-weight: 500; }
+.art-nav .lbl { margin-top: 4px; }
+.art-nav .cat { margin-bottom: 2px; }
+.art-nav .cat > .ct { display: flex; align-items: center; justify-content: space-between; gap: 10px; width: 100%; appearance: none; background: transparent; border: none; cursor: pointer; font-family: var(--font-body); text-align: left; padding: 9px 0; font-size: 14px; color: var(--warm-grey); border-bottom: 1px solid rgba(215,208,200,0.5); text-decoration: none; }
+.art-nav .cat > .ct .cc { font-size: 11px; color: var(--warm-grey-85); font-variant-numeric: tabular-nums; }
+.art-nav .cat > .ct:hover { color: var(--warm-grey-85); }
+.art-nav .cat.active > .ct { font-weight: 600; }
+.art-nav .cat .arts { overflow: hidden; padding: 4px 0 12px; }
+.art-nav .cat .arts a { display: block; padding: 7px 0 7px 12px; font-size: 13px; line-height: 1.35; color: var(--warm-grey-85); border-left: 1px solid var(--warm-grey-75); transition: color 0.15s, border-color 0.15s; }
+.art-nav .cat .arts a:hover { color: var(--warm-grey); }
+.art-nav .cat .arts a.current { color: var(--warm-grey); font-weight: 500; border-left-color: var(--accent); }
+.art-rail-services { margin-top: 36px; }
+.art-rail-services .lbl { font-size: 11px; letter-spacing: 0.18em; text-transform: uppercase; color: var(--warm-grey-85); font-weight: 500; margin-bottom: 12px; padding-bottom: 10px; border-bottom: var(--hairline); }
+.art-rail-services a { display: block; padding: 6px 0; font-size: 13px; color: var(--warm-grey-85); transition: color 0.15s; }
+.art-rail-services a:hover { color: var(--warm-grey); }
+
+.art-updated { display: inline-flex; align-items: center; gap: 6px; color: var(--warm-grey-85); }
+.art-updated .pip { width: 6px; height: 6px; border-radius: 50%; background: oklch(0.7 0.13 150); display: inline-block; }
+
+.art-kort { margin: 8px 0 48px; border: var(--hairline); border-left: 3px solid var(--accent); background: var(--accent-faint); padding: 26px 30px; border-radius: 4px; }
+.art-kort .lbl { font-size: 11px; letter-spacing: 0.18em; text-transform: uppercase; color: var(--warm-grey-85); font-weight: 500; margin-bottom: 16px; }
+.art-kort ul { list-style: none; display: flex; flex-direction: column; gap: 12px; }
+.art-kort li { display: grid; grid-template-columns: 22px 1fr; gap: 8px; font-size: 15.5px; line-height: 1.5; color: var(--warm-grey); }
+.art-kort li .n { font-family: var(--font-display); font-style: italic; color: #2c2825; font-size: 15px; }
+
+.art-prevnext { display: grid; grid-template-columns: 1fr 1fr; gap: 0; border-top: var(--hairline); margin-top: 56px; }
+.art-prevnext a { display: flex; flex-direction: column; gap: 8px; padding: 28px 24px; text-decoration: none; color: var(--warm-grey); transition: background 0.2s; }
+.art-prevnext a:hover { background: var(--accent-faint); }
+.art-prevnext a.next { text-align: right; align-items: flex-end; border-left: var(--hairline); }
+.art-prevnext .dir { font-size: 11px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--warm-grey-85); }
+.art-prevnext .ti { font-family: var(--font-display); font-size: 19px; font-weight: 400; letter-spacing: -0.012em; line-height: 1.2; }
+
+.art-feedback-done { font-size: 14px; color: var(--warm-grey-85); }
+
+/* ---- Kunnskapssenter v2: focus, responsive ---- */
+.hs-pill:focus-visible, .hs-chip:focus-visible, .hs-sortbtn:focus-visible,
+.hs-res:focus-visible, .hs-row:focus-visible, .hs-qa summary:focus-visible,
+.hs-search input:focus-visible, .hs-empty .clearbtn:focus-visible,
+.hs-empty .ghostbtn:focus-visible, .hs-res-cta:focus-visible {
+  outline: 2px solid var(--warm-grey); outline-offset: 2px; border-radius: 4px;
+}
+@media (max-width: 980px) {
+  .hs-paths { grid-template-columns: 1fr; border-left: 0; }
+  .hs-path { border-right: 0; }
+  .hs-faq-grid { grid-template-columns: 1fr; gap: 36px; }
+  .art-shell { grid-template-columns: 1fr; gap: 32px; }
+  .art-rail { position: static; max-height: none; order: 2; border-top: var(--hairline); padding-top: 24px; }
+  .art-toc { display: none; }
+  .art-prevnext { grid-template-columns: 1fr; }
+  .art-prevnext a.next { text-align: left; align-items: flex-start; border-left: 0; border-top: var(--hairline); }
+}
+@media (max-width: 760px) {
+  .hs-row { grid-template-columns: 1fr 20px; gap: 14px; }
+  .hs-row .rauthor, .hs-row .rread { display: none; }
+  .hs-search { height: 60px; padding: 0 16px; }
+  .hs-search input { font-size: 16px; }
+  .hs-search .kbd { display: none; }
+  .hs-sort { width: 100%; margin-left: 0; }
+  .hs-herostats { gap: 32px; }
+}

--- a/tests/unit/helpData.test.ts
+++ b/tests/unit/helpData.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from "vitest"
+
+import {
+  getOrderedHelpPosts,
+  helpNeighbours,
+  helpCategoryTitle,
+  HELP_CATEGORY_META,
+} from "@/lib/blog/help-data"
+
+type Post = { slug: string; title: string; categories: string[] }
+
+// Deliberately unsorted: category order is overview → getting-started → terms →
+// for-investors → analysis → valuation (HELP_CATEGORY_META), then title (nb).
+const POSTS: Post[] = [
+  { slug: "zeta", title: "Zeta", categories: ["valuation"] },
+  { slug: "yield", title: "Yield", categories: ["terms"] },
+  { slug: "aksje", title: "Åpning", categories: ["terms"] },
+  { slug: "advanti", title: "Advanti", categories: ["overview"] },
+  { slug: "alfa", title: "Alfa", categories: ["terms"] },
+  { slug: "invest", title: "Invest", categories: ["for-investors"] },
+]
+
+describe("getOrderedHelpPosts()", () => {
+  it("orders by category index then title (nb collation, deterministic)", () => {
+    const ordered = getOrderedHelpPosts(POSTS).map((p) => p.slug)
+    // overview, then terms (Alfa < Yield < Åpning in nb), then for-investors, then valuation
+    expect(ordered).toEqual([
+      "advanti",
+      "alfa",
+      "yield",
+      "aksje",
+      "invest",
+      "zeta",
+    ])
+  })
+
+  it("is a pure sort — does not mutate the input array", () => {
+    const input = [...POSTS]
+    getOrderedHelpPosts(input)
+    expect(input.map((p) => p.slug)).toEqual(POSTS.map((p) => p.slug))
+  })
+
+  it("puts unknown categories last without throwing", () => {
+    const withUnknown = [
+      { slug: "weird", title: "Weird", categories: ["nope"] },
+      ...POSTS,
+    ]
+    const ordered = getOrderedHelpPosts(withUnknown).map((p) => p.slug)
+    expect(ordered[ordered.length - 1]).toBe("weird")
+  })
+})
+
+describe("helpNeighbours()", () => {
+  it("returns the adjacent posts in the deterministic order", () => {
+    const { prev, next } = helpNeighbours(POSTS, "yield")
+    expect(prev?.slug).toBe("alfa")
+    expect(next?.slug).toBe("aksje")
+  })
+
+  it("first post has no prev, last has no next", () => {
+    expect(helpNeighbours(POSTS, "advanti").prev).toBeNull()
+    expect(helpNeighbours(POSTS, "zeta").next).toBeNull()
+  })
+
+  it("returns nulls for an unknown slug", () => {
+    expect(helpNeighbours(POSTS, "missing")).toEqual({ prev: null, next: null })
+  })
+})
+
+describe("helpCategoryTitle()", () => {
+  it("maps known slugs to their labels", () => {
+    expect(helpCategoryTitle("terms")).toBe("Begreper")
+    expect(helpCategoryTitle("valuation")).toBe("Verdivurdering")
+  })
+
+  it("falls back to a neutral label for unknown/undefined", () => {
+    expect(helpCategoryTitle("nope")).toBe("Artikkel")
+    expect(helpCategoryTitle(undefined)).toBe("Artikkel")
+  })
+
+  it("HELP_CATEGORY_META covers all six help categories", () => {
+    expect(HELP_CATEGORY_META).toHaveLength(6)
+  })
+})

--- a/tests/unit/helpData.test.ts
+++ b/tests/unit/helpData.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest"
 
 import {
+  foldNo,
   getOrderedHelpPosts,
   helpNeighbours,
   helpCategoryTitle,
@@ -19,6 +20,24 @@ const POSTS: Post[] = [
   { slug: "alfa", title: "Alfa", categories: ["terms"] },
   { slug: "invest", title: "Invest", categories: ["for-investors"] },
 ]
+
+describe("foldNo()", () => {
+  it("lets ASCII input match Norwegian special characters", () => {
+    // The whole point: a user typing without æ/ø/å still matches.
+    expect(foldNo("Hva er næringseiendom").includes(foldNo("naring"))).toBe(true)
+    expect(foldNo("Næringsmarkedet i Bodø").includes(foldNo("bodo"))).toBe(true)
+    expect(foldNo("Driftsøkonomi").includes(foldNo("drifts"))).toBe(true)
+  })
+
+  it("is case-insensitive and idempotent on plain ASCII", () => {
+    expect(foldNo("YIELD")).toBe("yield")
+    expect(foldNo(foldNo("Felleskostnader"))).toBe("felleskostnader")
+  })
+
+  it("folds æ→a, ø→o, å→a", () => {
+    expect(foldNo("æøå")).toBe("aoa")
+  })
+})
 
 describe("getOrderedHelpPosts()", () => {
   it("orders by category index then title (nb collation, deterministic)", () => {


### PR DESCRIPTION
## Kunnskapssenter v2 — design port (hub + article id-page)

Ports the approved **Kunnskapssenter v2** design onto the existing MDX-backed `/help` route group. The existing pages already used this design language (`ks-*` classes, `SubHero`, `CtaStrip`); v2 is the evolution. Content model and taxonomy are unchanged — only the visual/UX patterns are ported.

### Hub (`/help`)
- **Search combobox**: instant results (title + category + reading time), suggestion pills, recent searches (localStorage), `↑/↓` keyboard nav, empty-state → contact CTA, hero stat rail.
- **"Start her"** — 3 intent-based reading paths mapped to real article slugs.
- **Library index** — filterable list of all 27 articles: category chips with counts, sort (Mest lest / Nyeste / A–Å, deterministic), minisøk, empty state, "se hele kategorien" deep-link.
- **"Hurtigsvar" FAQ** — server-rendered `<details>` accordion + `FAQPage` JSON-LD (answer text mirrors the visible answer; "Les mer" links are a separate affordance).

### Article (`/help/article/[slug]`)
- Docs-style **left rail**: scroll-spy TOC + category nav (only the active category expanded), related-services block.
- **"Kort fortalt"** takeaways (new optional `takeaways` frontmatter; populated on the flagship article).
- Interactive **feedback** widget (dataLayer event), **prev/next** across a deterministic ordering, related articles.

### Architecture / quality
- New plain `src/lib/blog/help-data.ts` keeps client components off `content-collections` (the JSX-icon + collections import would otherwise bloat client JS); server pages pass plain DTOs.
- `prefetch={false}` on index rows + collapsed nav links (avoids prefetching all 27 routes on load — article JS budget measured 593 KB < 710 KB).
- Analytics via the shared `trackEvent`/`dataLayer` helper. No duplicate BreadcrumbList JSON-LD (article keeps the existing `<Breadcrumbs>`).

### Reviews & verification
- `/plan-eng-review`: 13 findings, all folded in (client/server boundary, deterministic sort, FAQ JSON-LD split, etc.) + Codex outside-voice.
- `/plan-design-review`: 7-pass, 7/10 → 9/10, no AI-slop hard-rejections.
- `pnpm build` + `pnpm typecheck` green. Unit: 172 pass (incl. new `helpData` ordering/neighbours tests). E2e (relevant subset): structured-data, routes, seo-meta, perf-budget, mobile-overflow `/help` — all green. `/qa`: 0 console errors, 0 bugs across hub + article (search, chips, sort, minisøk, FAQ, TOC scroll-spy, feedback, prev/next, mobile).

Full plan: `plans/013-kunnskapssenter-v2-design.md`.

> Note (for the owner): the Hurtigsvar FAQ keeps the design's verdivurdering price range (15 000–40 000 kr). It's a service price, not a market figure — adjust the copy in `src/lib/blog/help-data.ts` if you'd rather not publish it.

> Tests: I ran the relevant e2e specs rather than the full Playwright suite, which has documented pre-existing `/blog` + `/markedsinnsikt` mobile-overflow failures on `main` unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Key Takeaways" section to help articles for quick reference.
  * Enhanced help article pages with a left-sidebar table of contents with scroll-spy navigation.
  * Introduced interactive article feedback (Yes/No helpful voting) with analytics tracking.
  * Redesigned knowledge center hub with new sections: reading paths, curated library with search/filtering/sorting, and quick-answer FAQ.
  * Improved search with popular articles, recent searches, and reading time estimates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->