### PR TITLE
feat(nav): primary CTA → Til Analyseportal (/analyseportal)

### DIFF
--- a/src/components/site/Nav.tsx
+++ b/src/components/site/Nav.tsx
@@ -616,12 +616,12 @@ export function Nav({ groups }: NavProps) {
 
         <div className="nav-right">
           <Link
-            href="/verdivurdering"
+            href="/analyseportal"
             className="nav-cta"
-            onClick={() => trackEvent("cta_verdivurdering", { source: "nav" })}
+            onClick={() => trackEvent("cta_analyseportal", { source: "nav" })}
             onMouseEnter={scheduleClose}
           >
-            <span>Få verdivurdering</span>
+            <span>Til Analyseportal</span>
             <span className="arrow">→</span>
           </Link>
 
@@ -786,14 +786,14 @@ export function Nav({ groups }: NavProps) {
 
         <Link
           prefetch={false}
-          href="/verdivurdering"
+          href="/analyseportal"
           className="nav-cta nav-mobile-cta"
           onClick={() => {
             setMenuOpen(false);
-            trackEvent("cta_verdivurdering", { source: "nav_mobile" });
+            trackEvent("cta_analyseportal", { source: "nav_mobile" });
           }}
         >
-          <span>Få verdivurdering</span>
+          <span>Til Analyseportal</span>
           <span className="arrow">→</span>
         </Link>
       </div>

--- a/tests/nav.spec.ts
+++ b/tests/nav.spec.ts
@@ -10,7 +10,7 @@ import { REGISTRY } from "../src/lib/navigation";
  *  - Click-outside closes the open panel
  *  - Closed-group links are present in DOM (SSR crawlability)
  *  - Active trail: data-active on group button, aria-current on leaf links
- *  - Analytics events: nav_group_open and cta_verdivurdering fire
+ *  - Analytics events: nav_group_open and cta_analyseportal fire
  *  - SSR: GET / contains all inNav hrefs in initial HTML
  *  - Mobile (320×568): hamburger, inline accordion, last link + CTA reachable
  */
@@ -161,7 +161,7 @@ test.describe("Desktop nav groups", () => {
     await expect(leaf).toHaveAttribute("aria-current", "page");
   });
 
-  test("analytics: nav_group_open and cta_verdivurdering events fire", async ({
+  test("analytics: nav_group_open and cta_analyseportal events fire", async ({
     page,
   }) => {
     // Capture dataLayer pushes before the page loads.
@@ -183,7 +183,11 @@ test.describe("Desktop nav groups", () => {
     );
     expect(groupEvent).toBeDefined();
 
-    // Click the CTA — should push cta_verdivurdering
+    // The CTA points at the analyseportal and fires cta_analyseportal.
+    await expect(page.locator(".nav-cta").first()).toHaveAttribute(
+      "href",
+      "/analyseportal",
+    );
     await page.locator(".nav-cta").first().click();
     const dlAfterCta = await page.evaluate(
       () => (window as { dataLayer?: unknown[] }).dataLayer ?? [],
@@ -192,7 +196,7 @@ test.describe("Desktop nav groups", () => {
       (e) =>
         typeof e === "object" &&
         e !== null &&
-        (e as Record<string, unknown>).event === "cta_verdivurdering",
+        (e as Record<string, unknown>).event === "cta_analyseportal",
     );
     expect(ctaEvent).toBeDefined();
   });

--- a/tests/verdivurdering-reise.spec.ts
+++ b/tests/verdivurdering-reise.spec.ts
@@ -1,17 +1,17 @@
 import { test, expect, type APIRequestContext } from "@playwright/test";
 
 /**
- * Verdivurdering-reise — fase 4 nav/IA-redesign.
+ * Markedsinnsikt-/SeOgsa-reise — fase 4 nav/IA-redesign.
+ *
+ * NB: Forsidenavets CTA peker nå til /analyseportal (ikke /verdivurdering),
+ * så den gamle nav-CTA→/verdivurdering-reisen (tidligere a–c) er pensjonert.
+ * CTA-destinasjon + cta_analyseportal-eventet dekkes nå av tests/nav.spec.ts.
  *
  * Dekker:
- *  a. Forsidenavets CTA har href /verdivurdering (desktop + mobil)
- *  b. Journey-gang: / → CTA-klikk → /verdivurdering; intake-skjema +
- *     sjekkliste- og kalkulator-støttelenker er synlige på destinasjonssiden
- *  c. Analytics: stub dataLayer, klikk CTA, assert cta_verdivurdering med
- *     source-prop
  *  d. Se også på /naringsmegler/bodo: «Forstå markedet»-blokk viser ≤ 3 lenker,
  *     alle hrefs er reelle (ikke href="#")
  *  e. Lenkeintegritet: alle kurerte SeOgsa-hrefs returnerer ikke 404
+ *  f. Analytics: journey_step + seogsa_click
  */
 
 test.beforeEach(async ({ page }) => {
@@ -19,86 +19,6 @@ test.beforeEach(async ({ page }) => {
     /imagedelivery\.net|avatar\.vercel\.sh|\/_next\/image|basemaps\.cartocdn\.com/,
     (route) => route.abort(),
   );
-});
-
-// ── a. CTA href ───────────────────────────────────────────────────────────────
-
-test.describe("CTA href — /verdivurdering", () => {
-  test("desktop nav CTA peker til /verdivurdering", async ({ page }) => {
-    await page.setViewportSize({ width: 1280, height: 800 });
-    await page.goto("/");
-    // .nav-cta er den synlige CTA-knappen i desktop-headeren
-    const cta = page.locator(".nav-cta").first();
-    await expect(cta).toHaveAttribute("href", "/verdivurdering");
-  });
-
-  test("mobil nav CTA (320×568) peker til /verdivurdering", async ({ page }) => {
-    await page.setViewportSize({ width: 320, height: 568 });
-    await page.goto("/");
-    await page.getByRole("button", { name: "Åpne meny" }).click();
-    const cta = page.locator(".nav-mobile-cta");
-    await expect(cta).toHaveAttribute("href", "/verdivurdering");
-  });
-});
-
-// ── b. Journey-gang ───────────────────────────────────────────────────────────
-
-test("journey: / → CTA-klikk → /verdivurdering med skjema + støttelenker", async ({
-  page,
-}) => {
-  await page.setViewportSize({ width: 1280, height: 800 });
-  await page.goto("/");
-
-  // Klikk CTA og vent på at navigasjonen til verdivurderingssiden er ferdig
-  await Promise.all([
-    page.waitForURL("**/verdivurdering"),
-    page.locator(".nav-cta").first().click(),
-  ]);
-
-  // Intake-skjemaet skal være synlig (delt VerdivurderingIntakeForm)
-  await expect(
-    page.getByRole("heading", { name: "Be om verdivurdering." }),
-  ).toBeVisible();
-
-  // Sjekkliste- og kalkulator-støttelenker i hero
-  await expect(
-    page.locator('a[href="/sjekkliste-verdivurdering"]').first(),
-  ).toBeVisible();
-  await expect(
-    page.locator('a[href="/verktoy/naringskalkulator"]').first(),
-  ).toBeVisible();
-});
-
-// ── c. Analytics ──────────────────────────────────────────────────────────────
-
-test("analytics: cta_verdivurdering fyres med source-prop ved CTA-klikk", async ({
-  page,
-}) => {
-  await page.setViewportSize({ width: 1280, height: 800 });
-
-  // Installer dataLayer-stub FØR siden laster
-  await page.addInitScript(() => {
-    (window as { dataLayer?: unknown[] }).dataLayer = [];
-  });
-
-  await page.goto("/");
-
-  // Klikk CTA (navigerer til /verktoy/pris-verdivurdering via CSR)
-  await page.locator(".nav-cta").first().click();
-
-  // Evaluer dataLayer — Next.js CSR bevarer arrayen på tvers av klient­navigasjon
-  const events = await page.evaluate(
-    () => (window as { dataLayer?: unknown[] }).dataLayer ?? [],
-  );
-
-  const ctaEvent = events.find(
-    (e) =>
-      typeof e === "object" &&
-      e !== null &&
-      (e as Record<string, unknown>).event === "cta_verdivurdering" &&
-      (e as Record<string, unknown>).source !== undefined,
-  );
-  expect(ctaEvent).toBeDefined();
 });
 
 // ── d. Se også — /naringsmegler/bodo ─────────────────────────────────────────


### PR DESCRIPTION
## Nav-CTA → Analyseportal

Den primære nav-CTA-en øverst (desktop + mobil) er endret fra **«Få verdivurdering»** til **«Til Analyseportal»**, og lenker nå til `/analyseportal`.

- Begge nav-CTA-instansene oppdatert (desktop `.nav-cta` + mobil `.nav-mobile-cta`).
- Analytics-event omdøpt `cta_verdivurdering` → `cta_analyseportal` (samme `source`-props: `nav` / `nav_mobile`). **GTM/GA4:** oppdater evt. trigger som lyttet på `cta_verdivurdering` for denne knappen.
- Den kontekstuelle CTA-en inne i Tjenester-panelet («Få verdivurdering» → `/verktoy/pris-verdivurdering`) er **uendret**.

### Bevisst konsekvens (eier-godkjent)
Nav-CTA-en var eneste interne lenke til `/analyseportal`... nei — til `/verdivurdering` (intake-skjemaet). Den siden er nå kun tilgjengelig via direkte URL (`inNav:false, inFooter:false`). Eier valgte «erstatt helt»: analyseportal er ny primær-CTA.

### Tester
- `nav.spec.ts`: CTA-analytics-testen asserter nå `cta_analyseportal` + `href="/analyseportal"`.
- `verdivurdering-reise.spec.ts`: de tre nav-CTA→`/verdivurdering`-delene (a/b/c) er pensjonert; SeOgsa-, lenkeintegritets- og journey_step-delene (d/e/f) beholdt.
- 21/21 Playwright-tester grønne (nav + reise), build + typecheck grønt.

`/analyseportal` er en offentlig, indeksert side (markedsdata + SEO-metadata) — ingen innloggingsvegg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the main navigation call-to-action to direct to Analysis Portal with a new label and refreshed analytics tracking across desktop and mobile navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->