### PR TITLE
feat(blog): Advisor contact card + Mo i Rana editorial upgrade

### DIFF
--- a/content-collections.ts
+++ b/content-collections.ts
@@ -71,6 +71,10 @@ const BlogPost = defineCollection({
     seoDescription: z.string().optional(),
     author: z.string(),
     summary: z.string(),
+    // When true, the article renders its own <Advisor> inline (e.g. a
+    // localized contact card under a "Kontakt" section), so the blog page
+    // suppresses the global author advisor card to avoid showing it twice.
+    advisorInline: z.boolean().default(false),
     related: z.array(z.string()).optional(),
     githubRepos: z.array(z.string()).optional(),
     tweetIds: z.array(z.string()).optional(),

--- a/src/app/(blog)/blog/(post)/[slug]/page.tsx
+++ b/src/app/(blog)/blog/(post)/[slug]/page.tsx
@@ -1,3 +1,4 @@
+import { Advisor } from "@/components/blog/Advisor";
 import { ArticleToc } from "@/components/blog/ArticleToc";
 import { MDX } from "@/components/blog/mdx";
 import ScrollProgress from "@/components/blog/scroll-progress";
@@ -9,7 +10,8 @@ import { getBlurDataURL } from "@/lib/blog/images";
 import { calculateReadingTime } from "@/lib/blog/utils";
 import { constructMetadata } from "@/lib/utils";
 import { getBlogPost } from "@/lib/content";
-import { AUTHORS, getAuthorName } from "@/lib/authors";
+import { AUTHORS, getAuthorName, resolveAuthorCard } from "@/lib/authors";
+import { siteConfig } from "@/app/siteConfig";
 import { allBlogPosts } from "content-collections";
 import { Metadata } from "next";
 import Link from "next/link";
@@ -118,6 +120,10 @@ export default async function BlogArticle({
     : null;
   const authorMeta = AUTHORS[data.author];
   const authorName = getAuthorName(data.author);
+  const advisorCard = resolveAuthorCard(data.author);
+  const { streetAddress, postalCode, addressLocality } =
+    siteConfig.contact.address;
+  const advisorAddress = `${siteConfig.name} · ${streetAddress}, ${postalCode} ${addressLocality}`;
   const toc = data.tableOfContents ?? [];
 
   return (
@@ -244,21 +250,17 @@ export default async function BlogArticle({
                 }))}
               />
 
-              {/* Author footer */}
-              {authorMeta && (
-                <div
-                  className="ks-art-author"
-                  style={{ marginTop: 64, marginBottom: 0 }}
-                >
-                  <div
-                    className="av"
-                    style={{ backgroundImage: `url('${authorMeta.image}')` }}
-                  />
-                  <div className="meta">
-                    <span className="name">{authorMeta.name}</span>
-                    <span className="role">{authorMeta.role}</span>
-                  </div>
-                </div>
+              {/* Advisor card — rendered globally from the author's profile,
+                  unless the article placed its own inline (advisorInline). */}
+              {!data.advisorInline && advisorCard && (
+                <Advisor
+                  name={advisorCard.name}
+                  role={advisorCard.role}
+                  portrait={advisorCard.portrait}
+                  address={advisorAddress}
+                  phone={advisorCard.phone}
+                  email={advisorCard.email}
+                />
               )}
 
               {/* Related */}

--- a/src/components/blog/Advisor.tsx
+++ b/src/components/blog/Advisor.tsx
@@ -1,0 +1,88 @@
+import Link from "next/link";
+import BlurImage from "@/lib/blog/blur-image";
+
+/**
+ * Advisor — editorial contact card (the `.ae-advisor` block).
+ *
+ * Used two ways, both via this one component so the card stays consistent:
+ *  - Globally on every blog article (rendered by the post page from the
+ *    author's resolved profile), and
+ *  - Inline inside an MDX article that wants a localized card (e.g. a
+ *    "Din rådgiver i <by>" card under a Kontakt section). Such an article
+ *    sets `advisorInline: true` in frontmatter so the page skips the global one.
+ *
+ * Typed props only (no `children` escape hatch) so MDX authors can't break the
+ * card's consistency. When phone/email are absent it falls back to a single
+ * "Kontakt oss" link — never an empty `tel:`/`mailto:`.
+ */
+export interface AdvisorProps {
+  name: string;
+  role: string;
+  /** Portrait URL — always provide one (author avatar), never undefined. */
+  portrait: string;
+  label?: string;
+  /** Company + address line, e.g. "Advanti Estate · Dronningens gate 18, 8006 Bodø". */
+  address?: string;
+  /** Display phone, e.g. "+47 984 53 571". The href is normalized to digits. */
+  phone?: string;
+  email?: string;
+  /** Fallback link target when phone/email are missing. */
+  contactHref?: string;
+}
+
+export function Advisor({
+  name,
+  role,
+  portrait,
+  label = "Din rådgiver",
+  address,
+  phone,
+  email,
+  contactHref = "/kontakt",
+}: AdvisorProps) {
+  const telHref = phone ? `tel:${phone.replace(/[^\d+]/g, "")}` : null;
+  const mailHref = email ? `mailto:${email.toLowerCase()}` : null;
+  const hasDirectContact = Boolean(telHref || mailHref);
+
+  return (
+    <div className="ae-advisor">
+      <div className="ae-portrait">
+        <BlurImage src={portrait} alt={name} width={128} height={160} />
+      </div>
+      <div>
+        <span className="ae-ad-label">{label}</span>
+        <h4>{name}</h4>
+        <div className="ae-ad-role">{role}</div>
+        <div className="ae-ad-contact">
+          {address && (
+            <>
+              {address}
+              <br />
+            </>
+          )}
+          {hasDirectContact ? (
+            <>
+              {telHref && (
+                <>
+                  Telefon: <a href={telHref}>{phone}</a>
+                  {mailHref && " · "}
+                </>
+              )}
+              {mailHref && (
+                <>
+                  E&#8209;post: <a href={mailHref}>{email}</a>
+                </>
+              )}
+            </>
+          ) : (
+            <Link href={contactHref}>
+              Kontakt oss <span aria-hidden="true">&rarr;</span>
+            </Link>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default Advisor;

--- a/src/components/blog/mdx.tsx
+++ b/src/components/blog/mdx.tsx
@@ -9,6 +9,7 @@ import BlurImage from "@/lib/blog/blur-image"
 import { HELP_CATEGORIES, POPULAR_ARTICLES } from "@/lib/blog/content"
 import { cx } from "@/lib/utils"
 
+import { Advisor } from "./Advisor"
 import CategoryCard from "./category-card"
 import CopyBox from "./copy-box"
 import HelpArticleLink from "./help-article-link"
@@ -602,6 +603,7 @@ const components = {
   Compare,
   ReadMore,
   Changelog,
+  Advisor,
   CopyBox,
   HelpArticles: (props: { articles: string[] }) => (
     <div className="grid gap-2 rounded-xl border border-warm-grey-2/20 bg-warm-grey-2/10 p-4">

--- a/src/content/blog/naringseiendomsmarkedet-mo-i-rana-2026.mdx
+++ b/src/content/blog/naringseiendomsmarkedet-mo-i-rana-2026.mdx
@@ -1,11 +1,13 @@
 ---
 title: "Næringseiendomsmarkedet i Mo i Rana 2026: industri, yield og leiepriser"
 publishedAt: "2026-06-08"
+updatedAt: "2026-06-14"
 summary: Markedsoversikt for næringseiendom i Mo i Rana — yield, leiepriser og ledighet per segment, med vekt på industri- og logistikkmarkedet rundt Mo Industripark.
 image: /building/pexels-bw-facade-35770652.jpg
 author: codehagen
 categories:
   - market-analysis
+advisorInline: true
 related:
   - naringseiendomsmarkedet-bodo-2025
   - markedspuls-nord-norge-2025-2026
@@ -14,7 +16,7 @@ slug: naringseiendomsmarkedet-mo-i-rana-2026
 
 Mo i Rana er administrasjonssenteret i Rana og et av Nord-Norges viktigste industriknutepunkt. Med Mo Industripark som motor, betydelige investeringer i grønn industri og gode transportforbindelser via Nordlandsbanen og E6, har byen et næringseiendomsmarked med tydelig vekt på industri-, lager- og kombinasjonsbygg — i tillegg til sentrumsnær kontor- og handelseiendom.
 
-Denne analysen gir en oversikt over markedet per Q4 2025: yield-nivåer, leiepriser og ledighet, med særskilt blikk på industri- og logistikksegmentet.
+Denne analysen gir en oversikt over markedet per Q4 2025: yield-nivåer, leiepriser og ledighet, med særskilt blikk på industri- og logistikksegmentet. Ønsker du en lokal vurdering, se vår side for [næringsmegler i Mo i Rana](/naringsmegler/mo-i-rana).
 
 <StatStrip
   items={[
@@ -24,6 +26,10 @@ Denne analysen gir en oversikt over markedet per Q4 2025: yield-nivåer, leiepri
     { value: "1 100–1 700", unit: "kr/m²/år", label: "Kontorleie høy standard" },
   ]}
 />
+
+<Figure n="Fig. 01" caption="Mo i Rana kombinerer et sentrumsnært kontor- og handelsmarked med et stort industri- og logistikksegment forankret i Mo Industripark.">
+  <Image src="/building/pexels-grayscale-high-rise-14387919.jpg" alt="Næringsbygg som illustrerer eiendomsmarkedet i Mo i Rana" width={1280} height={720} />
+</Figure>
 
 ## Yield og leiepriser (Q4 2025)
 
@@ -40,6 +46,31 @@ Som et mindre og mer industriavhengig marked prises Mo i Rana høyere enn Bodø 
 
 *Tall er indikative og reflekterer prime kvalitet. Kilde: Advanti markedsdata (Q4 2025).*
 
+<Note variant="caution">
+Mo i Rana er et mindre og mindre likvid marked enn Bodø og Tromsø. Få transaksjoner gjør at yield- og leieintervallene er indikative og kan variere mer fra eiendom til eiendom enn i de større byene. Bruk tallene som retning, ikke som en fasit for den enkelte eiendommen.
+</Note>
+
+Avkastningskravet henger tett sammen med kontraktslengde og leietakerkvalitet. Et nytt kombinasjonsbygg med en solid leietaker og lang kontrakt prises i nedre del av intervallet, mens et eldre verkstedbygg med kort gjenværende leietid prises i øvre del — eller høyere.
+
+## Slik prises eiendommen — et regneeksempel
+
+Den vanligste måten å sette en markedsverdi på et utleid næringsbygg er å dele netto leieinntekt på et avkastningskrav (yield). Eksempelet under viser hvordan et moderne kombinasjonsbygg i logistikksegmentet kan verdsettes med tallene over.
+
+<Example
+  title="Kombinasjonsbygg, logistikk — 2 000 m²"
+  steps={[
+    { label: "Utleibart areal", value: "2 000 m²" },
+    { label: "Markedsleie", calculation: "× 2 000 m²", value: "900 kr/m²/år" },
+    { label: "Brutto leieinntekt", value: "1 800 000 kr/år" },
+    { label: "Eierkostnader (10 %)", calculation: "drift, vedlikehold, adm.", value: "−180 000 kr/år" },
+    { label: "Netto leieinntekt", value: "1 620 000 kr/år" },
+    { label: "Yield-krav (netto)", calculation: "÷ 0,075", value: "7,5 %" },
+    { label: "Estimert markedsverdi", value: "21 600 000 kr", isResult: true },
+  ]}
+/>
+
+Regnestykket illustrerer hvor følsom verdien er for yield-kravet: faller kravet fra 7,5 % til 7,0 % — for eksempel ved en lengre kontrakt eller en sterkere leietaker — øker verdien i eksempelet med over 1,5 mill. kroner. Det er nettopp her god posisjonering og dokumentasjon av kontantstrømmen gir uttelling.
+
 ## Ledighet etter segment
 
 Mo i Rana har moderat kontorledighet, men et stramt logistikk- og lagermarked — drevet av industri, dagligvare og transport. Det er nettopp her byen skiller seg ut: etterspørselen etter areal knyttet til Mo Industripark og logistikk holder ledigheten lav i segmentet.
@@ -54,7 +85,34 @@ Mo i Rana har moderat kontorledighet, men et stramt logistikk- og lagermarked �
 Logistikk- og industrisegmentet er Mo i Ranas styrke: med kun 2,8 % ledighet og en sterk industripark er dette markedet der etterspørselen er mest robust — og der godt posisjonerte eiendommer prises deretter.
 </Note>
 
+## Industri og logistikk vs. kontor og handel
+
+For en investor er det to ganske ulike markeder i samme by. Industri- og logistikksegmentet er der etterspørselen er mest robust, mens kontor og handel krever en mer selektiv tilnærming til beliggenhet og standard.
+
+<Compare
+  pro={{
+    head: "Industri & logistikk — markedets styrke",
+    items: [
+      "Kun 2,8 % ledighet — det strammeste segmentet lokalt.",
+      "Stabil etterspørsel forankret i Mo Industripark og vareflyt på Helgeland.",
+      "Moderne kombinasjonsbygg leier ut raskt og holder på leietakerne.",
+      "Lav nybygging demper tilbudssiden og støtter leienivået.",
+    ],
+  }}
+  con={{
+    head: "Kontor & handel — mer nyansert",
+    items: [
+      "Kontorledighet på 5,4 % gir leietaker mer forhandlingsmakt.",
+      "Eldre og usentrale bygg krever 8,25–9,75 % yield.",
+      "Prisingen avhenger tungt av beliggenhet, standard og leietakerkvalitet.",
+      "Tynt transaksjonsvolum gjør prisbildet mindre likvid.",
+    ],
+  }}
+/>
+
 ## Markedsdrivere
+
+Bak tallene ligger noen tydelige drivkrefter som forklarer hvorfor industri- og logistikksegmentet holder seg stramt, og hvorfor kontor- og handelseiendom har et stabilt fundament.
 
 <Summary
   title="Hva som driver markedet i Mo i Rana."
@@ -68,22 +126,33 @@ Logistikk- og industrisegmentet er Mo i Ranas styrke: med kun 2,8 % ledighet og 
 
 ## Hva betyr dette for deg som eier eller investor
 
-For eiere av industri- og logistikkeiendom er markedet gunstig: lav ledighet og stabil etterspørsel støtter både verdi og leieinntekter. For kontor- og handelseiendom er bildet mer nyansert — beliggenhet, standard og leietakerkvalitet avgjør prisingen.
+For eiere av industri- og logistikkeiendom er markedet gunstig: lav ledighet og stabil etterspørsel støtter både verdi og leieinntekter. Står bygget tomt eller med en kort kontrakt, er det ofte mer å hente på å sikre en solid, langsiktig leietaker enn på å presse leien — fordi nettopp kontraktslengde og leietakerkvalitet trekker yield-kravet ned.
 
-Skal du selge, leie ut eller få en verdivurdering, anbefaler vi en konkret vurdering basert på eiendommens segment og beliggenhet. Se hvordan vi jobber lokalt på [næringsmegler i Mo i Rana](/naringsmegler/mo-i-rana), eller direkte på [salg av næringseiendom i Mo i Rana](/tjenester/salg/mo-i-rana) og [verdivurdering i Mo i Rana](/tjenester/verdivurdering/mo-i-rana).
+For kontor- og handelseiendom er bildet mer nyansert. Beliggenhet, standard og leietakerkvalitet avgjør prisingen, og forskjellen mellom et moderne sentrumsbygg og et eldre, usentralt bygg er stor. Skal du selge, leie ut eller få en verdivurdering, anbefaler vi en konkret vurdering basert på eiendommens segment og beliggenhet.
 
-For det fulle bildet på tvers av landsdelen, se [markedsinnsikt](/markedsinnsikt) og den kvartalsvise [markedsrapporten](/markedsrapport).
+Se hvordan vi jobber lokalt på [næringsmegler i Mo i Rana](/naringsmegler/mo-i-rana), eller direkte på [salg av næringseiendom i Mo i Rana](/tjenester/salg/mo-i-rana) og [verdivurdering i Mo i Rana](/tjenester/verdivurdering/mo-i-rana). For det fulle bildet på tvers av landsdelen, se [markedsinnsikt](/markedsinnsikt) og den kvartalsvise [markedsrapporten](/markedsrapport).
+
+<CTA
+  badge="Verdivurdering i Mo i Rana"
+  title="Lurer du på hva eiendommen din er verdt i dagens marked?"
+  description="Vi har lokal tilstedeværelse i Mo i Rana og særlig erfaring med industri- og logistikkeiendom. Fra markedsanalyse og prising til gjennomført transaksjon — vi følger oppdraget tett hele veien."
+  primaryAction={{ label: "Kontakt oss", href: "/kontakt" }}
+  secondaryAction={{ label: "Se verdivurdering", href: "/tjenester/verdivurdering" }}
+/>
 
 ## Kontakt
 
 Trenger du en oppdatert verdivurdering av næringseiendommen din i Mo i Rana, eller ønsker du rådgivning rundt kjøp, salg eller utleie?
 
-**Christer Hagen**  
-Eiendomsmegler MNEF / Næringsmegler / Partner  
-Advanti Estate  
-Dronningens gate 18, 8006 Bodø  
-Telefon: +47 984 53 571  
-E‑post: Christer@advantiestate.no
+<Advisor
+  label="Din rådgiver i Mo i Rana"
+  name="Christer Hagen"
+  role="Eiendomsmegler MNEF · Næringsmegler · Partner"
+  portrait="https://kukzjreikqbgbolxvqaj.supabase.co/storage/v1/object/public/press/christer-hagen-web.jpg"
+  address="Advanti Estate · Dronningens gate 18, 8006 Bodø"
+  phone="+47 984 53 571"
+  email="christer@advantiestate.no"
+/>
 
 ---
 

--- a/src/lib/authors.ts
+++ b/src/lib/authors.ts
@@ -8,6 +8,8 @@
  * Adding a new blog author: add one entry below — no other file needs editing.
  */
 
+import { allPersonPosts } from "content-collections";
+
 export interface AuthorMeta {
   name: string;
   /** Short role line shown beneath the author name. */
@@ -51,4 +53,41 @@ export const AUTHORS: Record<string, AuthorMeta> = {
  */
 export function getAuthorName(handle: string): string {
   return AUTHORS[handle]?.name ?? handle;
+}
+
+/** Resolved data for the editorial advisor/contact card. */
+export interface AuthorCard {
+  name: string;
+  role: string;
+  portrait: string;
+  phone?: string;
+  email?: string;
+}
+
+/**
+ * Resolves a blog-author handle to the data the <Advisor> card needs.
+ *
+ * Server-only: reads the people collection so phone/email come from the
+ * matching /personer profile when one exists (via `personSlug`). Authors
+ * without a public profile (or unknown handles) still get a valid card from
+ * the AUTHORS metadata — `portrait` always falls back to the author image —
+ * and the card itself degrades to a "Kontakt oss" link when phone/email are
+ * absent. Returns null only for a completely unknown handle.
+ */
+export function resolveAuthorCard(handle: string): AuthorCard | null {
+  const meta = AUTHORS[handle];
+  if (!meta) return null;
+  const person = meta.personSlug
+    ? allPersonPosts.find((p) => p.slug === meta.personSlug)
+    : undefined;
+  return {
+    name: meta.name,
+    // Use the canonical AUTHORS role (editorial " · " form) so the card matches
+    // the byline above it — the people-collection `role` uses a hyphenated form
+    // ("Partner - Næringsmegler") that breaks the design separator convention.
+    role: meta.role,
+    portrait: meta.image,
+    phone: person?.phone,
+    email: person?.email,
+  };
 }

--- a/src/styles/advanti-design.css
+++ b/src/styles/advanti-design.css
@@ -6809,6 +6809,66 @@ h1, h2, h3 {
   .ae-changelog .ae-cl-item:hover .ae-rm-arrow { color: var(--warm-grey); }
 }
 
+/* -- 17 · ADVISOR (contact card) -------------------------- */
+.ae-advisor {
+  margin: 36px 0 0;
+  border: var(--hairline);
+  border-top: 2px solid var(--warm-grey);
+  display: grid;
+  grid-template-columns: 128px 1fr;
+  gap: 30px;
+  padding: 28px 30px;
+  align-items: center;
+}
+.ae-advisor .ae-portrait {
+  width: 128px;
+  height: 160px;
+  overflow: hidden;
+  background: var(--warm-grey-75);
+}
+.ae-advisor .ae-portrait img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: center top;
+}
+.ae-advisor .ae-ad-label {
+  display: block;
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--warm-grey-85);
+  font-weight: 500;
+  margin-bottom: 12px;
+}
+.ae-advisor h4 {
+  font-family: var(--font-display);
+  font-size: 23px;
+  font-weight: 400;
+  letter-spacing: -0.012em;
+  margin-bottom: 4px;
+}
+.ae-advisor .ae-ad-role {
+  font-size: 13.5px;
+  color: var(--warm-grey-85);
+  margin-bottom: 16px;
+}
+.ae-advisor .ae-ad-contact {
+  font-size: 14px;
+  color: var(--warm-grey-85);
+  line-height: 1.75;
+}
+.ae-advisor .ae-ad-contact a {
+  color: var(--warm-grey);
+  border-bottom: 1px solid var(--warm-grey-85);
+  transition: border-color 0.15s;
+}
+.ae-advisor .ae-ad-contact a:hover { border-color: var(--accent); }
+@media (max-width: 600px) {
+  .ae-advisor { grid-template-columns: 1fr; gap: 20px; padding: 24px; }
+  .ae-advisor .ae-portrait { width: 120px; }
+}
+
 /* ============================================================
    EIENDOMMER — listings index page (/eiendommer)
    Ported from design handoff "Advanti Estate CRM" 2026-05-25.

--- a/tests/editorial-mdx.spec.ts
+++ b/tests/editorial-mdx.spec.ts
@@ -47,6 +47,34 @@ test("blog article renders editorial Note, Formula and Example components", asyn
   await expect(page.locator(".ae-cta h4").first()).toBeVisible();
 });
 
+test("inline Advisor renders once on Mo i Rana with a tel: link (no global duplicate)", async ({
+  page,
+}) => {
+  // Mo i Rana sets advisorInline:true and places its own localized <Advisor>
+  // under Kontakt — the page must NOT also render the global one.
+  await page.goto("/blog/naringseiendomsmarkedet-mo-i-rana-2026", {
+    waitUntil: "domcontentloaded",
+  });
+  const advisor = page.locator(".ae-advisor");
+  await expect(advisor).toHaveCount(1);
+  await expect(advisor.locator('a[href^="tel:"]').first()).toBeVisible();
+  // The new Compare section ships with this rewrite too.
+  await expect(page.locator(".ae-compare .ae-col.is-accent").first()).toBeVisible();
+});
+
+test("global Advisor renders from author data on a non-inline article", async ({
+  page,
+}) => {
+  // dcf-analyse has no advisorInline flag, so the page renders the global
+  // advisor card from the author's resolved profile (codehagen → christer-hagen).
+  await page.goto("/blog/dcf-analyse-naringseiendom", {
+    waitUntil: "domcontentloaded",
+  });
+  const advisor = page.locator(".ae-advisor");
+  await expect(advisor).toHaveCount(1);
+  await expect(advisor.locator('a[href^="tel:"]').first()).toBeVisible();
+});
+
 test("Summary renders roman numerals (legacy iconName prop ignored)", async ({
   page,
 }) => {

--- a/tests/unit/advisor.test.tsx
+++ b/tests/unit/advisor.test.tsx
@@ -1,0 +1,55 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from "vitest"
+import { render } from "@testing-library/react"
+
+// next/image (via BlurImage) and next/link need framework context that jsdom
+// doesn't provide — stub them to plain elements so the test isolates the
+// Advisor card's own logic (tel/mailto normalization + the no-contact fallback).
+vi.mock("@/lib/blog/blur-image", () => ({
+  default: (props: { src: string; alt: string }) => (
+    // eslint-disable-next-line @next/next/no-img-element, jsx-a11y/alt-text
+    <img {...props} />
+  ),
+}))
+vi.mock("next/link", () => ({
+  default: ({ href, children }: { href: string; children: React.ReactNode }) => (
+    <a href={href}>{children}</a>
+  ),
+}))
+
+import { Advisor } from "@/components/blog/Advisor"
+
+describe("Advisor contact card", () => {
+  it("normalizes tel: (digits only) and lowercases mailto:", () => {
+    const { container } = render(
+      <Advisor
+        name="Christer Hagen"
+        role="Partner"
+        portrait="https://example.com/x.jpg"
+        phone="+47 984 53 571"
+        email="Christer@Advantiestate.no"
+      />,
+    )
+    const tel = container.querySelector('a[href^="tel:"]')
+    const mail = container.querySelector('a[href^="mailto:"]')
+    expect(tel?.getAttribute("href")).toBe("tel:+4798453571")
+    expect(mail?.getAttribute("href")).toBe("mailto:christer@advantiestate.no")
+    // Display text keeps the human-readable casing/spacing.
+    expect(tel?.textContent).toBe("+47 984 53 571")
+  })
+
+  it("falls back to a single Kontakt-oss link when phone and email are absent", () => {
+    const { container, getByText } = render(
+      <Advisor
+        name="Vegard Søraas"
+        role="Partner"
+        portrait="https://example.com/x.jpg"
+      />,
+    )
+    // The silent-failure branch: never an empty tel:/mailto:.
+    expect(container.querySelector('a[href^="tel:"]')).toBeNull()
+    expect(container.querySelector('a[href^="mailto:"]')).toBeNull()
+    const link = getByText(/Kontakt oss/i).closest("a")
+    expect(link?.getAttribute("href")).toBe("/kontakt")
+  })
+})


### PR DESCRIPTION
Implements the Claude Design handoff `advanti/blog-mo-i-rana-2026-preview.html`.

The `.ae-*` editorial system it uses was already shipped (TODO 19), so this fills the one real gap — a reusable **Advisor** contact card — and brings the Mo i Rana market article up to the design.

## Changes
- **`advisorInline`** flag on the BlogPost schema (`content-collections.ts`)
- **`Advisor.tsx`** — typed props, normalized `tel:`/`mailto:`, `/kontakt` fallback when phone/email absent
- **`.ae-advisor`** CSS in the BLOG section (design tokens, 600px breakpoint)
- **`resolveAuthorCard()`** in `authors.ts` — uses the canonical `AUTHORS` role so the card matches the byline
- Register `Advisor` in MDX; post page renders it **globally** on every article, suppressed when an article inlines its own
- **Mo i Rana MDX** rewritten to the design: Figure, caution Note, calculation Example, industri-vs-kontor Compare, CTA, inline Advisor — real internal routes, no `href="#"`

## Verification
- `pnpm build` clean (MDX compiles, `/blog/[slug]` generated)
- `pnpm lint` 0 errors
- `pnpm test:unit` 177/177 (incl. tel/mailto normalization + the no-profile fallback branch)
- Playwright `editorial-mdx.spec.ts` (inline single card + global card) + `blog-content.spec.ts` pass

Reviewed via `/plan-eng-review` + `/plan-design-review` (ENG + DESIGN cleared).

🤖 Generated with [Claude Code](https://claude.com/claude-code)