### PR TITLE
fix(ci): repair the two pre-existing red checks (blog overflow + markedskart flake)

### DIFF
--- a/src/components/blog/mdx.tsx
+++ b/src/components/blog/mdx.tsx
@@ -242,17 +242,19 @@ function Example(props: {
         <span className="ae-label">Eksempel</span>
         {props.title && <h4>{props.title}</h4>}
       </div>
-      <table>
-        <tbody>
-          {steps.map((s, i) => (
-            <tr key={i} className={s.isResult ? "is-result" : undefined}>
-              <td className="ae-elabel">{s.label}</td>
-              {hasCalc && <td className="ae-ecalc">{s.calculation ?? ""}</td>}
-              <td className="ae-eval">{fmt(s.value)}</td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+      <div className="ae-table-scroll">
+        <table>
+          <tbody>
+            {steps.map((s, i) => (
+              <tr key={i} className={s.isResult ? "is-result" : undefined}>
+                <td className="ae-elabel">{s.label}</td>
+                {hasCalc && <td className="ae-ecalc">{s.calculation ?? ""}</td>}
+                <td className="ae-eval">{fmt(s.value)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
     </div>
   )
 }
@@ -668,6 +670,14 @@ export function MDX({ code, images, className }: MDXProps) {
           ...components,
           Image: MDXImage,
           img: (props: any) => <MDXImage {...props} />,
+          // Markdown (GFM) tables: wrap in a horizontal scroll container so
+          // wide tables never overflow the viewport on mobile. A wrapper div
+          // (not display:block on the table) preserves the table a11y role.
+          table: (props: any) => (
+            <div className="ae-table-scroll">
+              <table {...props} />
+            </div>
+          ),
         }}
       />
     </article>

--- a/src/styles/advanti-design.css
+++ b/src/styles/advanti-design.css
@@ -2933,6 +2933,21 @@ h1, h2, h3 {
 .mi-tablewrap { overflow-x: auto; }
 .mi-tablewrap .mi-table { min-width: 520px; }
 
+/* Editorial/MDX table scroll container (GFM tables + the Example component).
+   Wide tables scroll horizontally instead of overflowing the mobile viewport;
+   the wrapper (not display:block on <table>) keeps the table a11y role. */
+.ae-table-scroll { overflow-x: auto; max-width: 100%; -webkit-overflow-scrolling: touch; }
+.ae-table-scroll > table { margin: 0; }
+/* Let the table take its intrinsic width inside the scroll container so the
+   WRAPPER scrolls, instead of width:100% clamping the table and letting its
+   rows overflow the page. The .ae-example selector beats `.ae-example table
+   { width:100% }` (higher specificity). */
+.ae-table-scroll > table,
+.ae-example .ae-table-scroll > table {
+  width: max-content;
+  min-width: 100%;
+}
+
 .mi-table {
   width: 100%;
   border-collapse: collapse;
@@ -4135,7 +4150,8 @@ h1, h2, h3 {
 }
 .ks-art-meta {
   display: flex;
-  gap: 18px;
+  flex-wrap: wrap;
+  gap: 8px 18px;
   align-items: center;
   margin-bottom: 32px;
   font-size: 12.5px;
@@ -6317,6 +6333,13 @@ h1, h2, h3 {
   .ae-stat-strip .ae-stat:nth-child(odd) { border-left: 0; padding-left: 0; }
   .ae-stat-strip .ae-stat { border-top: var(--hairline); padding: 22px 0; }
   .ae-stat-strip .ae-stat:nth-child(2n) { padding-left: 24px; border-left: var(--hairline); }
+}
+/* Phones: a 2-col strip is too narrow for non-wrapping values like
+   "1 100–1 700 kr/m²/år" — stack to one column so it never overflows. */
+@media (max-width: 480px) {
+  .ae-stat-strip { grid-template-columns: 1fr; }
+  .ae-stat-strip .ae-stat,
+  .ae-stat-strip .ae-stat:nth-child(2n) { padding-left: 0; border-left: 0; }
 }
 
 /* -- 5 · SUMMARY GRID ------------------------------------- */

--- a/tests/naringsmegler-qa-regression.spec.ts
+++ b/tests/naringsmegler-qa-regression.spec.ts
@@ -41,13 +41,16 @@ test("markedskart reacts to same-page hash changes (ISSUE-001)", async ({
   await page.goto("/markedsinnsikt/kart#yield", {
     waitUntil: "domcontentloaded",
   });
+  // The map reacts after Leaflet init + hydration; under CI's single-worker
+  // prod server that can take well over the 5s default. Allow more time — the
+  // behaviour is unchanged, only the wait is more patient (fixes CI flake).
   await expect(
     page.getByRole("button", { name: "Prime yield" }),
-  ).toHaveAttribute("aria-pressed", "true");
+  ).toHaveAttribute("aria-pressed", "true", { timeout: 15_000 });
   await page.evaluate(() => {
     window.location.hash = "#leie";
   });
   await expect(
     page.getByRole("button", { name: "Markedsleie" }),
-  ).toHaveAttribute("aria-pressed", "true");
+  ).toHaveAttribute("aria-pressed", "true", { timeout: 15_000 });
 });


### PR DESCRIPTION
## Fiks de to forhåndseksisterende røde CI-sjekkene på main

`main` har vært rød siden #68. Denne PR-en fikser begge feilene (urelatert til nav-arbeidet i #69):

### 1. Mobil-overflow på `/blog/...mo-i-rana` (375px)
Rotårsak: `.ks-art-meta`-bylinjen (forfatter · dato · lesetid) hadde `flex-wrap: nowrap` og rant utenfor skjermen på mobil (spanet «6 min lesing» endte på 429px). Nå `flex-wrap: wrap`.

Mens jeg var i editorial-komponentene (også fra #68s Mo-i-Rana-oppgradering):
- **Brede tabeller** (GFM + `Example`-komponenten) scroller nå horisontalt via en `.ae-table-scroll`-wrapper. De ble tidligere **klippet** av `.ae-example { overflow:hidden }` (innhold kuttet, ikke bare overflow) — wrapperen bevarer tabell-a11y og lar dem scrolle.
- **`.ae-stat-strip`** stables til én kolonne på telefon (≤480px), så ikke-brytbare verdier som «1 100–1 700 kr/m²/år» får plass.

### 2. markedskart hash-regresjon (ISSUE-001) — CI-flake
Testen er grønn lokalt (~330ms), men time-et ut i CI: kart-tilstand-assertene brukte 5s default-timeout, for stramt for Leaflet-init under CIs single-worker prod-server. Bumpet de to assertene til 15s — oppførsel uendret, bare mer tålmodig venting.

**Verifisert lokalt:** build + typecheck grønt, unit grønt, `mobile-overflow` (27/27) + `editorial-mdx` + `naringsmegler-qa-regression` (2/2) grønne.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed table overflow issues on mobile devices by implementing horizontal scrolling for wide editorial and example tables
  * Improved responsive layout for knowledge-base article metadata and stat strips on smaller viewports

* **Style**
  * Enhanced table styling with horizontal scroll container for better readability
  * Adjusted spacing and breakpoints for metadata and stat strip components across screen sizes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->