### PR TITLE
feat(seo): index /verdivurdering and add to sitemap

### DIFF
--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -34,6 +34,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     "/tjenester/utleie",
     "/tjenester/transaksjoner",
     "/tjenester/strategisk-radgivning",
+    "/verdivurdering",
     "/beslutningsgrunnlag",
     "/verktoy",
     "/verktoy/yield-kalkulator",

--- a/src/app/verdivurdering/page.tsx
+++ b/src/app/verdivurdering/page.tsx
@@ -11,10 +11,9 @@ import {
 
 export const metadata = constructMetadata({
   path: "/verdivurdering",
-  // Conversion endpoint, not an SEO surface — the organic page is
-  // /tjenester/verdivurdering. noIndex avoids cannibalising it and keeps this
-  // out of the sitemap.
-  noIndex: true,
+  // Indexed conversion page. Its own canonical (/verdivurdering) and a distinct,
+  // intent-led title ("Få verdivurdering …") keep it from cannibalising the
+  // explainer at /tjenester/verdivurdering, which targets the informational query.
   title: "Få verdivurdering av næringseiendom | Advanti Estate",
   description:
     "Be om en uforpliktende verdivurdering av næringseiendommen din. Svar fra en partner innen 24 timer, basert på vår transaksjonsdatabase med over 1 400 eiendommer i Nord-Norge.",


### PR DESCRIPTION
## Hva

Gjør `/verdivurdering` indekserbar og legger den i sitemap. Tidligere var siden bevisst `noindex` for å unngå kannibalisering av forklaringssiden `/tjenester/verdivurdering` — nå indekseres den i stedet.

## Hvorfor det er trygt mot kannibalisering

- **Egen canonical** (`/verdivurdering`) — ingen kryss-signaler mot `/tjenester/verdivurdering`.
- **Distinkt, intent-styrt tittel** ("Få verdivurdering av næringseiendom") — landingssiden eier den transaksjonelle intenten (be om vurdering), forklaringssiden eier den informasjonelle ("hva er en verdivurdering / metode").
- Siden var allerede footer-lenket (#69), så den er ikke lenger foreldreløs — nå med indekseringssignal i tillegg.

## Endringer

- `src/app/verdivurdering/page.tsx` — fjernet `noIndex: true` (emitter nå `index`, self-canonical).
- `src/app/sitemap.ts` — la `/verdivurdering` til i den statiske side-listen.

## Verifisert

- `pnpm build` grønt.
- Playwright: `seo-meta` (sitemap 200 + indekserbar + self-canonical), `routes` (hele sitemap rendrer uten 500), og `verdivurdering-reise` — alle grønne (29/29 lokalt).

## Gjenstår (utenfor repo)

GTM/GA4-triggeren `cta_verdivurdering` bør døpes om til `cta_analyseportal` i GTM-UI-et (nav-CTA peker nå til `/analyseportal`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)