### PR TITLE
feat(nav): Salg first, Kunnskapssenter top-level, fix /verdivurdering orphan

### DIFF
--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -35,7 +35,6 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     "/tjenester/transaksjoner",
     "/tjenester/strategisk-radgivning",
     "/beslutningsgrunnlag",
-    "/verdivurdering",
     "/verktoy",
     "/verktoy/yield-kalkulator",
     "/verktoy/boliglan-kalkulator",

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -35,6 +35,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     "/tjenester/transaksjoner",
     "/tjenester/strategisk-radgivning",
     "/beslutningsgrunnlag",
+    "/verdivurdering",
     "/verktoy",
     "/verktoy/yield-kalkulator",
     "/verktoy/boliglan-kalkulator",

--- a/src/components/site/Nav.tsx
+++ b/src/components/site/Nav.tsx
@@ -98,12 +98,12 @@ const PANELS: Record<
 > = {
   tjenester: {
     items: [
-      "/tjenester/utleie",
+      "/tjenester/salg",
       "/tjenester/verdivurdering",
       "/tjenester/transaksjoner",
       "/tjenester/radgivning",
       "/tjenester/strategisk-radgivning",
-      "/tjenester/salg",
+      "/tjenester/utleie",
       "/naringsmegler",
     ],
     seeAll: { href: "/tjenester", label: "Se alle tjenester" },
@@ -122,7 +122,6 @@ const PANELS: Record<
       "/markedsinnsikt/kart",
       "/markedsrapport",
       "/verktoy",
-      "/help",
       "/blog",
     ],
     seeAll: { href: "/markedsinnsikt", label: "Gå til markedsinnsikt" },
@@ -606,6 +605,14 @@ export function Nav({ groups }: NavProps) {
           </button>
 
           <Link
+            href="/help"
+            aria-current={isLinkActive("/help") ? "page" : undefined}
+            onMouseEnter={scheduleClose}
+          >
+            Kunnskapssenter
+          </Link>
+
+          <Link
             href="/kontakt"
             aria-current={isLinkActive("/kontakt") ? "page" : undefined}
             onMouseEnter={scheduleClose}
@@ -773,6 +780,15 @@ export function Nav({ groups }: NavProps) {
             }))}
             onLinkClick={() => setMenuOpen(false)}
           />
+
+          <Link
+            prefetch={false}
+            href="/help"
+            aria-current={isLinkActive("/help") ? "page" : undefined}
+            onClick={() => setMenuOpen(false)}
+          >
+            Kunnskapssenter
+          </Link>
 
           <Link
             prefetch={false}

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -57,18 +57,18 @@ export const REGISTRY: NavEntry[] = [
     navGroup: "tjenester",
   },
   {
-    path: "/tjenester/verdivurdering",
-    label: "Verdivurdering",
-    description: "Dokumentert markedsverdi med DCF- og yield-analyse.",
+    path: "/tjenester/salg",
+    label: "Salg",
+    description: "Strukturert salgsprosess fra verdivurdering til oppgjør.",
     parent: "/tjenester",
     inNav: true,
     inFooter: true,
     navGroup: "tjenester",
   },
   {
-    path: "/tjenester/salg",
-    label: "Salg",
-    description: "Strukturert salgsprosess fra verdivurdering til oppgjør.",
+    path: "/tjenester/verdivurdering",
+    label: "Verdivurdering",
+    description: "Dokumentert markedsverdi med DCF- og yield-analyse.",
     parent: "/tjenester",
     inNav: true,
     inFooter: true,
@@ -177,13 +177,14 @@ export const REGISTRY: NavEntry[] = [
     navGroup: "innsikt",
     description: "Kalkulatorer for yield, ROI og verdivurdering.",
   },
+  // Kunnskapssenter — promoted to a top-level nav item (own breadcrumb root),
+  // no longer nested under the Innsikt panel.
   {
     path: "/help",
     label: "Kunnskapssenter",
-    parent: "/markedsinnsikt",
+    parent: null,
     inNav: true,
     inFooter: true,
-    navGroup: "innsikt",
     description: "Guider og fagartikler om næringseiendom.",
   },
   {
@@ -273,7 +274,7 @@ export const REGISTRY: NavEntry[] = [
 
   // ── deliberately outside nav/footer (gated or landing pages) ─────────────
   { path: "/presentasjon", label: "Presentasjon", parent: null, inNav: false, inFooter: false },
-  { path: "/verdivurdering", label: "Få verdivurdering", parent: null, inNav: false, inFooter: false },
+  { path: "/verdivurdering", label: "Få verdivurdering", parent: null, inNav: false, inFooter: true },
   // Indexable conversion surface — reached via sitemap + cross-links (SeOgsa),
   // not primary nav. Parent gives it a Tjenester breadcrumb trail.
   { path: "/beslutningsgrunnlag", label: "Beslutningsgrunnlag", parent: "/tjenester", inNav: false, inFooter: false },
@@ -304,7 +305,9 @@ export const footerColumns: Record<"tjenester" | "advanti", NavEntry[]> = {
   tjenester: REGISTRY.filter(
     (e) =>
       e.inFooter === true &&
-      (e.navGroup === "tjenester" || e.path === "/naringsmegler") &&
+      (e.navGroup === "tjenester" ||
+        e.path === "/naringsmegler" ||
+        e.path === "/verdivurdering") &&
       e.path !== "/tjenester" // parent row not shown as a plain link in footer
   ),
   advanti: [

--- a/tests/unit/breadcrumbs.test.ts
+++ b/tests/unit/breadcrumbs.test.ts
@@ -90,10 +90,9 @@ describe("buildCrumbs", () => {
   it("resolves /help/article/[slug] through the full parent chain", () => {
     const crumbs = buildCrumbs("/help/article/some-article", "Hva er næringseiendom?")
     expect(crumbs).not.toBeNull()
-    // Hjem → Markedsinnsikt → Kunnskapssenter → [article title]
+    // Kunnskapssenter is now a top-level section: Hjem → Kunnskapssenter → [article title]
     expect(crumbs![0].href).toBe("/")
     const hrefs = crumbs!.map((c) => c.href)
-    expect(hrefs).toContain("/markedsinnsikt")
     expect(hrefs).toContain("/help")
     // Leaf
     expect(crumbs!.at(-1)).toMatchObject({

--- a/tests/unit/navHelpers.test.ts
+++ b/tests/unit/navHelpers.test.ts
@@ -18,6 +18,8 @@ describe("navItems()", () => {
     // Top-level labels visible in the desktop nav bar
     expect(paths).toContain("/eiendommer")
     expect(paths).toContain("/kontakt")
+    // Kunnskapssenter promoted to a top-level link (out of the Innsikt group)
+    expect(paths).toContain("/help")
     // Group triggers (Tjenester, Innsikt, Om oss) are also inNav:true + parent:null
     expect(paths).toContain("/tjenester")
     expect(paths).toContain("/markedsinnsikt")
@@ -128,10 +130,10 @@ describe("navGroups.innsikt", () => {
     expect(paths).toContain("/markedsrapport")
   })
 
-  it("includes /verktoy and /help (cross-links to tools and knowledge centre)", () => {
+  it("includes /verktoy; /help was promoted out to a top-level nav link", () => {
     const paths = navGroups.innsikt.map((e) => e.path)
     expect(paths).toContain("/verktoy")
-    expect(paths).toContain("/help")
+    expect(paths).not.toContain("/help")
   })
 
   it("every entry has inNav:true and navGroup === 'innsikt'", () => {


### PR DESCRIPTION
## Nav-IA: Salg først, Kunnskapssenter i navbaren, + fiks /verdivurdering-foreldreløshet

Tre ting du ba om, alt på siste main (`0293b2c`).

### 1. Salg øverst-til-venstre, Utleie dit Salg sto
Tjenester-panelet (og registeret som driver mobil + /tjenester) har nå rekkefølge: **Salg** · Verdivurdering · Transaksjoner · Rådgivning · Strategisk · **Utleie** · Næringsmegler.

### 2. Kunnskapssenter opp i navbaren
`/help` er løftet til et **eget toppnivå-element** i navbaren (desktop + mobil) — «Tjenester · Eiendommer · Innsikt · Om oss · **Kunnskapssenter** · Kontakt» — og fjernet fra Innsikt-dropdownen (ingen dobbeltoppføring). Registeret er kilden: `parent→null` + droppet `navGroup`, så brødsmuler (nå Hjem → Kunnskapssenter), mobilmeny og footer følger automatisk. `nav.spec` SSR + `navHelpers`/`breadcrumbs` enhetstester oppdatert til ny IA.

### 3. /verdivurdering var foreldreløst — fikset
Etter at nav-CTA-en ble flyttet til Analyseportalen (#66) hadde `/verdivurdering` (intake-skjemaet) ingen intern lenke og lå ikke i sitemap. Best practice for denne typen konverteringsside i dette repoet (jf. `/beslutningsgrunnlag`): lagt til i **sitemap** + en intern lenke i **footer (Tjenester-kolonnen)**.

**GTM/GA4:** `cta_verdivurdering` → `cta_analyseportal`-omdøpingen er allerede ferdig i koden (#66), ingen rester i repoet. En evt. GTM-trigger som lyttet på `cta_verdivurdering` må byttes i GTM-UI-en (eksternt — kan ikke endres fra repoet).

**Verifisert:** build + typecheck grønt, **177 enhetstester** grønne, **22/22 nav+breadcrumb e2e** grønne. Browser-bekreftet toppnivå-rekkefølge, panel-rekkefølge, Innsikt uten Kunnskapssenter, og footer-lenken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
