### PR TITLE
improve: full-repo audit fixes + plans 014/015/016 implemented

### DIFF
--- a/content-collections.ts
+++ b/content-collections.ts
@@ -4,6 +4,7 @@
 // own pipeline, not by the app's `tsc --noEmit`.
 import { defineCollection, defineConfig } from "@content-collections/core";
 import { compileMDX } from "@content-collections/mdx";
+import { z } from "zod";
 import { remarkGfm } from "fumadocs-core/mdx-plugins";
 import GithubSlugger from "github-slugger";
 import rehypeAutolinkHeadings from "rehype-autolink-headings";
@@ -57,7 +58,7 @@ const BlogPost = defineCollection({
   name: "BlogPost",
   directory: "src/content/blog",
   include: "**/*.mdx",
-  schema: (z) => ({
+  schema: z.object({
     title: z.string(),
     categories: z
       .array(z.enum(["company", "valuation", "market-analysis", "casestudies"]))
@@ -116,7 +117,7 @@ const ChangelogPost = defineCollection({
   name: "ChangelogPost",
   directory: "src/content/changelog",
   include: "*.mdx",
-  schema: (z) => ({
+  schema: z.object({
     title: z.string(),
     publishedAt: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
     summary: z.string(),
@@ -159,7 +160,7 @@ export const CustomersPost = defineCollection({
   name: "CustomersPost",
   directory: "src/content/customers",
   include: "*.mdx",
-  schema: (z) => ({
+  schema: z.object({
     title: z.string(),
     publishedAt: z.string(),
     summary: z.string(),
@@ -209,7 +210,7 @@ export const HelpPost = defineCollection({
   name: "HelpPost",
   directory: "src/content/help",
   include: "*.mdx",
-  schema: (z) => ({
+  schema: z.object({
     title: z.string(),
     updatedAt: z.string(),
     summary: z.string(),
@@ -286,7 +287,7 @@ export const LegalPost = defineCollection({
   name: "LegalPost",
   directory: "src/content/legal",
   include: "*.mdx",
-  schema: (z) => ({
+  schema: z.object({
     title: z.string(),
     updatedAt: z.string(),
     slug: z.string().optional(),
@@ -326,7 +327,7 @@ export const IntegrationsPost = defineCollection({
   name: "IntegrationsPost",
   directory: "src/content/integrations",
   include: "*.mdx",
-  schema: (z) => ({
+  schema: z.object({
     title: z.string(),
     publishedAt: z.string(),
     summary: z.string(),
@@ -375,7 +376,7 @@ export const PersonPost = defineCollection({
   name: "PersonPost",
   directory: "src/content/people",
   include: "*.mdx",
-  schema: (z) => ({
+  schema: z.object({
     name: z.string(),
     role: z.string(),
     avatar: z.string(),
@@ -441,7 +442,7 @@ export const LocationPost = defineCollection({
   name: "LocationPost",
   directory: "src/content/locations",
   include: "**/*.mdx",
-  schema: (z) => ({
+  schema: z.object({
     name: z.string(),
     order: z.number(),
     region: z.string(),
@@ -564,7 +565,7 @@ export const ListingPost = defineCollection({
   name: "ListingPost",
   directory: "src/content/listings",
   include: "*.mdx",
-  schema: (z) => ({
+  schema: z.object({
     // Editorial title — split into a non-italic head and an italic tail so
     // the H1 + listing-card H3 render with the design's two-tone treatment
     // without authors having to embed JSX in frontmatter. `title` (plain) is

--- a/content-collections.ts
+++ b/content-collections.ts
@@ -10,7 +10,7 @@ import rehypeAutolinkHeadings from "rehype-autolink-headings";
 import rehypeSlug from "rehype-slug";
 
 const computedFields = (
-  type: "blog" | "changelog" | "customers" | "help" | "legal" | "integrations",
+  _type: "blog" | "changelog" | "customers" | "help" | "legal" | "integrations",
 ) => ({
   slug: (document) => {
     const slugger = new GithubSlugger();

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -21,6 +21,16 @@ const config = [
       "@typescript-eslint/ban-ts-comment": "off",
       "@typescript-eslint/no-explicit-any": "off",
       "@typescript-eslint/no-require-imports": "off",
+      // Honor the repo's `_`-prefix convention for intentionally-unused args,
+      // vars, and caught errors (stub signatures, interface-required params).
+      "@typescript-eslint/no-unused-vars": [
+        "warn",
+        {
+          argsIgnorePattern: "^_",
+          varsIgnorePattern: "^_",
+          caughtErrorsIgnorePattern: "^_",
+        },
+      ],
       "prefer-const": "off",
       "react-hooks/immutability": "off",
       "react-hooks/preserve-manual-memoization": "off",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "resend": "^6.12.3",
     "tailwind-merge": "^2.6.0",
     "tailwind-variants": "^0.3.0",
-    "vaul": "^1.1.2"
+    "vaul": "^1.1.2",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@content-collections/core": "^0.8.0",

--- a/package.json
+++ b/package.json
@@ -52,9 +52,9 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@content-collections/core": "^0.8.0",
-    "@content-collections/mdx": "^0.2.0",
-    "@content-collections/next": "^0.2.4",
+    "@content-collections/core": "^0.15.1",
+    "@content-collections/mdx": "^0.2.2",
+    "@content-collections/next": "^0.2.11",
     "@playwright/test": "^1.60.0",
     "@tailwindcss/forms": "^0.5.10",
     "@testing-library/react": "^16.3.2",
@@ -67,7 +67,7 @@
     "@types/react-katex": "^3.0.4",
     "eslint": "^9.0.0",
     "eslint-config-next": "16.2.9",
-    "fumadocs-core": "^15.0.8",
+    "fumadocs-core": "^16.10.3",
     "github-slugger": "^2.0.0",
     "jsdom": "^29.1.1",
     "postcss": "^8.4.49",

--- a/plans/013-faa-verdivurdering-funnel.md
+++ b/plans/013-faa-verdivurdering-funnel.md
@@ -1,6 +1,14 @@
 # 013 — «Få verdivurdering»-funnel (dedikert konverteringsside)
 
-**Status:** IMPLEMENTERT på `feat/faa-verdivurdering-funnel` (build grønn). Gate-valg: bygg nå (de-risket) + noIndex konverteringsside.
+> **OPPDATERT 2026-06-14 (PR #71, commit `9fc4f2d`):** SEO-rollen i denne planen
+> (C1 / Decision 1 / Decision 9 — `/verdivurdering` = `noIndex` + ut av sitemap)
+> er **reversert**. Siden er nå **indeksert og i `sitemap.ts`**. Anti-kannibalisering
+> håndteres i stedet av egen self-canonical (`/verdivurdering`), distinkt intent-styrt
+> tittel («Få verdivurdering …») mot forklaringssiden `/tjenester/verdivurdering`, og
+> GSC-overvåking de neste 2–4 ukene. Alle `noIndex`-referanser nedenfor beskriver den
+> opprinnelige (nå utdaterte) beslutningen og beholdes kun som historikk.
+
+**Status:** IMPLEMENTERT på `feat/faa-verdivurdering-funnel` (build grønn). Gate-valg: bygg nå (de-risket) + noIndex konverteringsside. **SEO-rolle senere reversert til indeksert — se banner over.**
 **Branch (implementasjon):** `feat/faa-verdivurdering-funnel` (lages fra `main` før kode)
 **Design-kilde:** Claude Design-handoff `advanti/verdivurdering.html` (+ chat16). README sier: gjenskap visuelt, ikke kopier prototypens struktur.
 

--- a/plans/014-dependency-security-bumps.md
+++ b/plans/014-dependency-security-bumps.md
@@ -1,0 +1,72 @@
+# 014 — Patch transitive dependency vulnerabilities
+
+**Status:** TODO
+**Written against commit:** `9dda014`
+**Priority:** P2 · **Effort:** M · **Risk of the fix:** MED (build-critical deps)
+**Depends on:** —
+
+## Why this matters
+
+`pnpm audit` reports several high/moderate vulnerabilities, all *transitive* (no
+direct dependency on the vulnerable packages). The notable ones reach the build
+pipeline through `@content-collections/core`:
+
+- `serialize-javascript` ≤7.0.2 — RCE (via `@content-collections/core`)
+- `esbuild` <0.28.1, `js-yaml`, `uuid` — same chain
+- `path-to-regexp` 8.0.0–8.3.x — ReDoS (via `fumadocs-core`)
+- `flatted` <3.4.2 — prototype pollution / DoS (via `eslint`)
+
+Real-world exposure is lower than direct deps (these run at build time on trusted
+editorial content, not attacker input). But `@content-collections/core` is
+build-critical, and `serialize-javascript` RCE during content rendering is the
+one worth closing if a future feature ever feeds user data into a collection.
+
+This is a planned, isolated bump — NOT an `improve`-time auto-fix — because the
+upgrade crosses a major (`@content-collections/core` 0.8 → 0.15) and could break
+type generation.
+
+## Verification gate (this repo)
+
+- `pnpm build` is the real typecheck + content-collections codegen gate.
+  Standalone `pnpm typecheck` (`tsc --noEmit`) FAILS on a clean tree because the
+  generated `content-collections` types only exist after a build. Always build.
+- `pnpm test:unit` (vitest, ~2s) and `pnpm test` (Playwright, builds + starts a
+  prod server, slow) are the behavioral gates.
+
+## Steps
+
+1. Branch from `main`: `git checkout -b deps/security-bumps`.
+2. Record baseline: `pnpm audit > /tmp/audit-before.txt 2>&1` (note the count).
+3. Bump the content-collections chain first (highest value, highest risk):
+   `pnpm up @content-collections/core@latest @content-collections/next@latest @content-collections/mdx@latest`
+   (match whatever scoped packages appear in `package.json`).
+4. Run `pnpm build`. If type generation breaks (e.g. the collection config API
+   changed in the major), read `content-collections.ts` and the package
+   changelog, adapt the config, and rebuild. **STOP and report** if the config
+   API change is non-trivial (more than field renames) — do not guess at a large
+   migration.
+5. Bump `fumadocs-core` to clear `path-to-regexp`; rebuild.
+6. `eslint`/`flatted` is dev-only — bump `eslint` only if it doesn't force a flat-
+   config migration; otherwise leave it and note that `flatted` is dev-chain only.
+7. `pnpm audit > /tmp/audit-after.txt` and diff against baseline.
+
+## Done criteria (machine-checkable)
+
+- `pnpm build` → "Compiled successfully", exit 0.
+- `pnpm test:unit` → all pass.
+- `pnpm audit` shows the `serialize-javascript` and `path-to-regexp` advisories
+  resolved (or documented as unreachable if a bump isn't available).
+- `git diff package.json` touches only dependency versions.
+
+## Out of scope (do NOT touch)
+
+- TypeScript 6, Tailwind 4, Shiki 4 majors — separate, larger migrations
+  (rejected in prior audits as "no current cost"). Not part of this plan.
+- Any source file other than `content-collections.ts` (only if the config API
+  changed) and lockfile/`package.json`.
+
+## Escape hatch
+
+If the `@content-collections/core` major requires a config rewrite beyond simple
+field renames, STOP, revert the bump, and report — the security upside (build-
+time-only, trusted-input) does not justify a risky blind migration.

--- a/plans/015-markedsinnsikt-tab-aria.md
+++ b/plans/015-markedsinnsikt-tab-aria.md
@@ -1,0 +1,74 @@
+# 015 — Proper tab semantics for MarkedsinnsiktShell subtab/sector buttons
+
+**Status:** TODO
+**Written against commit:** `9dda014`
+**Priority:** P3 · **Effort:** S · **Risk of the fix:** LOW–MED (3 tests assert the attribute)
+**Depends on:** —
+
+## Why this matters
+
+`pnpm lint` reports 3 remaining warnings (the only ones left after plan-time
+cleanup):
+
+```
+src/components/markedsinnsikt/MarkedsinnsiktShell.tsx
+  293:13  warning  aria-selected is not supported by the role button … jsx-a11y/role-supports-aria-props
+  498:13  warning  aria-selected …
+ 1196:13  warning  aria-selected …
+```
+
+These are single-select control groups (subtabs at 293/498, sector picker at
+1196) rendered as bare `<button aria-selected={…}>`. `aria-selected` is only
+valid on roles like `tab`/`option`, not an implicit `button` role — so screen
+readers ignore the selected state.
+
+This was deliberately NOT auto-fixed by swapping to `aria-pressed`, because:
+
+1. A sibling control group at line ~153 already uses the correct
+   `role="tab"` + `aria-selected` inside `role="tablist"`. The buggy groups
+   should match that pattern, not diverge to `aria-pressed`.
+2. **Three Playwright tests assert `aria-selected="true"` on these controls**
+   (`tests/markedsinnsikt.spec.ts:114, 136, 175`). Swapping to `aria-pressed`
+   would break them and change the tested contract.
+
+## Current state (read these first)
+
+- `src/components/markedsinnsikt/MarkedsinnsiktShell.tsx` — the correct pattern
+  already in the file at ~line 148–155:
+  ```tsx
+  <div className="miv-range" role="tablist" aria-label="Tidsrom">
+    …
+    <button role="tab" aria-selected={value === r.id} … >
+  ```
+  The three warning sites use `<button aria-selected={…}>` WITHOUT `role="tab"`
+  and (likely) without a `role="tablist"` wrapper.
+- `tests/markedsinnsikt.spec.ts:114, 136, 175` — assert `aria-selected="true"`.
+
+## Steps
+
+1. For each of the three control groups (around lines 293, 498, 1196):
+   - Ensure the wrapping container has `role="tablist"` and an `aria-label`.
+   - Add `role="tab"` to each `<button>` that carries `aria-selected`.
+   - If the buttons control a panel, add `aria-controls={panelId}` and give the
+     panel `role="tabpanel"` + `id`. If there is no distinct panel element
+     (the view swaps inline), `role="tab"` + `aria-selected` alone clears the
+     lint and is acceptable — match the existing line-153 pattern exactly.
+2. Do NOT change `aria-selected` to `aria-pressed` anywhere.
+
+## Done criteria
+
+- `pnpm lint` → `0 errors, 0 warnings` (the 3 aria warnings gone).
+- `pnpm test` (or at least `npx playwright test tests/markedsinnsikt.spec.ts`)
+  → green; the 3 `aria-selected="true"` assertions still pass.
+
+## Out of scope
+
+- Any refactor of MarkedsinnsiktShell's state/structure (that is a separate,
+  larger maintainability item — see plans/README "considered and rejected").
+- The line-153 group, which is already correct.
+
+## Escape hatch
+
+If adding `role="tab"` requires a `tablist`/`tabpanel` restructure that the
+existing markup can't accommodate without reflowing the layout, STOP and report
+— the a11y win is small and not worth a risky DOM restructure.

--- a/plans/016-server-action-input-validation.md
+++ b/plans/016-server-action-input-validation.md
@@ -1,0 +1,72 @@
+# 016 — Zod input validation on lead/contact server actions
+
+**Status:** TODO
+**Written against commit:** `9dda014`
+**Priority:** P2 · **Effort:** M · **Risk of the fix:** LOW (additive)
+**Depends on:** — (complements the Discord sanitization already landed)
+
+## Why this matters
+
+The lead/contact server actions extract `FormData` with ad-hoc `String(...)` +
+`.slice()` and truthiness checks. There is no schema validation, so malformed or
+oversized payloads reach business logic and downstream sinks. The team already
+knows the right pattern — `naringsmegler-lead.ts` whitelists `propertyType`
+against `PROPERTY_TYPES` and length-caps every field — but it is applied
+unevenly. Discord-markdown injection is already mitigated at the choke point
+(`lib/email/sanitize.ts`); this plan closes the broader validation gap.
+
+## Scope — these actions
+
+- `src/app/actions/verdivurdering-intake.ts`
+- `src/app/actions/onboarding/onboarding.ts` (contact form)
+- `src/app/actions/cta-lead.ts`
+- `src/app/actions/newsletter.ts`
+- `src/app/actions/investorportal.ts`
+
+(Use `naringsmegler-lead.ts` as the exemplar — it already validates + caps.)
+
+## Current state (read these first)
+
+- `src/app/actions/naringsmegler-lead.ts` — the pattern to copy: `clean()` (now
+  delegates to `lib/email/sanitize.ts`), `PROPERTY_TYPES` whitelist, `SLUG_RE`,
+  hard length caps, honeypot field, `checkRateLimit`.
+- The actions in scope above — note where they read `formData.get(...)` raw.
+- `zod` — check `package.json`; if not present, this plan adds it
+  (`pnpm add zod`). It is a common, Layer-1 choice and tree-shakes well.
+
+## Steps
+
+1. Branch from `main`. Add `zod` if absent.
+2. Create `src/lib/forms/schemas.ts` with one schema per action input:
+   - `.string().trim().max(N)` per field (mirror the existing length caps).
+   - Email via `.string().email()`.
+   - Enums (property type, purpose) via `z.enum([...])` from the existing
+     constant arrays — do NOT duplicate the lists; import them.
+   - All optional fields `.optional()`.
+3. In each action, replace manual extraction with `schema.safeParse(raw)`.
+   On failure return the existing user-facing error shape
+   (`{ ok: false, error: "…" }`) — do not throw to the client.
+4. Keep `checkRateLimit` and the `sanitizeDiscordValue` choke point as-is; this
+   is validation, not a replacement for sanitization (defense in depth).
+5. Preserve every current success/error return shape so callers and tests are
+   unaffected.
+
+## Done criteria
+
+- `pnpm build` → exit 0.
+- `pnpm test:unit` + the relevant Playwright specs (`contact-form.spec.ts`,
+  `verdivurdering-reise.spec.ts`, `kontakt.spec.ts`) → green.
+- New unit tests in `tests/unit/` for each schema: a valid payload parses; an
+  oversized/invalid one is rejected with the user-facing error (follow
+  `tests/unit/verdivurdering-intake.test.ts` as the pattern).
+
+## Out of scope
+
+- Rate-limit architecture (in-memory per-instance is by design + Vercel WAF).
+- Re-routing or CRM-field changes (separate concern).
+
+## Escape hatch
+
+If an action's current return contract is load-bearing for a client component in
+a way a schema can't preserve, STOP and report rather than changing the
+client-facing shape.

--- a/plans/README.md
+++ b/plans/README.md
@@ -22,9 +22,9 @@ done.
 | 011  | Artikkel-veikart: 15 nye kunnskapsartikler i tre klynger (terms / for-investors / analysis) | P1 | L | 009 (anbefalt etter 010) | DONE (15 artikler i 3 batcher, APPROVED @ c4f3cab etter 3 korrektur-/speilingsrevisjoner; help 12→27 artikler; merget til main via PR #45 `63d3a4e`, 2026-06-12) |
 | 012  | Avkannibaliser blog↔help-duplikatene (sensitivitetsanalyse, DCF) | P2 | S–M | — (anbefalt etter 010) | DONE (APPROVED @ 706e6bf etter 1 terminologirevisjon; rolleregel etablert: help = kanonisk begrep («hva er X»), blog = praktisk/aktuelt; merget til main via PR #45 `63d3a4e`, 2026-06-12) |
 | 013  | Port «Kunnskapssenter v2»-designet (hub + artikkel-id-side) til /help | P1 | L | 009–012 | DONE (impl @ 3022e5b på `feat/kunnskapssenter-v2-design`; ENG+DESIGN CLEARED; build+typecheck grønt; /qa grønt — 0 konsollfeil, 0 bugs på hub+artikkel, alle nye interaksjoner + mobil verifisert. Ikke pushet/PR-et) |
-| 014  | Patch transitive dependency vulnerabilities (serialize-javascript / path-to-regexp via content-collections + fumadocs) | P2 | M | — | TODO |
-| 015  | Proper tab semantics (role="tab"/tablist) for MarkedsinnsiktShell subtab/sector buttons — clears the last 3 lint warnings | P3 | S | — | TODO |
-| 016  | Zod input validation on lead/contact server actions (complements the landed Discord sanitization) | P2 | M | — | TODO |
+| 014  | Patch transitive dependency vulnerabilities (serialize-javascript / path-to-regexp via content-collections + fumadocs) | P2 | M | — | DONE (core 0.8→0.15 + fumadocs 15→16 on `improve/audit-fixes`; schema-as-function → z.object migration; 9→4 audit advisories, the 4 remaining build/dev-chain only; build + 188 tests green) |
+| 015  | Proper tab semantics (role="tab"/tablist) for MarkedsinnsiktShell subtab/sector buttons — clears the last 3 lint warnings | P3 | S | — | DONE (`improve/audit-fixes`; lint now 0 warnings; 3 aria-selected tests still green) |
+| 016  | Zod input validation on lead/contact server actions (complements the landed Discord sanitization) | P2 | M | — | DONE (`improve/audit-fixes`; zod 4 schemas for 5 actions + 9 unit tests; investorportal also re-routed through subscribe() so it actually reaches the CRM) |
 
 Status values: TODO | IN PROGRESS | DONE | BLOCKED (with one-line reason) | REJECTED (with one-line rationale)
 

--- a/plans/README.md
+++ b/plans/README.md
@@ -22,8 +22,37 @@ done.
 | 011  | Artikkel-veikart: 15 nye kunnskapsartikler i tre klynger (terms / for-investors / analysis) | P1 | L | 009 (anbefalt etter 010) | DONE (15 artikler i 3 batcher, APPROVED @ c4f3cab etter 3 korrektur-/speilingsrevisjoner; help 12→27 artikler; merget til main via PR #45 `63d3a4e`, 2026-06-12) |
 | 012  | Avkannibaliser blog↔help-duplikatene (sensitivitetsanalyse, DCF) | P2 | S–M | — (anbefalt etter 010) | DONE (APPROVED @ 706e6bf etter 1 terminologirevisjon; rolleregel etablert: help = kanonisk begrep («hva er X»), blog = praktisk/aktuelt; merget til main via PR #45 `63d3a4e`, 2026-06-12) |
 | 013  | Port «Kunnskapssenter v2»-designet (hub + artikkel-id-side) til /help | P1 | L | 009–012 | DONE (impl @ 3022e5b på `feat/kunnskapssenter-v2-design`; ENG+DESIGN CLEARED; build+typecheck grønt; /qa grønt — 0 konsollfeil, 0 bugs på hub+artikkel, alle nye interaksjoner + mobil verifisert. Ikke pushet/PR-et) |
+| 014  | Patch transitive dependency vulnerabilities (serialize-javascript / path-to-regexp via content-collections + fumadocs) | P2 | M | — | TODO |
+| 015  | Proper tab semantics (role="tab"/tablist) for MarkedsinnsiktShell subtab/sector buttons — clears the last 3 lint warnings | P3 | S | — | TODO |
+| 016  | Zod input validation on lead/contact server actions (complements the landed Discord sanitization) | P2 | M | — | TODO |
 
 Status values: TODO | IN PROGRESS | DONE | BLOCKED (with one-line reason) | REJECTED (with one-line rationale)
+
+## Full-repo audit 2026-06-14 (commit `eb166f1` → branch `improve/audit-fixes`)
+
+First full re-audit (correctness/security/perf/tests/deps/DX) since 2026-06-10
+(`3c71295`); the 009–013 rounds were help/SEO-scoped. 4-agent fan-out + code-level
+vetting + live Supabase schema check.
+
+**Implemented directly on `improve/audit-fixes` (safe, high-leverage):**
+- Lead routing: the three `HIGH_INTENT` lists had drifted — `leads.ts` omitted
+  `investorportal`, so investor-portal leads silently routed to `web_signups`
+  instead of `crm_leads`. Unified to one exported constant (decision: investor
+  leads → CRM). Confirmed via Supabase MCP: 0 stranded rows, schema-safe. + crm_
+  activities failure no longer discards a saved lead. + 2 regression tests.
+- Security: `sanitizeDiscordValue()` choke point in `discord.ts` (Discord-markdown
+  injection across all sources, not just naringsmegler).
+- DRY: removed duplicate `stripHash`.
+- Lint: 20 → 3 warnings (eslint `_`-prefix convention, dead disables, useEffect
+  const hoist, OG `<img>` alt). Remaining 3 → plan 015.
+
+**Considered and rejected (don't re-audit):**
+- `@react-email/components` deprecated — monitor, don't migrate (as 2026-06-10).
+- TS 6 / Tailwind 4 / Shiki 4 majors — no current cost; defer.
+- `/eiendommer/[slug]` related-covers waterfall — speculative, MED-conf, minor.
+- Supabase RLS / global rate-limit — ops-side; in-memory limiter is by design.
+- Modal duplication (6 CtaLead modals) + `MarkedsinnsiktShell` 1218-line split —
+  real maintainability debt, L effort, low urgency; revisit on next touch.
 
 ## Dependency notes
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,6 +127,9 @@ importers:
       vaul:
         specifier: ^1.1.2
         version: 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@content-collections/core':
         specifier: ^0.8.0
@@ -4813,6 +4816,9 @@ packages:
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
@@ -7153,8 +7159,8 @@ snapshots:
       '@babel/parser': 7.29.3
       eslint: 9.39.4(jiti@1.21.7)
       hermes-parser: 0.25.1
-      zod: 3.25.76
-      zod-validation-error: 4.0.2(zod@3.25.76)
+      zod: 4.4.3
+      zod-validation-error: 4.0.2(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -9847,10 +9853,12 @@ snapshots:
 
   yoga-wasm-web@0.3.3: {}
 
-  zod-validation-error@4.0.2(zod@3.25.76):
+  zod-validation-error@4.0.2(zod@4.4.3):
     dependencies:
-      zod: 3.25.76
+      zod: 4.4.3
 
   zod@3.25.76: {}
+
+  zod@4.4.3: {}
 
   zwitch@2.0.4: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,14 +132,14 @@ importers:
         version: 4.4.3
     devDependencies:
       '@content-collections/core':
-        specifier: ^0.8.0
-        version: 0.8.2(typescript@5.9.3)
+        specifier: ^0.15.1
+        version: 0.15.1(typescript@5.9.3)
       '@content-collections/mdx':
-        specifier: ^0.2.0
-        version: 0.2.2(@content-collections/core@0.8.2(typescript@5.9.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        specifier: ^0.2.2
+        version: 0.2.2(@content-collections/core@0.15.1(typescript@5.9.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@content-collections/next':
-        specifier: ^0.2.4
-        version: 0.2.8(@content-collections/core@0.8.2(typescript@5.9.3))(next@16.2.9(@babel/core@7.29.0)(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+        specifier: ^0.2.11
+        version: 0.2.11(@content-collections/core@0.15.1(typescript@5.9.3))(next@16.2.9(@babel/core@7.29.0)(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
       '@playwright/test':
         specifier: ^1.60.0
         version: 1.60.0
@@ -177,8 +177,8 @@ importers:
         specifier: 16.2.9
         version: 16.2.9(@typescript-eslint/parser@8.59.4(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
       fumadocs-core:
-        specifier: ^15.0.8
-        version: 15.8.5(@types/react@19.2.17)(lucide-react@1.18.0(react@19.2.7))(next@16.2.9(@babel/core@7.29.0)(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        specifier: ^16.10.3
+        version: 16.10.3(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.18.0(react@19.2.7))(next@16.2.9(@babel/core@7.29.0)(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
       github-slugger:
         specifier: ^2.0.0
         version: 2.0.0
@@ -211,7 +211,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@types/node@22.18.12)(jsdom@29.1.1)(vite@8.0.16(@types/node@22.18.12)(esbuild@0.25.11)(jiti@1.21.7)(yaml@2.9.0))
+        version: 4.1.8(@types/node@22.18.12)(jsdom@29.1.1)(vite@8.0.16(@types/node@22.18.12)(esbuild@0.25.12)(jiti@1.21.7)(yaml@2.9.0))
 
 packages:
 
@@ -236,6 +236,10 @@ packages:
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/code-frame@7.29.7':
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/compat-data@7.29.3':
@@ -276,6 +280,10 @@ packages:
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-option@7.27.1':
     resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
     engines: {node: '>=6.9.0'}
@@ -291,6 +299,10 @@ packages:
 
   '@babel/runtime@7.28.4':
     resolution: {integrity: sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/runtime@7.29.7':
+    resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/template@7.28.6':
@@ -309,13 +321,13 @@ packages:
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
     hasBin: true
 
-  '@content-collections/core@0.8.2':
-    resolution: {integrity: sha512-62yVC3ne47YJ1KeCw5nk0H/G/xGBagcoWyMpVyTaCnDJhoIoTvmqBrsc+78Zk8s2Ssnb0Eo1Q4w3ZHwgL88pjg==}
+  '@content-collections/core@0.15.1':
+    resolution: {integrity: sha512-uQmhvvsSgNJs7QOi4+IgvDhv7v1yueCr6n7WgMahUDFeVchML/WFl9D2vrklxUnXY+YaBGTkc2+q8PcEVM19WA==}
     peerDependencies:
-      typescript: ^5.0.2
+      typescript: ^5.0.2 || ^6.0.0
 
-  '@content-collections/integrations@0.3.0':
-    resolution: {integrity: sha512-He+TXQC94LO/1bNygTioh3J5H0K/mkFVPVkIrM5kHybprvi5bRmGa91ViZ6K6icFAzGH4jFD0iasR56fZcMGTA==}
+  '@content-collections/integrations@0.5.0':
+    resolution: {integrity: sha512-1en7r518sct0Y8CQ5IsuuBN4uAmtNLaWuxmseW43OxeXyj43Uu2aPBfbopjL4b5xH8WZBdDrrPmikgOl42U46A==}
     peerDependencies:
       '@content-collections/core': 0.x
 
@@ -326,11 +338,11 @@ packages:
       react: '>= 18'
       react-dom: '>= 18'
 
-  '@content-collections/next@0.2.8':
-    resolution: {integrity: sha512-66phtKBPjx5Uz4dDCrjB5wtW+skzd7Jk5AXC9fqTk1wqUdZwb6qs6d3/td4LcZI8ZMN0SPyls8N04k8xAcHm9A==}
+  '@content-collections/next@0.2.11':
+    resolution: {integrity: sha512-/JV+QEXjsWRD5Qn9uBiMUB/2ml66wCRllG6PuJUpOH7PMT4cy/Qk5UnIEpfjdINF6rxfXjUtv8z9Q8QWxR6ZQg==}
     peerDependencies:
       '@content-collections/core': 0.x
-      next: ^12 || ^13 || ^14 || ^15
+      next: ^12 || ^13 || ^14 || ^15 || ^16
 
   '@csstools/color-helpers@6.0.2':
     resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
@@ -391,158 +403,158 @@ packages:
     peerDependencies:
       esbuild: '*'
 
-  '@esbuild/aix-ppc64@0.25.11':
-    resolution: {integrity: sha512-Xt1dOL13m8u0WE8iplx9Ibbm+hFAO0GsU2P34UNoDGvZYkY8ifSiy6Zuc1lYxfG7svWE2fzqCUmFp5HCn51gJg==}
+  '@esbuild/aix-ppc64@0.25.12':
+    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.25.11':
-    resolution: {integrity: sha512-9slpyFBc4FPPz48+f6jyiXOx/Y4v34TUeDDXJpZqAWQn/08lKGeD8aDp9TMn9jDz2CiEuHwfhRmGBvpnd/PWIQ==}
+  '@esbuild/android-arm64@0.25.12':
+    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm@0.25.11':
-    resolution: {integrity: sha512-uoa7dU+Dt3HYsethkJ1k6Z9YdcHjTrSb5NUy66ZfZaSV8hEYGD5ZHbEMXnqLFlbBflLsl89Zke7CAdDJ4JI+Gg==}
+  '@esbuild/android-arm@0.25.12':
+    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.25.11':
-    resolution: {integrity: sha512-Sgiab4xBjPU1QoPEIqS3Xx+R2lezu0LKIEcYe6pftr56PqPygbB7+szVnzoShbx64MUupqoE0KyRlN7gezbl8g==}
+  '@esbuild/android-x64@0.25.12':
+    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.25.11':
-    resolution: {integrity: sha512-VekY0PBCukppoQrycFxUqkCojnTQhdec0vevUL/EDOCnXd9LKWqD/bHwMPzigIJXPhC59Vd1WFIL57SKs2mg4w==}
+  '@esbuild/darwin-arm64@0.25.12':
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.25.11':
-    resolution: {integrity: sha512-+hfp3yfBalNEpTGp9loYgbknjR695HkqtY3d3/JjSRUyPg/xd6q+mQqIb5qdywnDxRZykIHs3axEqU6l1+oWEQ==}
+  '@esbuild/darwin-x64@0.25.12':
+    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.25.11':
-    resolution: {integrity: sha512-CmKjrnayyTJF2eVuO//uSjl/K3KsMIeYeyN7FyDBjsR3lnSJHaXlVoAK8DZa7lXWChbuOk7NjAc7ygAwrnPBhA==}
+  '@esbuild/freebsd-arm64@0.25.12':
+    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.25.11':
-    resolution: {integrity: sha512-Dyq+5oscTJvMaYPvW3x3FLpi2+gSZTCE/1ffdwuM6G1ARang/mb3jvjxs0mw6n3Lsw84ocfo9CrNMqc5lTfGOw==}
+  '@esbuild/freebsd-x64@0.25.12':
+    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.25.11':
-    resolution: {integrity: sha512-Qr8AzcplUhGvdyUF08A1kHU3Vr2O88xxP0Tm8GcdVOUm25XYcMPp2YqSVHbLuXzYQMf9Bh/iKx7YPqECs6ffLA==}
+  '@esbuild/linux-arm64@0.25.12':
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm@0.25.11':
-    resolution: {integrity: sha512-TBMv6B4kCfrGJ8cUPo7vd6NECZH/8hPpBHHlYI3qzoYFvWu2AdTvZNuU/7hsbKWqu/COU7NIK12dHAAqBLLXgw==}
+  '@esbuild/linux-arm@0.25.12':
+    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.25.11':
-    resolution: {integrity: sha512-TmnJg8BMGPehs5JKrCLqyWTVAvielc615jbkOirATQvWWB1NMXY77oLMzsUjRLa0+ngecEmDGqt5jiDC6bfvOw==}
+  '@esbuild/linux-ia32@0.25.12':
+    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.25.11':
-    resolution: {integrity: sha512-DIGXL2+gvDaXlaq8xruNXUJdT5tF+SBbJQKbWy/0J7OhU8gOHOzKmGIlfTTl6nHaCOoipxQbuJi7O++ldrxgMw==}
+  '@esbuild/linux-loong64@0.25.12':
+    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.25.11':
-    resolution: {integrity: sha512-Osx1nALUJu4pU43o9OyjSCXokFkFbyzjXb6VhGIJZQ5JZi8ylCQ9/LFagolPsHtgw6himDSyb5ETSfmp4rpiKQ==}
+  '@esbuild/linux-mips64el@0.25.12':
+    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.25.11':
-    resolution: {integrity: sha512-nbLFgsQQEsBa8XSgSTSlrnBSrpoWh7ioFDUmwo158gIm5NNP+17IYmNWzaIzWmgCxq56vfr34xGkOcZ7jX6CPw==}
+  '@esbuild/linux-ppc64@0.25.12':
+    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.25.11':
-    resolution: {integrity: sha512-HfyAmqZi9uBAbgKYP1yGuI7tSREXwIb438q0nqvlpxAOs3XnZ8RsisRfmVsgV486NdjD7Mw2UrFSw51lzUk1ww==}
+  '@esbuild/linux-riscv64@0.25.12':
+    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.25.11':
-    resolution: {integrity: sha512-HjLqVgSSYnVXRisyfmzsH6mXqyvj0SA7pG5g+9W7ESgwA70AXYNpfKBqh1KbTxmQVaYxpzA/SvlB9oclGPbApw==}
+  '@esbuild/linux-s390x@0.25.12':
+    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-x64@0.25.11':
-    resolution: {integrity: sha512-HSFAT4+WYjIhrHxKBwGmOOSpphjYkcswF449j6EjsjbinTZbp8PJtjsVK1XFJStdzXdy/jaddAep2FGY+wyFAQ==}
+  '@esbuild/linux-x64@0.25.12':
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/netbsd-arm64@0.25.11':
-    resolution: {integrity: sha512-hr9Oxj1Fa4r04dNpWr3P8QKVVsjQhqrMSUzZzf+LZcYjZNqhA3IAfPQdEh1FLVUJSiu6sgAwp3OmwBfbFgG2Xg==}
+  '@esbuild/netbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.25.11':
-    resolution: {integrity: sha512-u7tKA+qbzBydyj0vgpu+5h5AeudxOAGncb8N6C9Kh1N4n7wU1Xw1JDApsRjpShRpXRQlJLb9wY28ELpwdPcZ7A==}
+  '@esbuild/netbsd-x64@0.25.12':
+    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/openbsd-arm64@0.25.11':
-    resolution: {integrity: sha512-Qq6YHhayieor3DxFOoYM1q0q1uMFYb7cSpLD2qzDSvK1NAvqFi8Xgivv0cFC6J+hWVw2teCYltyy9/m/14ryHg==}
+  '@esbuild/openbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.25.11':
-    resolution: {integrity: sha512-CN+7c++kkbrckTOz5hrehxWN7uIhFFlmS/hqziSFVWpAzpWrQoAG4chH+nN3Be+Kzv/uuo7zhX716x3Sn2Jduw==}
+  '@esbuild/openbsd-x64@0.25.12':
+    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openharmony-arm64@0.25.11':
-    resolution: {integrity: sha512-rOREuNIQgaiR+9QuNkbkxubbp8MSO9rONmwP5nKncnWJ9v5jQ4JxFnLu4zDSRPf3x4u+2VN4pM4RdyIzDty/wQ==}
+  '@esbuild/openharmony-arm64@0.25.12':
+    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
 
-  '@esbuild/sunos-x64@0.25.11':
-    resolution: {integrity: sha512-nq2xdYaWxyg9DcIyXkZhcYulC6pQ2FuCgem3LI92IwMgIZ69KHeY8T4Y88pcwoLIjbed8n36CyKoYRDygNSGhA==}
+  '@esbuild/sunos-x64@0.25.12':
+    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/win32-arm64@0.25.11':
-    resolution: {integrity: sha512-3XxECOWJq1qMZ3MN8srCJ/QfoLpL+VaxD/WfNRm1O3B4+AZ/BnLVgFbUV3eiRYDMXetciH16dwPbbHqwe1uU0Q==}
+  '@esbuild/win32-arm64@0.25.12':
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.25.11':
-    resolution: {integrity: sha512-3ukss6gb9XZ8TlRyJlgLn17ecsK4NSQTmdIXRASVsiS2sQ6zPPZklNJT5GR5tE/MUarymmy8kCEf5xPCNCqVOA==}
+  '@esbuild/win32-ia32@0.25.12':
+    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-x64@0.25.11':
-    resolution: {integrity: sha512-D7Hpz6A2L4hzsRpPaCYkQnGOotdUpDzSGRIv9I+1ITdHROSFUWW95ZPZWQmGka1Fg7W3zFJowyn9WGwMJ0+KPA==}
+  '@esbuild/win32-x64@0.25.12':
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -611,9 +623,6 @@ packages:
 
   '@floating-ui/utils@0.2.10':
     resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
-
-  '@formatjs/intl-localematcher@0.6.2':
-    resolution: {integrity: sha512-XOMO2Hupl0wdd172Y06h6kLpBz6Dv+J4okPLl4LPtzbr8f66WbIoy4ev98EBuZ6ZK4h5ydTN6XneT4QVpD7cdA==}
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -910,94 +919,12 @@ packages:
       react: ^18 || ^19
       react-dom: ^18 || ^19
 
-  '@orama/orama@3.1.16':
-    resolution: {integrity: sha512-scSmQBD8eANlMUOglxHrN1JdSW8tDghsPuS83otqealBiIeMukCQMOf/wc0JJjDXomqwNdEQFLXLGHrU6PGxuA==}
+  '@orama/orama@3.1.18':
+    resolution: {integrity: sha512-a61ljmRVVyG5MC/698C8/FfFDw5a8LOIvyOLW5fztgUXqUpc1jOfQzOitSCbge657OgXXThmY3Tk8fpiDb4UcA==}
     engines: {node: '>= 20.0.0'}
 
   '@oxc-project/types@0.133.0':
     resolution: {integrity: sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==}
-
-  '@parcel/watcher-android-arm64@2.5.1':
-    resolution: {integrity: sha512-KF8+j9nNbUN8vzOFDpRMsaKBHZ/mcjEjMToVMJOhTozkDonQFFrRcfdLWn6yWKCmJKmdVxSgHiYvTCef4/qcBA==}
-    engines: {node: '>= 10.0.0'}
-    cpu: [arm64]
-    os: [android]
-
-  '@parcel/watcher-darwin-arm64@2.5.1':
-    resolution: {integrity: sha512-eAzPv5osDmZyBhou8PoF4i6RQXAfeKL9tjb3QzYuccXFMQU0ruIc/POh30ePnaOyD1UXdlKguHBmsTs53tVoPw==}
-    engines: {node: '>= 10.0.0'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@parcel/watcher-darwin-x64@2.5.1':
-    resolution: {integrity: sha512-1ZXDthrnNmwv10A0/3AJNZ9JGlzrF82i3gNQcWOzd7nJ8aj+ILyW1MTxVk35Db0u91oD5Nlk9MBiujMlwmeXZg==}
-    engines: {node: '>= 10.0.0'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@parcel/watcher-freebsd-x64@2.5.1':
-    resolution: {integrity: sha512-SI4eljM7Flp9yPuKi8W0ird8TI/JK6CSxju3NojVI6BjHsTyK7zxA9urjVjEKJ5MBYC+bLmMcbAWlZ+rFkLpJQ==}
-    engines: {node: '>= 10.0.0'}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@parcel/watcher-linux-arm-glibc@2.5.1':
-    resolution: {integrity: sha512-RCdZlEyTs8geyBkkcnPWvtXLY44BCeZKmGYRtSgtwwnHR4dxfHRG3gR99XdMEdQ7KeiDdasJwwvNSF5jKtDwdA==}
-    engines: {node: '>= 10.0.0'}
-    cpu: [arm]
-    os: [linux]
-
-  '@parcel/watcher-linux-arm-musl@2.5.1':
-    resolution: {integrity: sha512-6E+m/Mm1t1yhB8X412stiKFG3XykmgdIOqhjWj+VL8oHkKABfu/gjFj8DvLrYVHSBNC+/u5PeNrujiSQ1zwd1Q==}
-    engines: {node: '>= 10.0.0'}
-    cpu: [arm]
-    os: [linux]
-
-  '@parcel/watcher-linux-arm64-glibc@2.5.1':
-    resolution: {integrity: sha512-LrGp+f02yU3BN9A+DGuY3v3bmnFUggAITBGriZHUREfNEzZh/GO06FF5u2kx8x+GBEUYfyTGamol4j3m9ANe8w==}
-    engines: {node: '>= 10.0.0'}
-    cpu: [arm64]
-    os: [linux]
-
-  '@parcel/watcher-linux-arm64-musl@2.5.1':
-    resolution: {integrity: sha512-cFOjABi92pMYRXS7AcQv9/M1YuKRw8SZniCDw0ssQb/noPkRzA+HBDkwmyOJYp5wXcsTrhxO0zq1U11cK9jsFg==}
-    engines: {node: '>= 10.0.0'}
-    cpu: [arm64]
-    os: [linux]
-
-  '@parcel/watcher-linux-x64-glibc@2.5.1':
-    resolution: {integrity: sha512-GcESn8NZySmfwlTsIur+49yDqSny2IhPeZfXunQi48DMugKeZ7uy1FX83pO0X22sHntJ4Ub+9k34XQCX+oHt2A==}
-    engines: {node: '>= 10.0.0'}
-    cpu: [x64]
-    os: [linux]
-
-  '@parcel/watcher-linux-x64-musl@2.5.1':
-    resolution: {integrity: sha512-n0E2EQbatQ3bXhcH2D1XIAANAcTZkQICBPVaxMeaCVBtOpBZpWJuf7LwyWPSBDITb7In8mqQgJ7gH8CILCURXg==}
-    engines: {node: '>= 10.0.0'}
-    cpu: [x64]
-    os: [linux]
-
-  '@parcel/watcher-win32-arm64@2.5.1':
-    resolution: {integrity: sha512-RFzklRvmc3PkjKjry3hLF9wD7ppR4AKcWNzH7kXR7GUe0Igb3Nz8fyPwtZCSquGrhU5HhUNDr/mKBqj7tqA2Vw==}
-    engines: {node: '>= 10.0.0'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@parcel/watcher-win32-ia32@2.5.1':
-    resolution: {integrity: sha512-c2KkcVN+NJmuA7CGlaGD1qJh1cLfDnQsHjE89E60vUEMlqduHGCdCLJCID5geFVM0dOtA3ZiIO8BoEQmzQVfpQ==}
-    engines: {node: '>= 10.0.0'}
-    cpu: [ia32]
-    os: [win32]
-
-  '@parcel/watcher-win32-x64@2.5.1':
-    resolution: {integrity: sha512-9lHBdJITeNR++EvSQVUcaZoWupyHfXe1jZvGZ06O/5MflPcuPLtEphScIBL+AiCWBO46tDSHzWyD0uDmmZqsgA==}
-    engines: {node: '>= 10.0.0'}
-    cpu: [x64]
-    os: [win32]
-
-  '@parcel/watcher@2.5.1':
-    resolution: {integrity: sha512-dfUnCxiN9H4ap84DvD2ubjw+3vUNpstxa0TneY/Paat8a3R4uQZDLSvWjmznAY/DoahqTHl9V46HF/Zs3F29pg==}
-    engines: {node: '>= 10.0.0'}
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -1600,44 +1527,48 @@ packages:
   '@shikijs/core@1.29.2':
     resolution: {integrity: sha512-vju0lY9r27jJfOY4Z7+Rt/nIOjzJpZ3y+nYpqtUZInVoXQ/TJZcfGnNOGnKjFdVZb8qexiCuSlZRKcGfhhTTZQ==}
 
-  '@shikijs/core@3.13.0':
-    resolution: {integrity: sha512-3P8rGsg2Eh2qIHekwuQjzWhKI4jV97PhvYjYUzGqjvJfqdQPz+nMlfWahU24GZAyW1FxFI1sYjyhfh5CoLmIUA==}
+  '@shikijs/core@4.2.0':
+    resolution: {integrity: sha512-Hc87Ab1Ld/vEbZRCbwx344I5v+4RU8CVToUTRkqXL1+TjbuOp9U5Xa0M23V4GEWHxVn+yO5otb+HkQVm3ptWQQ==}
+    engines: {node: '>=20'}
 
   '@shikijs/engine-javascript@1.29.2':
     resolution: {integrity: sha512-iNEZv4IrLYPv64Q6k7EPpOCE/nuvGiKl7zxdq0WFuRPF5PAE9PRo2JGq/d8crLusM59BRemJ4eOqrFrC4wiQ+A==}
 
-  '@shikijs/engine-javascript@3.13.0':
-    resolution: {integrity: sha512-Ty7xv32XCp8u0eQt8rItpMs6rU9Ki6LJ1dQOW3V/56PKDcpvfHPnYFbsx5FFUP2Yim34m/UkazidamMNVR4vKg==}
+  '@shikijs/engine-javascript@4.2.0':
+    resolution: {integrity: sha512-fjETeq1k5ffyXqRgS6+3hpvqseLalp1kjNfRbXpUgWR8FpZ1CmQfiNHovc5lncYjt/Vg5JK/WJEmLahjwMa0og==}
+    engines: {node: '>=20'}
 
   '@shikijs/engine-oniguruma@1.29.2':
     resolution: {integrity: sha512-7iiOx3SG8+g1MnlzZVDYiaeHe7Ez2Kf2HrJzdmGwkRisT7r4rak0e655AcM/tF9JG/kg5fMNYlLLKglbN7gBqA==}
 
-  '@shikijs/engine-oniguruma@3.13.0':
-    resolution: {integrity: sha512-O42rBGr4UDSlhT2ZFMxqM7QzIU+IcpoTMzb3W7AlziI1ZF7R8eS2M0yt5Ry35nnnTX/LTLXFPUjRFCIW+Operg==}
+  '@shikijs/engine-oniguruma@4.2.0':
+    resolution: {integrity: sha512-hTorK1dffPkpbMUk6Z+828PgRo7d07HbnizoP0hNPFjhxMHctj0Px/qoHeGMYafc6ju+u9iMldN4JbVzNQM++g==}
+    engines: {node: '>=20'}
 
   '@shikijs/langs@1.29.2':
     resolution: {integrity: sha512-FIBA7N3LZ+223U7cJDUYd5shmciFQlYkFXlkKVaHsCPgfVLiO+e12FmQE6Tf9vuyEsFe3dIl8qGWKXgEHL9wmQ==}
 
-  '@shikijs/langs@3.13.0':
-    resolution: {integrity: sha512-672c3WAETDYHwrRP0yLy3W1QYB89Hbpj+pO4KhxK6FzIrDI2FoEXNiNCut6BQmEApYLfuYfpgOZaqbY+E9b8wQ==}
+  '@shikijs/langs@4.2.0':
+    resolution: {integrity: sha512-bwrVRlJ0wUhZxAbVdvBbv2TTC9yLsh4C/IO5Ofz0T8MQntgDvyVnkbjw9vi50r1kx7RCIJdnJnjZAwmAsXFLZQ==}
+    engines: {node: '>=20'}
 
-  '@shikijs/rehype@3.13.0':
-    resolution: {integrity: sha512-dxvB5gXEpiTI3beGwOPEwxFxQNmUWM4cwOWbvUmL6DnQJGl18/+cCjVHZK2OnasmU0v7SvM39Zh3iliWdwfBDA==}
+  '@shikijs/primitive@4.2.0':
+    resolution: {integrity: sha512-NOq+DtUkVBJtZMVXL5A0vI0Xk8nvDYaXetFHSJFlOqjDZIVhIPRYFdGkSoElDqNuegikcc3A76SNUa8dTqtAYA==}
+    engines: {node: '>=20'}
 
   '@shikijs/themes@1.29.2':
     resolution: {integrity: sha512-i9TNZlsq4uoyqSbluIcZkmPL9Bfi3djVxRnofUHwvx/h6SRW3cwgBC5SML7vsDcWyukY0eCzVN980rqP6qNl9g==}
 
-  '@shikijs/themes@3.13.0':
-    resolution: {integrity: sha512-Vxw1Nm1/Od8jyA7QuAenaV78BG2nSr3/gCGdBkLpfLscddCkzkL36Q5b67SrLLfvAJTOUzW39x4FHVCFriPVgg==}
-
-  '@shikijs/transformers@3.13.0':
-    resolution: {integrity: sha512-833lcuVzcRiG+fXvgslWsM2f4gHpjEgui1ipIknSizRuTgMkNZupiXE5/TVJ6eSYfhNBFhBZKkReKWO2GgYmqA==}
+  '@shikijs/themes@4.2.0':
+    resolution: {integrity: sha512-RX8IHYeLv8Cu2W6ruc3RxUqWn0IYCqSrMBzi/uRGAmfyDNOnNO5BF/Px7o97n4XTpmFTo5GbRaazuOWj+2ak2w==}
+    engines: {node: '>=20'}
 
   '@shikijs/types@1.29.2':
     resolution: {integrity: sha512-VJjK0eIijTZf0QSTODEXCqinjBn0joAHQ+aPSBzrv4O2d/QSbsMw+ZeSRx03kV34Hy7NzUvV/7NqfYGRLrASmw==}
 
-  '@shikijs/types@3.13.0':
-    resolution: {integrity: sha512-oM9P+NCFri/mmQ8LoFGVfVyemm5Hi27330zuOBp0annwJdKH1kOLndw3zCtAVDehPLg9fKqoEx3Ht/wNZxolfw==}
+  '@shikijs/types@4.2.0':
+    resolution: {integrity: sha512-VT/MKtlpOhEPZloSH3Pb9WCZEBDoQVMa9jedp5UAwmJOar1DVc9DRODAxmYPW9M93IK4ryuqRejFfmlvlVDemw==}
+    engines: {node: '>=20'}
 
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
@@ -1760,6 +1691,9 @@ packages:
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
   '@types/geojson@7946.0.16':
     resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
@@ -2248,6 +2182,10 @@ packages:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
     engines: {node: '>= 8.10.0'}
 
+  chokidar@4.0.3:
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
+
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
 
@@ -2404,6 +2342,9 @@ packages:
   decode-named-character-reference@1.2.0:
     resolution: {integrity: sha512-c6fcElNV6ShtZXmsgNgFFV5tVX2PaV4g+MOAkb8eXHvn6sryJBrZa9r0zV6+dtTyoCKxtDy5tyQ5ZwQuidtd+Q==}
 
+  decode-named-character-reference@1.3.0:
+    resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
+
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
@@ -2422,11 +2363,6 @@ packages:
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
-
-  detect-libc@1.0.3:
-    resolution: {integrity: sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==}
-    engines: {node: '>=0.10'}
-    hasBin: true
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
@@ -2538,8 +2474,8 @@ packages:
   esast-util-from-js@2.0.1:
     resolution: {integrity: sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw==}
 
-  esbuild@0.25.11:
-    resolution: {integrity: sha512-KohQwyzrKTQmhXDW1PjCv3Tyspn9n5GcY2RTDqeORIdIJY8yKIF7sTSopFmn/wpMPW4rdPXI0UE5LJLuq3bx0Q==}
+  esbuild@0.25.12:
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -2697,8 +2633,8 @@ packages:
   estree-util-to-js@2.0.0:
     resolution: {integrity: sha512-WDF+xj5rRWmD5tj6bIqRi6CkLIXbbNQUcxQHzGysQzvHmdYG2G7p/Tf0J0gpxGgkeMZNTIjT/AoSvC9Xehcgdg==}
 
-  estree-util-value-to-estree@3.4.1:
-    resolution: {integrity: sha512-E4fEc8KLhDXnbyDa5XrbdT9PbgSMt0AGZPFUsGFok8N2Q7DTO+F6xAFJjIdw71EkidRg186I1mQCKzZ1ZbEsCw==}
+  estree-util-value-to-estree@3.5.0:
+    resolution: {integrity: sha512-aMV56R27Gv3QmfmF1MY12GWkGzzeAezAX+UplqHVASfjc9wNzI/X6hC0S9oxq61WT4aQesLGslWP9tKk6ghRZQ==}
 
   estree-util-visit@2.0.0:
     resolution: {integrity: sha512-m5KgiH85xAhhW8Wta0vShLcUvOsh3LLPI2YVwcbio1l7E09NTLL1EyMZFM1OyWowoH0skScNbhOPl4kcBgzTww==}
@@ -2817,30 +2753,49 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
-  fumadocs-core@15.8.5:
-    resolution: {integrity: sha512-hyJtKGuB2J/5y7tDfI1EnGMKlNbSXM5N5cpwvgCY0DcBJwFMDG/GpSpaVRzh3aWy67pAYDZFIwdtbKXBa/q5bg==}
+  fumadocs-core@16.10.3:
+    resolution: {integrity: sha512-xXhqz/fqbN7pLlshJb/B5L+vzMJOmWxoPj7+KMRTa/4A669hKeeCBPpRAiooMqjblWqIRSxLiO02/ds8ltvUPQ==}
     peerDependencies:
-      '@mixedbread/sdk': ^0.19.0
-      '@oramacloud/client': 1.x.x || 2.x.x
+      '@mdx-js/mdx': '*'
+      '@mixedbread/sdk': 0.x.x
+      '@orama/core': 1.x.x
+      '@oramacloud/client': 2.x.x
       '@tanstack/react-router': 1.x.x
+      '@types/estree-jsx': '*'
+      '@types/hast': '*'
+      '@types/mdast': '*'
       '@types/react': ^19.2.0
       algoliasearch: 5.x.x
+      flexsearch: '*'
       lucide-react: '*'
-      next: 14.x.x || 15.x.x
-      react: 18.x.x || 19.x.x
-      react-dom: 18.x.x || 19.x.x
+      next: 16.x.x
+      react: ^19.2.0
+      react-dom: ^19.2.0
       react-router: 7.x.x
-      waku: ^0.26.0
+      waku: '*'
+      zod: 4.x.x
     peerDependenciesMeta:
+      '@mdx-js/mdx':
+        optional: true
       '@mixedbread/sdk':
+        optional: true
+      '@orama/core':
         optional: true
       '@oramacloud/client':
         optional: true
       '@tanstack/react-router':
         optional: true
+      '@types/estree-jsx':
+        optional: true
+      '@types/hast':
+        optional: true
+      '@types/mdast':
+        optional: true
       '@types/react':
         optional: true
       algoliasearch:
+        optional: true
+      flexsearch:
         optional: true
       lucide-react:
         optional: true
@@ -2853,6 +2808,8 @@ packages:
       react-router:
         optional: true
       waku:
+        optional: true
+      zod:
         optional: true
 
   function-bind@1.1.2:
@@ -2955,6 +2912,10 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
+    engines: {node: '>= 0.4'}
+
   hast-util-heading-rank@3.0.0:
     resolution: {integrity: sha512-EJKb8oMUXVHcWZTDepnr+WNbfnXKFNf9duMesmr4S8SXTJBJ9M4Yok08pu9vxdJwdlGRhVumk9mEhkEvKGifwA==}
 
@@ -3012,11 +2973,6 @@ packages:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
-  image-size@2.0.2:
-    resolution: {integrity: sha512-IRqXKlaXwgSMAMtpNzZa1ZAe8m+Sa1770Dhk8VkSsP9LS+iHD62Zd8FQKs8fbPiagBE7BzoFX23cxFnwshpV6w==}
-    engines: {node: '>=16.x'}
-    hasBin: true
-
   immer@10.2.0:
     resolution: {integrity: sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==}
 
@@ -3033,6 +2989,9 @@ packages:
 
   inline-style-parser@0.2.4:
     resolution: {integrity: sha512-0aO8FkhNZlj/ZIbNi7Lxxr12obT7cL1moPfE4tg1LkX7LlLfC6DeX4l2ZEud1ukP9jNQyNnfzQVqwbwmAATY4Q==}
+
+  inline-style-parser@0.2.7:
+    resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
 
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
@@ -3077,6 +3036,10 @@ packages:
 
   is-core-module@2.16.1:
     resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
+    engines: {node: '>= 0.4'}
+
+  is-core-module@2.16.2:
+    resolution: {integrity: sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==}
     engines: {node: '>= 0.4'}
 
   is-data-view@1.0.2:
@@ -3196,8 +3159,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@3.14.1:
-    resolution: {integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==}
+  js-yaml@3.14.2:
+    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
     hasBin: true
 
   js-yaml@4.2.0:
@@ -3405,6 +3368,9 @@ packages:
 
   mdast-util-from-markdown@2.0.2:
     resolution: {integrity: sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==}
+
+  mdast-util-from-markdown@2.0.3:
+    resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
 
   mdast-util-frontmatter@2.0.1:
     resolution: {integrity: sha512-LRqI9+wdgC25P0URIJY9vwocIzCcksduHQ9OF2joxQoyTNVduwLAFUzjoopuRJbJAReaKrNQKAZKL3uCMugWJA==}
@@ -3633,10 +3599,6 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
-  negotiator@1.0.0:
-    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
-    engines: {node: '>= 0.6'}
-
   next@16.2.9:
     resolution: {integrity: sha512-MEOJiq/UvuezAdqVSceHbqDgZt1kDw2tpGVOlsdIoJsQdbN2JY2hpVG4xnXGkbdJUOEWhnRfiu/O4Hpc9Juwww==}
     engines: {node: '>=20.9.0'}
@@ -3658,9 +3620,6 @@ packages:
       sass:
         optional: true
 
-  node-addon-api@7.1.1:
-    resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
-
   node-releases@2.0.45:
     resolution: {integrity: sha512-iIbHXV9eBB2nB0wa7oTsrrXq+qQt+9SIlx9AX3T96YgobtEQfis5n6TJ6vV+3QP8DwdriEAcGhARaFCu37peBg==}
     engines: {node: '>=18'}
@@ -3668,10 +3627,6 @@ packages:
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
-
-  npm-to-yarn@3.0.1:
-    resolution: {integrity: sha512-tt6PvKu4WyzPwWUzy/hvPFqn+uwXO0K1ZHka8az3NnrhWJDmSqI8ncWq0fkL0k/lmmi5tAC11FXwXuh0rFbt1A==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
   number-flow@0.5.8:
     resolution: {integrity: sha512-FPr1DumWyGi5Nucoug14bC6xEz70A1TnhgSHhKyfqjgji2SOTz+iLJxKtv37N5JyJbteGYCm6NQ9p1O4KZ7iiA==}
@@ -3716,14 +3671,14 @@ packages:
     resolution: {integrity: sha512-AWGB9WFcRXOQs48Z/udjI5ZcZMHXwX8XPByNpOydgcGsDLIzjGizhoMWJyKAWze7AVW/2W1i+/gPX4YtKe5cyg==}
     engines: {node: '>=12.20.0'}
 
-  oniguruma-parser@0.12.1:
-    resolution: {integrity: sha512-8Unqkvk1RYc6yq2WBYRj4hdnsAxVze8i7iPfQr8e4uSP3tRv0rpZcbGUDvxfQQcdwHt/e9PrMvGCsa8OqG9X3w==}
+  oniguruma-parser@0.12.2:
+    resolution: {integrity: sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==}
 
   oniguruma-to-es@2.3.0:
     resolution: {integrity: sha512-bwALDxriqfKGfUufKGGepCzu9x7nJQuoRoAFp4AnwehhC2crqrDIAP/uN2qdlsAvSMpeRC3+Yzhqc7hLmle5+g==}
 
-  oniguruma-to-es@4.3.3:
-    resolution: {integrity: sha512-rPiZhzC3wXwE59YQMRDodUwwT9FZ9nNBwQQfsd1wfdtlKEyCdRV0avrTcSZ5xlIvGRVPd/cx6ZN45ECmS39xvg==}
+  oniguruma-to-es@4.3.6:
+    resolution: {integrity: sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -3781,9 +3736,6 @@ packages:
   path-scurry@1.11.1:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
-
-  path-to-regexp@8.3.0:
-    resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -3961,15 +3913,15 @@ packages:
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
+  property-information@7.2.0:
+    resolution: {integrity: sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
-
-  randombytes@2.1.0:
-    resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
 
   react-dom@19.2.7:
     resolution: {integrity: sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==}
@@ -4062,6 +4014,10 @@ packages:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
 
+  readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
+
   recharts@3.8.1:
     resolution: {integrity: sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==}
     engines: {node: '>=18'}
@@ -4108,8 +4064,8 @@ packages:
   regex@5.1.1:
     resolution: {integrity: sha512-dN5I359AVGPnwzJm2jN1k0W9LPZ+ePvoOeVMMfqIMFz53sSwXkxaJoxr50ptnsC771lK95BnTrVSZxq0b9yCGw==}
 
-  regex@6.0.1:
-    resolution: {integrity: sha512-uorlqlzAKjKQZ5P+kTJr3eeJGSVroLKoHmquUj4zHWuR+hEyNqlXsSKlYYF5F4NI6nl7tWCs0apKJ0lmfsXAPA==}
+  regex@6.1.0:
+    resolution: {integrity: sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==}
 
   regexp.prototype.flags@1.5.4:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
@@ -4176,6 +4132,11 @@ packages:
     engines: {node: '>= 0.4'}
     hasBin: true
 
+  resolve@1.22.12:
+    resolution: {integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==}
+    engines: {node: '>= 0.4'}
+    hasBin: true
+
   resolve@2.0.0-next.5:
     resolution: {integrity: sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==}
     hasBin: true
@@ -4195,9 +4156,6 @@ packages:
   safe-array-concat@1.1.3:
     resolution: {integrity: sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==}
     engines: {node: '>=0.4'}
-
-  safe-buffer@5.2.1:
-    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
   safe-push-apply@1.0.0:
     resolution: {integrity: sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==}
@@ -4237,8 +4195,9 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  serialize-javascript@6.0.2:
-    resolution: {integrity: sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==}
+  serialize-javascript@7.0.5:
+    resolution: {integrity: sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==}
+    engines: {node: '>=20.0.0'}
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -4267,8 +4226,9 @@ packages:
   shiki@1.29.2:
     resolution: {integrity: sha512-njXuliz/cP+67jU2hukkxCNuH1yUi4QfdZZY+sMr5PPrIyXSu5iTb/qYC4BiWWB0vZ+7TbdvYUCeL23zpwCfbg==}
 
-  shiki@3.13.0:
-    resolution: {integrity: sha512-aZW4l8Og16CokuCLf8CF8kq+KK2yOygapU5m3+hoGw0Mdosc6fPitjM+ujYarppj5ZIKGyPDPP1vqmQhr+5/0g==}
+  shiki@4.2.0:
+    resolution: {integrity: sha512-hjNax6o/ylDy9lefQEaSDtzaT3iVNtZ3WmpQnbuQNoG4xvnSKf2kSKbihZVO4JRG1TTMejs7CmNRYlWgAL66pQ==}
+    engines: {node: '>=20'}
 
   side-channel-list@1.0.0:
     resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
@@ -4383,8 +4343,14 @@ packages:
   style-to-js@1.1.18:
     resolution: {integrity: sha512-JFPn62D4kJaPTnhFUI244MThx+FEGbi+9dw1b9yBBQ+1CZpV7QAT8kUtJ7b7EUNdHajjF/0x8fT+16oLJoojLg==}
 
+  style-to-js@1.1.21:
+    resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
+
   style-to-object@1.0.11:
     resolution: {integrity: sha512-5A560JmXr7wDyGLK12Nq/EYS38VkGlglVzkis1JEdbGWSnbQIEhZzTJhzURXN5/8WwwFCs/f/VVcmkTppbXLow==}
+
+  style-to-object@1.0.14:
+    resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
 
   styled-jsx@5.1.6:
     resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
@@ -4579,6 +4545,9 @@ packages:
 
   unist-util-visit@5.0.0:
     resolution: {integrity: sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==}
+
+  unist-util-visit@5.1.0:
+    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
 
   unrs-resolver@1.11.1:
     resolution: {integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==}
@@ -4800,8 +4769,8 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
-  yocto-queue@1.2.1:
-    resolution: {integrity: sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==}
+  yocto-queue@1.2.2:
+    resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
     engines: {node: '>=12.20'}
 
   yoga-wasm-web@0.3.3:
@@ -4812,9 +4781,6 @@ packages:
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
-
-  zod@3.25.76:
-    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
@@ -4849,6 +4815,12 @@ snapshots:
   '@babel/code-frame@7.29.0':
     dependencies:
       '@babel/helper-validator-identifier': 7.28.5
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/code-frame@7.29.7':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.29.7
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
@@ -4912,6 +4884,8 @@ snapshots:
 
   '@babel/helper-validator-identifier@7.28.5': {}
 
+  '@babel/helper-validator-identifier@7.29.7': {}
+
   '@babel/helper-validator-option@7.27.1': {}
 
   '@babel/helpers@7.29.2':
@@ -4924,6 +4898,8 @@ snapshots:
       '@babel/types': 7.29.0
 
   '@babel/runtime@7.28.4': {}
+
+  '@babel/runtime@7.29.7': {}
 
   '@babel/template@7.28.6':
     dependencies:
@@ -4952,40 +4928,40 @@ snapshots:
     dependencies:
       css-tree: 3.2.1
 
-  '@content-collections/core@0.8.2(typescript@5.9.3)':
+  '@content-collections/core@0.15.1(typescript@5.9.3)':
     dependencies:
-      '@parcel/watcher': 2.5.1
+      '@standard-schema/spec': 1.1.0
       camelcase: 8.0.0
-      esbuild: 0.25.11
+      chokidar: 4.0.3
+      esbuild: 0.25.12
       gray-matter: 4.0.3
       p-limit: 6.2.0
       picomatch: 2.3.2
       pluralize: 8.0.0
-      serialize-javascript: 6.0.2
-      tinyglobby: 0.2.15
+      serialize-javascript: 7.0.5
+      tinyglobby: 0.2.17
       typescript: 5.9.3
       yaml: 2.9.0
-      zod: 3.25.76
 
-  '@content-collections/integrations@0.3.0(@content-collections/core@0.8.2(typescript@5.9.3))':
+  '@content-collections/integrations@0.5.0(@content-collections/core@0.15.1(typescript@5.9.3))':
     dependencies:
-      '@content-collections/core': 0.8.2(typescript@5.9.3)
+      '@content-collections/core': 0.15.1(typescript@5.9.3)
 
-  '@content-collections/mdx@0.2.2(@content-collections/core@0.8.2(typescript@5.9.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@content-collections/mdx@0.2.2(@content-collections/core@0.15.1(typescript@5.9.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@content-collections/core': 0.8.2(typescript@5.9.3)
-      esbuild: 0.25.11
-      mdx-bundler: 10.1.1(esbuild@0.25.11)
+      '@content-collections/core': 0.15.1(typescript@5.9.3)
+      esbuild: 0.25.12
+      mdx-bundler: 10.1.1(esbuild@0.25.12)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
       unified: 11.0.5
     transitivePeerDependencies:
       - supports-color
 
-  '@content-collections/next@0.2.8(@content-collections/core@0.8.2(typescript@5.9.3))(next@16.2.9(@babel/core@7.29.0)(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
+  '@content-collections/next@0.2.11(@content-collections/core@0.15.1(typescript@5.9.3))(next@16.2.9(@babel/core@7.29.0)(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
     dependencies:
-      '@content-collections/core': 0.8.2(typescript@5.9.3)
-      '@content-collections/integrations': 0.3.0(@content-collections/core@0.8.2(typescript@5.9.3))
+      '@content-collections/core': 0.15.1(typescript@5.9.3)
+      '@content-collections/integrations': 0.5.0(@content-collections/core@0.15.1(typescript@5.9.3))
       next: 16.2.9(@babel/core@7.29.0)(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
 
   '@csstools/color-helpers@6.0.2': {}
@@ -5044,92 +5020,92 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@esbuild-plugins/node-resolve@0.2.2(esbuild@0.25.11)':
+  '@esbuild-plugins/node-resolve@0.2.2(esbuild@0.25.12)':
     dependencies:
       '@types/resolve': 1.20.6
       debug: 4.4.3
-      esbuild: 0.25.11
+      esbuild: 0.25.12
       escape-string-regexp: 4.0.0
-      resolve: 1.22.11
+      resolve: 1.22.12
     transitivePeerDependencies:
       - supports-color
 
-  '@esbuild/aix-ppc64@0.25.11':
+  '@esbuild/aix-ppc64@0.25.12':
     optional: true
 
-  '@esbuild/android-arm64@0.25.11':
+  '@esbuild/android-arm64@0.25.12':
     optional: true
 
-  '@esbuild/android-arm@0.25.11':
+  '@esbuild/android-arm@0.25.12':
     optional: true
 
-  '@esbuild/android-x64@0.25.11':
+  '@esbuild/android-x64@0.25.12':
     optional: true
 
-  '@esbuild/darwin-arm64@0.25.11':
+  '@esbuild/darwin-arm64@0.25.12':
     optional: true
 
-  '@esbuild/darwin-x64@0.25.11':
+  '@esbuild/darwin-x64@0.25.12':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.25.11':
+  '@esbuild/freebsd-arm64@0.25.12':
     optional: true
 
-  '@esbuild/freebsd-x64@0.25.11':
+  '@esbuild/freebsd-x64@0.25.12':
     optional: true
 
-  '@esbuild/linux-arm64@0.25.11':
+  '@esbuild/linux-arm64@0.25.12':
     optional: true
 
-  '@esbuild/linux-arm@0.25.11':
+  '@esbuild/linux-arm@0.25.12':
     optional: true
 
-  '@esbuild/linux-ia32@0.25.11':
+  '@esbuild/linux-ia32@0.25.12':
     optional: true
 
-  '@esbuild/linux-loong64@0.25.11':
+  '@esbuild/linux-loong64@0.25.12':
     optional: true
 
-  '@esbuild/linux-mips64el@0.25.11':
+  '@esbuild/linux-mips64el@0.25.12':
     optional: true
 
-  '@esbuild/linux-ppc64@0.25.11':
+  '@esbuild/linux-ppc64@0.25.12':
     optional: true
 
-  '@esbuild/linux-riscv64@0.25.11':
+  '@esbuild/linux-riscv64@0.25.12':
     optional: true
 
-  '@esbuild/linux-s390x@0.25.11':
+  '@esbuild/linux-s390x@0.25.12':
     optional: true
 
-  '@esbuild/linux-x64@0.25.11':
+  '@esbuild/linux-x64@0.25.12':
     optional: true
 
-  '@esbuild/netbsd-arm64@0.25.11':
+  '@esbuild/netbsd-arm64@0.25.12':
     optional: true
 
-  '@esbuild/netbsd-x64@0.25.11':
+  '@esbuild/netbsd-x64@0.25.12':
     optional: true
 
-  '@esbuild/openbsd-arm64@0.25.11':
+  '@esbuild/openbsd-arm64@0.25.12':
     optional: true
 
-  '@esbuild/openbsd-x64@0.25.11':
+  '@esbuild/openbsd-x64@0.25.12':
     optional: true
 
-  '@esbuild/openharmony-arm64@0.25.11':
+  '@esbuild/openharmony-arm64@0.25.12':
     optional: true
 
-  '@esbuild/sunos-x64@0.25.11':
+  '@esbuild/sunos-x64@0.25.12':
     optional: true
 
-  '@esbuild/win32-arm64@0.25.11':
+  '@esbuild/win32-arm64@0.25.12':
     optional: true
 
-  '@esbuild/win32-ia32@0.25.11':
+  '@esbuild/win32-ia32@0.25.12':
     optional: true
 
-  '@esbuild/win32-x64@0.25.11':
+  '@esbuild/win32-x64@0.25.12':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4(jiti@1.21.7))':
@@ -5198,10 +5174,6 @@ snapshots:
       react-dom: 19.2.7(react@19.2.7)
 
   '@floating-ui/utils@0.2.10': {}
-
-  '@formatjs/intl-localematcher@0.6.2':
-    dependencies:
-      tslib: 2.8.1
 
   '@humanfs/core@0.19.2':
     dependencies:
@@ -5344,11 +5316,11 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@mdx-js/esbuild@3.1.1(esbuild@0.25.11)':
+  '@mdx-js/esbuild@3.1.1(esbuild@0.25.12)':
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@types/unist': 3.0.3
-      esbuild: 0.25.11
+      esbuild: 0.25.12
       source-map: 0.7.6
       vfile: 6.0.3
       vfile-message: 4.0.3
@@ -5470,69 +5442,9 @@ snapshots:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
 
-  '@orama/orama@3.1.16': {}
+  '@orama/orama@3.1.18': {}
 
   '@oxc-project/types@0.133.0': {}
-
-  '@parcel/watcher-android-arm64@2.5.1':
-    optional: true
-
-  '@parcel/watcher-darwin-arm64@2.5.1':
-    optional: true
-
-  '@parcel/watcher-darwin-x64@2.5.1':
-    optional: true
-
-  '@parcel/watcher-freebsd-x64@2.5.1':
-    optional: true
-
-  '@parcel/watcher-linux-arm-glibc@2.5.1':
-    optional: true
-
-  '@parcel/watcher-linux-arm-musl@2.5.1':
-    optional: true
-
-  '@parcel/watcher-linux-arm64-glibc@2.5.1':
-    optional: true
-
-  '@parcel/watcher-linux-arm64-musl@2.5.1':
-    optional: true
-
-  '@parcel/watcher-linux-x64-glibc@2.5.1':
-    optional: true
-
-  '@parcel/watcher-linux-x64-musl@2.5.1':
-    optional: true
-
-  '@parcel/watcher-win32-arm64@2.5.1':
-    optional: true
-
-  '@parcel/watcher-win32-ia32@2.5.1':
-    optional: true
-
-  '@parcel/watcher-win32-x64@2.5.1':
-    optional: true
-
-  '@parcel/watcher@2.5.1':
-    dependencies:
-      detect-libc: 1.0.3
-      is-glob: 4.0.3
-      micromatch: 4.0.8
-      node-addon-api: 7.1.1
-    optionalDependencies:
-      '@parcel/watcher-android-arm64': 2.5.1
-      '@parcel/watcher-darwin-arm64': 2.5.1
-      '@parcel/watcher-darwin-x64': 2.5.1
-      '@parcel/watcher-freebsd-x64': 2.5.1
-      '@parcel/watcher-linux-arm-glibc': 2.5.1
-      '@parcel/watcher-linux-arm-musl': 2.5.1
-      '@parcel/watcher-linux-arm64-glibc': 2.5.1
-      '@parcel/watcher-linux-arm64-musl': 2.5.1
-      '@parcel/watcher-linux-x64-glibc': 2.5.1
-      '@parcel/watcher-linux-x64-musl': 2.5.1
-      '@parcel/watcher-win32-arm64': 2.5.1
-      '@parcel/watcher-win32-ia32': 2.5.1
-      '@parcel/watcher-win32-x64': 2.5.1
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -6013,9 +5925,10 @@ snapshots:
       '@types/hast': 3.0.4
       hast-util-to-html: 9.0.5
 
-  '@shikijs/core@3.13.0':
+  '@shikijs/core@4.2.0':
     dependencies:
-      '@shikijs/types': 3.13.0
+      '@shikijs/primitive': 4.2.0
+      '@shikijs/types': 4.2.0
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
       hast-util-to-html: 9.0.5
@@ -6026,58 +5939,50 @@ snapshots:
       '@shikijs/vscode-textmate': 10.0.2
       oniguruma-to-es: 2.3.0
 
-  '@shikijs/engine-javascript@3.13.0':
+  '@shikijs/engine-javascript@4.2.0':
     dependencies:
-      '@shikijs/types': 3.13.0
+      '@shikijs/types': 4.2.0
       '@shikijs/vscode-textmate': 10.0.2
-      oniguruma-to-es: 4.3.3
+      oniguruma-to-es: 4.3.6
 
   '@shikijs/engine-oniguruma@1.29.2':
     dependencies:
       '@shikijs/types': 1.29.2
       '@shikijs/vscode-textmate': 10.0.2
 
-  '@shikijs/engine-oniguruma@3.13.0':
+  '@shikijs/engine-oniguruma@4.2.0':
     dependencies:
-      '@shikijs/types': 3.13.0
+      '@shikijs/types': 4.2.0
       '@shikijs/vscode-textmate': 10.0.2
 
   '@shikijs/langs@1.29.2':
     dependencies:
       '@shikijs/types': 1.29.2
 
-  '@shikijs/langs@3.13.0':
+  '@shikijs/langs@4.2.0':
     dependencies:
-      '@shikijs/types': 3.13.0
+      '@shikijs/types': 4.2.0
 
-  '@shikijs/rehype@3.13.0':
+  '@shikijs/primitive@4.2.0':
     dependencies:
-      '@shikijs/types': 3.13.0
+      '@shikijs/types': 4.2.0
+      '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
-      hast-util-to-string: 3.0.1
-      shiki: 3.13.0
-      unified: 11.0.5
-      unist-util-visit: 5.0.0
 
   '@shikijs/themes@1.29.2':
     dependencies:
       '@shikijs/types': 1.29.2
 
-  '@shikijs/themes@3.13.0':
+  '@shikijs/themes@4.2.0':
     dependencies:
-      '@shikijs/types': 3.13.0
-
-  '@shikijs/transformers@3.13.0':
-    dependencies:
-      '@shikijs/core': 3.13.0
-      '@shikijs/types': 3.13.0
+      '@shikijs/types': 4.2.0
 
   '@shikijs/types@1.29.2':
     dependencies:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
 
-  '@shikijs/types@3.13.0':
+  '@shikijs/types@4.2.0':
     dependencies:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
@@ -6138,8 +6043,8 @@ snapshots:
 
   '@testing-library/dom@10.4.1':
     dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/runtime': 7.28.4
+      '@babel/code-frame': 7.29.7
+      '@babel/runtime': 7.29.7
       '@types/aria-query': 5.0.4
       aria-query: 5.3.0
       dom-accessibility-api: 0.5.16
@@ -6209,6 +6114,8 @@ snapshots:
       '@types/estree': 1.0.8
 
   '@types/estree@1.0.8': {}
+
+  '@types/estree@1.0.9': {}
 
   '@types/geojson@7946.0.16': {}
 
@@ -6434,13 +6341,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.8(vite@8.0.16(@types/node@22.18.12)(esbuild@0.25.11)(jiti@1.21.7)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.8(vite@8.0.16(@types/node@22.18.12)(esbuild@0.25.12)(jiti@1.21.7)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.8
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.16(@types/node@22.18.12)(esbuild@0.25.11)(jiti@1.21.7)(yaml@2.9.0)
+      vite: 8.0.16(@types/node@22.18.12)(esbuild@0.25.12)(jiti@1.21.7)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.8':
     dependencies:
@@ -6685,6 +6592,10 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
+  chokidar@4.0.3:
+    dependencies:
+      readdirp: 4.1.2
+
   client-only@0.0.1: {}
 
   clsx@2.1.1: {}
@@ -6817,6 +6728,10 @@ snapshots:
     dependencies:
       character-entities: 2.0.2
 
+  decode-named-character-reference@1.3.0:
+    dependencies:
+      character-entities: 2.0.2
+
   deep-is@0.1.4: {}
 
   deepmerge@4.3.1: {}
@@ -6834,8 +6749,6 @@ snapshots:
       object-keys: 1.1.1
 
   dequal@2.0.3: {}
-
-  detect-libc@1.0.3: {}
 
   detect-libc@2.1.2: {}
 
@@ -7014,34 +6927,34 @@ snapshots:
       esast-util-from-estree: 2.0.0
       vfile-message: 4.0.3
 
-  esbuild@0.25.11:
+  esbuild@0.25.12:
     optionalDependencies:
-      '@esbuild/aix-ppc64': 0.25.11
-      '@esbuild/android-arm': 0.25.11
-      '@esbuild/android-arm64': 0.25.11
-      '@esbuild/android-x64': 0.25.11
-      '@esbuild/darwin-arm64': 0.25.11
-      '@esbuild/darwin-x64': 0.25.11
-      '@esbuild/freebsd-arm64': 0.25.11
-      '@esbuild/freebsd-x64': 0.25.11
-      '@esbuild/linux-arm': 0.25.11
-      '@esbuild/linux-arm64': 0.25.11
-      '@esbuild/linux-ia32': 0.25.11
-      '@esbuild/linux-loong64': 0.25.11
-      '@esbuild/linux-mips64el': 0.25.11
-      '@esbuild/linux-ppc64': 0.25.11
-      '@esbuild/linux-riscv64': 0.25.11
-      '@esbuild/linux-s390x': 0.25.11
-      '@esbuild/linux-x64': 0.25.11
-      '@esbuild/netbsd-arm64': 0.25.11
-      '@esbuild/netbsd-x64': 0.25.11
-      '@esbuild/openbsd-arm64': 0.25.11
-      '@esbuild/openbsd-x64': 0.25.11
-      '@esbuild/openharmony-arm64': 0.25.11
-      '@esbuild/sunos-x64': 0.25.11
-      '@esbuild/win32-arm64': 0.25.11
-      '@esbuild/win32-ia32': 0.25.11
-      '@esbuild/win32-x64': 0.25.11
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
 
   escalade@3.2.0: {}
 
@@ -7260,7 +7173,7 @@ snapshots:
 
   estree-util-attach-comments@3.0.0:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
 
   estree-util-build-jsx@3.0.1:
     dependencies:
@@ -7282,9 +7195,9 @@ snapshots:
       astring: 1.9.0
       source-map: 0.7.6
 
-  estree-util-value-to-estree@3.4.1:
+  estree-util-value-to-estree@3.5.0:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
 
   estree-util-visit@2.0.0:
     dependencies:
@@ -7391,32 +7304,36 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
-  fumadocs-core@15.8.5(@types/react@19.2.17)(lucide-react@1.18.0(react@19.2.7))(next@16.2.9(@babel/core@7.29.0)(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  fumadocs-core@16.10.3(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.18.0(react@19.2.7))(next@16.2.9(@babel/core@7.29.0)(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3):
     dependencies:
-      '@formatjs/intl-localematcher': 0.6.2
-      '@orama/orama': 3.1.16
-      '@shikijs/rehype': 3.13.0
-      '@shikijs/transformers': 3.13.0
+      '@orama/orama': 3.1.18
+      estree-util-value-to-estree: 3.5.0
       github-slugger: 2.0.0
       hast-util-to-estree: 3.1.3
       hast-util-to-jsx-runtime: 2.3.6
-      image-size: 2.0.2
-      negotiator: 1.0.0
-      npm-to-yarn: 3.0.1
-      path-to-regexp: 8.3.0
-      react-remove-scroll: 2.7.1(@types/react@19.2.17)(react@19.2.7)
+      js-yaml: 4.2.0
+      mdast-util-mdx: 3.0.0
+      mdast-util-to-markdown: 2.1.2
       remark: 15.0.1
       remark-gfm: 4.0.1
       remark-rehype: 11.1.2
       scroll-into-view-if-needed: 3.1.0
-      shiki: 3.13.0
-      unist-util-visit: 5.0.0
+      shiki: 4.2.0
+      tinyglobby: 0.2.17
+      unified: 11.0.5
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
     optionalDependencies:
+      '@mdx-js/mdx': 3.1.1
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
       '@types/react': 19.2.17
       lucide-react: 1.18.0(react@19.2.7)
       next: 16.2.9(@babel/core@7.29.0)(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
+      zod: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -7499,7 +7416,7 @@ snapshots:
 
   gray-matter@4.0.3:
     dependencies:
-      js-yaml: 3.14.1
+      js-yaml: 3.14.2
       kind-of: 6.0.3
       section-matter: 1.0.0
       strip-bom-string: 1.0.0
@@ -7526,6 +7443,10 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hasown@2.0.4:
+    dependencies:
+      function-bind: 1.1.2
+
   hast-util-heading-rank@3.0.0:
     dependencies:
       '@types/hast': 3.0.4
@@ -7536,7 +7457,7 @@ snapshots:
 
   hast-util-to-estree@3.1.3:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.4
       comma-separated-tokens: 2.0.3
@@ -7547,9 +7468,9 @@ snapshots:
       mdast-util-mdx-expression: 2.0.1
       mdast-util-mdx-jsx: 3.2.0
       mdast-util-mdxjs-esm: 2.0.1
-      property-information: 7.1.0
+      property-information: 7.2.0
       space-separated-tokens: 2.0.2
-      style-to-js: 1.1.18
+      style-to-js: 1.1.21
       unist-util-position: 5.0.0
       zwitch: 2.0.4
     transitivePeerDependencies:
@@ -7634,8 +7555,6 @@ snapshots:
 
   ignore@7.0.5: {}
 
-  image-size@2.0.2: {}
-
   immer@10.2.0: {}
 
   immer@11.1.8: {}
@@ -7648,6 +7567,8 @@ snapshots:
   imurmurhash@0.1.4: {}
 
   inline-style-parser@0.2.4: {}
+
+  inline-style-parser@0.2.7: {}
 
   internal-slot@1.1.0:
     dependencies:
@@ -7700,6 +7621,10 @@ snapshots:
   is-core-module@2.16.1:
     dependencies:
       hasown: 2.0.2
+
+  is-core-module@2.16.2:
+    dependencies:
+      hasown: 2.0.4
 
   is-data-view@1.0.2:
     dependencies:
@@ -7815,7 +7740,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@3.14.1:
+  js-yaml@3.14.2:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
@@ -8016,12 +7941,29 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  mdast-util-from-markdown@2.0.3:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      mdast-util-to-string: 4.0.0
+      micromark: 4.0.2
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-decode-string: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
   mdast-util-frontmatter@2.0.1:
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
       escape-string-regexp: 5.0.0
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
       micromark-extension-frontmatter: 2.0.0
     transitivePeerDependencies:
@@ -8039,7 +7981,7 @@ snapshots:
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
       micromark-util-normalize-identifier: 2.0.1
     transitivePeerDependencies:
@@ -8048,7 +7990,7 @@ snapshots:
   mdast-util-gfm-strikethrough@2.0.0:
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
@@ -8058,7 +8000,7 @@ snapshots:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
       markdown-table: 3.0.4
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
@@ -8067,14 +8009,14 @@ snapshots:
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
   mdast-util-gfm@3.1.0:
     dependencies:
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.3
       mdast-util-gfm-autolink-literal: 2.0.1
       mdast-util-gfm-footnote: 2.1.0
       mdast-util-gfm-strikethrough: 2.0.0
@@ -8114,7 +8056,7 @@ snapshots:
 
   mdast-util-mdx@3.0.0:
     dependencies:
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.3
       mdast-util-mdx-expression: 2.0.1
       mdast-util-mdx-jsx: 3.2.0
       mdast-util-mdxjs-esm: 2.0.1
@@ -8159,7 +8101,7 @@ snapshots:
       mdast-util-to-string: 4.0.0
       micromark-util-classify-character: 2.0.1
       micromark-util-decode-string: 2.0.1
-      unist-util-visit: 5.0.0
+      unist-util-visit: 5.1.0
       zwitch: 2.0.4
 
   mdast-util-to-string@4.0.0:
@@ -8168,13 +8110,13 @@ snapshots:
 
   mdn-data@2.27.1: {}
 
-  mdx-bundler@10.1.1(esbuild@0.25.11):
+  mdx-bundler@10.1.1(esbuild@0.25.12):
     dependencies:
-      '@babel/runtime': 7.28.4
-      '@esbuild-plugins/node-resolve': 0.2.2(esbuild@0.25.11)
+      '@babel/runtime': 7.29.7
+      '@esbuild-plugins/node-resolve': 0.2.2(esbuild@0.25.12)
       '@fal-works/esbuild-plugin-global-externals': 2.1.2
-      '@mdx-js/esbuild': 3.1.1(esbuild@0.25.11)
-      esbuild: 0.25.11
+      '@mdx-js/esbuild': 3.1.1(esbuild@0.25.12)
+      esbuild: 0.25.12
       gray-matter: 4.0.3
       remark-frontmatter: 5.0.0
       remark-mdx-frontmatter: 4.0.0
@@ -8501,8 +8443,6 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  negotiator@1.0.0: {}
-
   next@16.2.9(@babel/core@7.29.0)(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
       '@next/env': 16.2.9
@@ -8528,13 +8468,9 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  node-addon-api@7.1.1: {}
-
   node-releases@2.0.45: {}
 
   normalize-path@3.0.0: {}
-
-  npm-to-yarn@3.0.1: {}
 
   number-flow@0.5.8:
     dependencies:
@@ -8586,7 +8522,7 @@ snapshots:
 
   obug@2.1.2: {}
 
-  oniguruma-parser@0.12.1: {}
+  oniguruma-parser@0.12.2: {}
 
   oniguruma-to-es@2.3.0:
     dependencies:
@@ -8594,10 +8530,10 @@ snapshots:
       regex: 5.1.1
       regex-recursion: 5.1.1
 
-  oniguruma-to-es@4.3.3:
+  oniguruma-to-es@4.3.6:
     dependencies:
-      oniguruma-parser: 0.12.1
-      regex: 6.0.1
+      oniguruma-parser: 0.12.2
+      regex: 6.1.0
       regex-recursion: 6.0.2
 
   optionator@0.9.4:
@@ -8621,7 +8557,7 @@ snapshots:
 
   p-limit@6.2.0:
     dependencies:
-      yocto-queue: 1.2.1
+      yocto-queue: 1.2.2
 
   p-locate@5.0.0:
     dependencies:
@@ -8669,8 +8605,6 @@ snapshots:
     dependencies:
       lru-cache: 10.4.3
       minipass: 7.1.2
-
-  path-to-regexp@8.3.0: {}
 
   pathe@2.0.3: {}
 
@@ -8765,13 +8699,11 @@ snapshots:
 
   property-information@7.1.0: {}
 
+  property-information@7.2.0: {}
+
   punycode@2.3.1: {}
 
   queue-microtask@1.2.3: {}
-
-  randombytes@2.1.0:
-    dependencies:
-      safe-buffer: 5.2.1
 
   react-dom@19.2.7(react@19.2.7):
     dependencies:
@@ -8851,6 +8783,8 @@ snapshots:
   readdirp@3.6.0:
     dependencies:
       picomatch: 2.3.2
+
+  readdirp@4.1.2: {}
 
   recharts@3.8.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1):
     dependencies:
@@ -8933,7 +8867,7 @@ snapshots:
     dependencies:
       regex-utilities: 2.3.0
 
-  regex@6.0.1:
+  regex@6.1.0:
     dependencies:
       regex-utilities: 2.3.0
 
@@ -8995,7 +8929,7 @@ snapshots:
     dependencies:
       '@types/mdast': 4.0.4
       estree-util-is-identifier-name: 3.0.0
-      estree-util-value-to-estree: 3.4.1
+      estree-util-value-to-estree: 3.5.0
       toml: 3.0.0
       unified: 11.0.5
       yaml: 2.9.0
@@ -9060,6 +8994,13 @@ snapshots:
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
+  resolve@1.22.12:
+    dependencies:
+      es-errors: 1.3.0
+      is-core-module: 2.16.2
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
+
   resolve@2.0.0-next.5:
     dependencies:
       is-core-module: 2.16.1
@@ -9100,8 +9041,6 @@ snapshots:
       get-intrinsic: 1.3.0
       has-symbols: 1.1.0
       isarray: 2.0.5
-
-  safe-buffer@5.2.1: {}
 
   safe-push-apply@1.0.0:
     dependencies:
@@ -9151,9 +9090,7 @@ snapshots:
 
   semver@7.7.3: {}
 
-  serialize-javascript@6.0.2:
-    dependencies:
-      randombytes: 2.1.0
+  serialize-javascript@7.0.5: {}
 
   set-function-length@1.2.2:
     dependencies:
@@ -9226,14 +9163,14 @@ snapshots:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
 
-  shiki@3.13.0:
+  shiki@4.2.0:
     dependencies:
-      '@shikijs/core': 3.13.0
-      '@shikijs/engine-javascript': 3.13.0
-      '@shikijs/engine-oniguruma': 3.13.0
-      '@shikijs/langs': 3.13.0
-      '@shikijs/themes': 3.13.0
-      '@shikijs/types': 3.13.0
+      '@shikijs/core': 4.2.0
+      '@shikijs/engine-javascript': 4.2.0
+      '@shikijs/engine-oniguruma': 4.2.0
+      '@shikijs/langs': 4.2.0
+      '@shikijs/themes': 4.2.0
+      '@shikijs/types': 4.2.0
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
 
@@ -9380,9 +9317,17 @@ snapshots:
     dependencies:
       style-to-object: 1.0.11
 
+  style-to-js@1.1.21:
+    dependencies:
+      style-to-object: 1.0.14
+
   style-to-object@1.0.11:
     dependencies:
       inline-style-parser: 0.2.4
+
+  style-to-object@1.0.14:
+    dependencies:
+      inline-style-parser: 0.2.7
 
   styled-jsx@5.1.6(@babel/core@7.29.0)(react@19.2.7):
     dependencies:
@@ -9622,6 +9567,12 @@ snapshots:
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
 
+  unist-util-visit@5.1.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
   unrs-resolver@1.11.1:
     dependencies:
       napi-postinstall: 0.3.4
@@ -9715,7 +9666,7 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
-  vite@8.0.16(@types/node@22.18.12)(esbuild@0.25.11)(jiti@1.21.7)(yaml@2.9.0):
+  vite@8.0.16(@types/node@22.18.12)(esbuild@0.25.12)(jiti@1.21.7)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 2.3.2
@@ -9724,15 +9675,15 @@ snapshots:
       tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 22.18.12
-      esbuild: 0.25.11
+      esbuild: 0.25.12
       fsevents: 2.3.3
       jiti: 1.21.7
       yaml: 2.9.0
 
-  vitest@4.1.8(@types/node@22.18.12)(jsdom@29.1.1)(vite@8.0.16(@types/node@22.18.12)(esbuild@0.25.11)(jiti@1.21.7)(yaml@2.9.0)):
+  vitest@4.1.8(@types/node@22.18.12)(jsdom@29.1.1)(vite@8.0.16(@types/node@22.18.12)(esbuild@0.25.12)(jiti@1.21.7)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.8
-      '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@22.18.12)(esbuild@0.25.11)(jiti@1.21.7)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@22.18.12)(esbuild@0.25.12)(jiti@1.21.7)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.8
       '@vitest/runner': 4.1.8
       '@vitest/snapshot': 4.1.8
@@ -9749,7 +9700,7 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 8.0.16(@types/node@22.18.12)(esbuild@0.25.11)(jiti@1.21.7)(yaml@2.9.0)
+      vite: 8.0.16(@types/node@22.18.12)(esbuild@0.25.12)(jiti@1.21.7)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.18.12
@@ -9849,15 +9800,13 @@ snapshots:
 
   yocto-queue@0.1.0: {}
 
-  yocto-queue@1.2.1: {}
+  yocto-queue@1.2.2: {}
 
   yoga-wasm-web@0.3.3: {}
 
   zod-validation-error@4.0.2(zod@4.4.3):
     dependencies:
       zod: 4.4.3
-
-  zod@3.25.76: {}
 
   zod@4.4.3: {}
 

--- a/src/app/actions/cta-lead.ts
+++ b/src/app/actions/cta-lead.ts
@@ -2,6 +2,7 @@
 
 import { subscribe } from "@/lib/email/subscribe"
 import { checkRateLimit } from "@/lib/rate-limit"
+import { ctaLeadSchema } from "@/lib/forms/schemas"
 
 export type CtaLeadInput = {
   /** Norwegian form label, e.g. "Verdsettelse" — shown in the Discord digest. */
@@ -17,7 +18,6 @@ export type CtaLeadInput = {
 
 export type CtaLeadResult = { ok: true } | { ok: false; error: string }
 
-const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
 const MAX_FIELDS = 15
 const MAX_VALUE_LEN = 500
 
@@ -26,15 +26,15 @@ export async function submitCtaLead(input: CtaLeadInput): Promise<CtaLeadResult>
     return { ok: false, error: "For mange forsøk. Prøv igjen om noen minutter." }
   }
 
-  const email = String(input.email ?? "").trim().toLowerCase()
-  const name = String(input.name ?? "").trim().slice(0, 200)
-  if (!EMAIL_RE.test(email) || !name) {
+  const parsed = ctaLeadSchema.safeParse(input)
+  if (!parsed.success) {
     return { ok: false, error: "Fyll inn navn og en gyldig e-postadresse." }
   }
+  const { email, name, formType, phone, pageUrl, fields } = parsed.data
 
-  const intake: Record<string, string> = { Type: String(input.formType ?? "").slice(0, 100) }
-  if (input.phone) intake.Telefon = String(input.phone).slice(0, 50)
-  for (const [k, v] of Object.entries(input.fields ?? {}).slice(0, MAX_FIELDS)) {
+  const intake: Record<string, string> = { Type: formType ?? "" }
+  if (phone) intake.Telefon = phone
+  for (const [k, v] of Object.entries(fields ?? {}).slice(0, MAX_FIELDS)) {
     const value = String(v ?? "").trim().slice(0, MAX_VALUE_LEN)
     if (value) intake[String(k).slice(0, 50)] = value
   }
@@ -47,7 +47,7 @@ export async function submitCtaLead(input: CtaLeadInput): Promise<CtaLeadResult>
   const result = await subscribe({
     email,
     source: "service-modal",
-    pageUrl: input.pageUrl?.slice(0, 200),
+    pageUrl,
     firstName: name,
     intake,
   })

--- a/src/app/actions/investorportal.ts
+++ b/src/app/actions/investorportal.ts
@@ -1,6 +1,7 @@
 "use server"
 
 import { notifyLead } from "@/lib/email/discord"
+import { subscribe } from "@/lib/email/subscribe"
 import { checkRateLimit } from "@/lib/rate-limit"
 
 export type InvestorAccessFormState =
@@ -38,7 +39,11 @@ export async function requestInvestorAccess(
     }
   }
 
-  await notifyLead({
+  // Route through the shared pipeline (Discord + Supabase crm_leads) rather than
+  // notifyLead alone — investorportal is high-intent, so the access request must
+  // land as a curated CRM lead, not just a Discord ping that's lost when missed.
+  // No marketingConsent: an access request is not a newsletter opt-in.
+  const result = await subscribe({
     email,
     source: "investorportal",
     pageUrl: "/investorportal",
@@ -50,6 +55,9 @@ export async function requestInvestorAccess(
     },
   })
 
+  if (!result.ok) {
+    return { status: "error", message: result.error }
+  }
   return { status: "success" }
 }
 

--- a/src/app/actions/investorportal.ts
+++ b/src/app/actions/investorportal.ts
@@ -3,6 +3,7 @@
 import { notifyLead } from "@/lib/email/discord"
 import { subscribe } from "@/lib/email/subscribe"
 import { checkRateLimit } from "@/lib/rate-limit"
+import { investorAccessSchema } from "@/lib/forms/schemas"
 
 export type InvestorAccessFormState =
   | { status: "idle" }
@@ -27,17 +28,19 @@ export async function requestInvestorAccess(
     }
   }
 
-  const name = String(formData.get("name") ?? "").trim().slice(0, 200)
-  const email = String(formData.get("email") ?? "").trim().toLowerCase()
-  const company = String(formData.get("company") ?? "").trim().slice(0, 200)
-  const mandate = String(formData.get("mandate") ?? "").trim().slice(0, 500)
-
-  if (!name || !EMAIL_RE.test(email)) {
+  const parsed = investorAccessSchema.safeParse({
+    name: String(formData.get("name") ?? ""),
+    email: String(formData.get("email") ?? ""),
+    company: String(formData.get("company") ?? ""),
+    mandate: String(formData.get("mandate") ?? ""),
+  })
+  if (!parsed.success) {
     return {
       status: "error",
       message: "Fyll inn navn og en gyldig e-postadresse.",
     }
   }
+  const { name, email, company, mandate } = parsed.data
 
   // Route through the shared pipeline (Discord + Supabase crm_leads) rather than
   // notifyLead alone — investorportal is high-intent, so the access request must

--- a/src/app/actions/naringsmegler-lead.ts
+++ b/src/app/actions/naringsmegler-lead.ts
@@ -2,6 +2,7 @@
 
 import { PROPERTY_TYPES } from "@/components/naringsmegler/leadConstants"
 import { subscribe } from "@/lib/email/subscribe"
+import { sanitizeDiscordValue } from "@/lib/email/sanitize"
 import { checkRateLimit } from "@/lib/rate-limit"
 
 export type CityLeadResult = { ok: true } | { ok: false; error: string }
@@ -11,18 +12,12 @@ export type CityLeadResult = { ok: true } | { ok: false; error: string }
 // Discord digest / CRM via pageUrl.
 const SLUG_RE = /^[a-z0-9-]{1,40}$/
 
-/**
- * Trim + hard-cap a field, and neutralize Discord-markdown metacharacters and
- * newlines — intake values are interpolated into embed markdown that the team
- * reads as trusted (`**${k}:** ${v}`), so a submitter must not be able to
- * forge extra labelled lines or masked links.
- */
+// Trim + hard-cap + neutralize Discord-markdown metacharacters via the shared
+// sanitizer (see lib/email/sanitize.ts). discord.ts now also sanitizes at the
+// choke point, so this is belt-and-suspenders, but cleaning here keeps the
+// capped values consistent with the per-field limits below.
 function clean(v: FormDataEntryValue | null, max: number): string {
-  return String(v ?? "")
-    .replace(/[\r\n*_`~|[\]]/g, " ")
-    .replace(/\s+/g, " ")
-    .trim()
-    .slice(0, max)
+  return sanitizeDiscordValue(v as string | null, max)
 }
 
 /**

--- a/src/app/actions/newsletter.ts
+++ b/src/app/actions/newsletter.ts
@@ -2,6 +2,7 @@
 
 import { subscribe, type SubscribeSource } from "@/lib/email/subscribe"
 import { checkRateLimit } from "@/lib/rate-limit"
+import { newsletterSchema } from "@/lib/forms/schemas"
 
 // Form-state shape consumed by useFormState in NewsletterSignup. Lets the
 // client component render the same surface for idle / success / error.
@@ -18,16 +19,21 @@ export async function subscribeNewsletter(
     return { status: "error", message: "For mange forsøk. Prøv igjen om noen minutter." }
   }
 
-  const email = String(formData.get("email") ?? "")
-  const source = (String(formData.get("source") ?? "footer") as SubscribeSource)
-  const pageUrl = String(formData.get("pageUrl") ?? "")
-  const firstName = String(formData.get("firstName") ?? "") || undefined
+  const parsed = newsletterSchema.safeParse({
+    email: String(formData.get("email") ?? ""),
+    source: String(formData.get("source") ?? ""),
+    pageUrl: String(formData.get("pageUrl") ?? ""),
+    firstName: String(formData.get("firstName") ?? ""),
+  })
+  if (!parsed.success) {
+    return { status: "error", message: "Fyll inn en gyldig e-postadresse." }
+  }
 
   const result = await subscribe({
-    email,
-    source,
-    pageUrl,
-    firstName,
+    email: parsed.data.email,
+    source: (parsed.data.source ?? "footer") as SubscribeSource,
+    pageUrl: parsed.data.pageUrl ?? "",
+    firstName: parsed.data.firstName,
     marketingConsent: true,
   })
 

--- a/src/app/actions/onboarding/onboarding.ts
+++ b/src/app/actions/onboarding/onboarding.ts
@@ -4,6 +4,7 @@ import { cookies } from "next/headers";
 import { checkRateLimit } from "@/lib/rate-limit";
 import { subscribe } from "@/lib/email/subscribe";
 import { sanitizeDiscordValue } from "@/lib/email/sanitize";
+import { contactInquirySchema } from "@/lib/forms/schemas";
 
 interface DiscordMessage {
   content: string;
@@ -141,11 +142,20 @@ export async function submitContactInquiry(data: ContactInquiryData) {
     return { success: false, error: "For mange forsøk. Prøv igjen om noen minutter." };
   }
 
+  const parsed = contactInquirySchema.safeParse(data);
+  if (!parsed.success) {
+    return {
+      success: false,
+      error: "Fyll inn navn, en gyldig e-postadresse og ønsket tjeneste.",
+    };
+  }
+  const d = parsed.data;
+
   try {
     const intake: Record<string, string | undefined> = {
-      Telefon: data.phone,
-      Tjeneste: data.service,
-      Beskjed: data.message,
+      Telefon: d.phone,
+      Tjeneste: d.service,
+      Beskjed: d.message,
     };
 
     // Full pipeline: Resend (audience + welcome), Discord #team digest
@@ -153,8 +163,8 @@ export async function submitContactInquiry(data: ContactInquiryData) {
     // "kontakt" source is already wired end-to-end in lib/email and
     // lib/supabase — see leads.ts HIGH_INTENT.
     const pipeline = subscribe({
-      email: data.email,
-      firstName: data.name,
+      email: d.email,
+      firstName: d.name,
       source: "kontakt",
       pageUrl: "/kontakt",
       intake,
@@ -168,21 +178,21 @@ export async function submitContactInquiry(data: ContactInquiryData) {
           embeds: [
             {
               title: "📬 Ny nettside-henvendelse",
-              description: `**${data.name}** — ${data.service}`,
+              description: `**${sanitizeDiscordValue(d.name)}** — ${sanitizeDiscordValue(d.service)}`,
               color: 0x00ff88,
               fields: [
-                { name: "Navn", value: sanitizeDiscordValue(data.name) },
-                { name: "E-post", value: sanitizeDiscordValue(data.email) },
-                { name: "Telefon", value: sanitizeDiscordValue(data.phone) },
+                { name: "Navn", value: sanitizeDiscordValue(d.name) },
+                { name: "E-post", value: sanitizeDiscordValue(d.email) },
+                { name: "Telefon", value: sanitizeDiscordValue(d.phone) },
                 {
                   name: "Ønsket tjeneste",
-                  value: sanitizeDiscordValue(data.service),
+                  value: sanitizeDiscordValue(d.service),
                 },
-                ...(data.message
+                ...(d.message
                   ? [
                       {
                         name: "Melding",
-                        value: sanitizeDiscordValue(data.message, 1024),
+                        value: sanitizeDiscordValue(d.message, 1024),
                       },
                     ]
                   : []),

--- a/src/app/actions/onboarding/onboarding.ts
+++ b/src/app/actions/onboarding/onboarding.ts
@@ -3,6 +3,7 @@
 import { cookies } from "next/headers";
 import { checkRateLimit } from "@/lib/rate-limit";
 import { subscribe } from "@/lib/email/subscribe";
+import { sanitizeDiscordValue } from "@/lib/email/sanitize";
 
 interface DiscordMessage {
   content: string;
@@ -50,22 +51,22 @@ export async function submitOnboarding(data: OnboardingData) {
           fields: [
             {
               name: "Purpose",
-              value: data.purpose,
+              value: sanitizeDiscordValue(data.purpose),
             },
             {
               name: "Company Details",
               value: [
-                `**Name**: ${data.company.name}`,
-                `**Org Number**: ${data.company.orgNumber}`,
-                `**Address**: ${data.company.address}`,
+                `**Name**: ${sanitizeDiscordValue(data.company.name)}`,
+                `**Org Number**: ${sanitizeDiscordValue(data.company.orgNumber)}`,
+                `**Address**: ${sanitizeDiscordValue(data.company.address)}`,
               ].join("\n"),
             },
             {
               name: "Contact Information",
               value: [
-                `**Name**: ${data.contact.name}`,
-                `**Email**: ${data.contact.email}`,
-                `**Phone**: ${data.contact.phone}`,
+                `**Name**: ${sanitizeDiscordValue(data.contact.name)}`,
+                `**Email**: ${sanitizeDiscordValue(data.contact.email)}`,
+                `**Phone**: ${sanitizeDiscordValue(data.contact.phone)}`,
               ].join("\n"),
             },
             {
@@ -170,18 +171,18 @@ export async function submitContactInquiry(data: ContactInquiryData) {
               description: `**${data.name}** — ${data.service}`,
               color: 0x00ff88,
               fields: [
-                { name: "Navn", value: data.name },
-                { name: "E-post", value: data.email },
-                { name: "Telefon", value: data.phone },
-                { name: "Ønsket tjeneste", value: data.service },
+                { name: "Navn", value: sanitizeDiscordValue(data.name) },
+                { name: "E-post", value: sanitizeDiscordValue(data.email) },
+                { name: "Telefon", value: sanitizeDiscordValue(data.phone) },
+                {
+                  name: "Ønsket tjeneste",
+                  value: sanitizeDiscordValue(data.service),
+                },
                 ...(data.message
                   ? [
                       {
                         name: "Melding",
-                        value:
-                          data.message.length > 1024
-                            ? data.message.substring(0, 1021) + "..."
-                            : data.message,
+                        value: sanitizeDiscordValue(data.message, 1024),
                       },
                     ]
                   : []),

--- a/src/app/actions/verdivurdering-intake.ts
+++ b/src/app/actions/verdivurdering-intake.ts
@@ -2,6 +2,7 @@
 
 import { subscribe, type SubscribeSource } from "@/lib/email/subscribe"
 import { checkRateLimit } from "@/lib/rate-limit"
+import { verdivurderingIntakeSchema } from "@/lib/forms/schemas"
 
 export type IntakeResult = { ok: true } | { ok: false; error: string }
 
@@ -29,68 +30,63 @@ export async function subscribeVerdivurderingIntake(
     return { ok: false, error: "For mange forsøk. Prøv igjen om noen minutter." }
   }
 
-  const get = (k: string) => {
-    const v = String(formData.get(k) ?? "").trim()
-    return v.length > 0 ? v : undefined
+  // Validate + cap. Hard-intent minimum: email (valid) + property type +
+  // location + purpose; firstName is required at the form level. Optional /
+  // surface-specific fields (address, company, free-text areal/leie from the
+  // næringskalkulator, legacy size/horizon) are length-capped and dropped when
+  // blank so they don't clutter the Discord notification.
+  const parsed = verdivurderingIntakeSchema.safeParse({
+    email: String(formData.get("email") ?? ""),
+    firstName: String(formData.get("firstName") ?? ""),
+    propertyType: String(formData.get("propertyType") ?? ""),
+    location: String(formData.get("location") ?? ""),
+    purpose: String(formData.get("purpose") ?? ""),
+    address: String(formData.get("address") ?? ""),
+    company: String(formData.get("company") ?? ""),
+    areal: String(formData.get("areal") ?? ""),
+    leie: String(formData.get("leie") ?? ""),
+    size: String(formData.get("size") ?? ""),
+    horizon: String(formData.get("horizon") ?? ""),
+    phone: String(formData.get("phone") ?? ""),
+    notes: String(formData.get("notes") ?? ""),
+    page: String(formData.get("page") ?? ""),
+    intakeSource: String(formData.get("intakeSource") ?? ""),
+  })
+  if (!parsed.success) {
+    return { ok: false, error: "Fyll ut alle påkrevde felt." }
   }
-
-  const email = get("email") ?? ""
-  const firstName = get("firstName")
-  const propertyType = get("propertyType") ?? ""
-  const location = get("location") ?? ""
-  const purpose = get("purpose") ?? ""
-
-  // Optional / surface-specific fields. The dedicated /verdivurdering page
-  // sends address + company + free-text areal/leie (carried from the
-  // næringskalkulator); the legacy #bestill form may send size/horizon.
-  const address = get("address")
-  const company = get("company")
-  const areal = get("areal")
-  const leie = get("leie")
-  const size = get("size")
-  const horizon = get("horizon")
-  const phone = get("phone")
-  const notes = get("notes")
-
-  // `page` distinguishes which surface produced the lead so the funnel can be
-  // measured (verdivurdering-page vs tjeneste-bestill). Defaults to the legacy
-  // service page for backward compatibility.
-  const page = get("page") ?? "/tjenester/verdivurdering"
+  const d = parsed.data
 
   // `intakeSource` selects the CRM source (verdivurdering vs beslutningsgrunnlag).
   // Falls back to verdivurdering-intake for every existing form that doesn't
   // send it, and ignores any value not on the whitelist.
-  const requested = get("intakeSource") as SubscribeSource | undefined
+  const requested = d.intakeSource as SubscribeSource | undefined
   const source: SubscribeSource =
     requested && ALLOWED_SOURCES.includes(requested)
       ? requested
       : "verdivurdering-intake"
 
-  // Hard-intent minimum: email + property type + location + purpose. firstName
-  // is required at the form level so we can address them in the welcome.
-  if (!email || !propertyType || !location || !purpose) {
-    return { ok: false, error: "Fyll ut alle påkrevde felt." }
-  }
+  // `page` distinguishes which surface produced the lead (funnel measurement).
+  // Defaults to the legacy service page for backward compatibility.
+  const page = d.page ?? "/tjenester/verdivurdering"
 
-  // Build the structured context dynamically so empty optional fields don't
-  // clutter the Discord notification.
   const intake: Record<string, string | undefined> = {
-    Eiendomstype: propertyType,
-    Adresse: address,
-    Sted: location,
-    Areal: areal ? `${areal} m²` : undefined,
-    "Årlig leie": leie,
-    Størrelse: size,
-    Formål: purpose,
-    Tidshorisont: horizon,
-    Selskap: company,
-    Telefon: phone,
-    Beskjed: notes,
+    Eiendomstype: d.propertyType,
+    Adresse: d.address,
+    Sted: d.location,
+    Areal: d.areal ? `${d.areal} m²` : undefined,
+    "Årlig leie": d.leie,
+    Størrelse: d.size,
+    Formål: d.purpose,
+    Tidshorisont: d.horizon,
+    Selskap: d.company,
+    Telefon: d.phone,
+    Beskjed: d.notes,
   }
 
   const result = await subscribe({
-    email,
-    firstName,
+    email: d.email,
+    firstName: d.firstName,
     source,
     pageUrl: page,
     intake,

--- a/src/components/ContactUsForm.tsx
+++ b/src/components/ContactUsForm.tsx
@@ -70,7 +70,7 @@ export default function ContactUsForm() {
       } else {
         setError(result.error || "Innsending feilet. Vennligst prøv igjen.");
       }
-    } catch (err) {
+    } catch {
       setError("En uventet feil oppstod. Vennligst prøv igjen.");
     } finally {
       setIsSubmitting(false);

--- a/src/components/blog/modal.tsx
+++ b/src/components/blog/modal.tsx
@@ -33,7 +33,7 @@ export default function Modal({
       return
     }
     // fire onClose event if provided
-    onClose && onClose()
+    if (onClose) onClose()
 
     // if setShowModal is defined, use it to close modal
     if (setShowModal) {

--- a/src/components/markedsinnsikt/MarkedsinnsiktShell.tsx
+++ b/src/components/markedsinnsikt/MarkedsinnsiktShell.tsx
@@ -288,10 +288,12 @@ function YieldView() {
       </div>
 
       <div className="miv-controls">
-        <div className="mi-subtabs">
+        <div className="mi-subtabs" role="tablist" aria-label="Visning">
           {SUB_TABS.map((t) => (
             <button
               key={t.id}
+              type="button"
+              role="tab"
               aria-selected={sub === t.id}
               onClick={() => setSub(t.id)}
             >
@@ -493,10 +495,12 @@ function LeieView() {
       </div>
 
       <div className="miv-controls">
-        <div className="mi-subtabs">
+        <div className="mi-subtabs" role="tablist" aria-label="Visning">
           {SUB_TABS.map((t) => (
             <button
               key={t.id}
+              type="button"
+              role="tab"
               aria-selected={sub === t.id}
               onClick={() => setSub(t.id)}
             >
@@ -1188,12 +1192,16 @@ export function MarkedsinnsiktShell() {
 
   return (
     <div className="mi-shell">
-      <aside className="mi-nav" aria-label="Sektorer">
-        <div className="mi-nav-label">Sektor</div>
+      <aside className="mi-nav" role="tablist" aria-label="Sektorer">
+        <div className="mi-nav-label" aria-hidden="true">
+          Sektor
+        </div>
         {SECTORS.map((s, i) => (
           <Fragment key={s.id}>
-            {i === 4 && <div className="divider" />}
+            {i === 4 && <div className="divider" aria-hidden="true" />}
             <button
+              type="button"
+              role="tab"
               data-sector={s.id}
               aria-selected={sector === s.id}
               onClick={() => selectSector(s.id)}

--- a/src/components/markedsinnsikt/maps/MarkedsKartLeafletCelle.tsx
+++ b/src/components/markedsinnsikt/maps/MarkedsKartLeafletCelle.tsx
@@ -251,7 +251,6 @@ function MapController({
     if (zs) moveTo(zs.center[0], zs.center[1], zs.zoom)
     else moveTo(city.lat, city.lon, 11)
     // Bare selected som trigger — andre deps via stabile refs
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selected, moveTo])
 
   // (b) ViewRequest → eksplisitt kartbevegelse (CTA, chip, reset)

--- a/src/components/og/EditorialCard.tsx
+++ b/src/components/og/EditorialCard.tsx
@@ -226,8 +226,11 @@ export function EditorialCard(props: EditorialCardProps) {
           {props.mode === "article" ? (
             <div style={{ display: "flex", alignItems: "center" }}>
               {props.authorAvatar ? (
+                // OG cards render via satori (next/image is unsupported here).
+                // eslint-disable-next-line @next/next/no-img-element
                 <img
                   src={props.authorAvatar}
+                  alt=""
                   width={48}
                   height={48}
                   style={{

--- a/src/components/site/Nav.tsx
+++ b/src/components/site/Nav.tsx
@@ -30,8 +30,7 @@ import {
   Megaphone,
 } from "lucide-react";
 import { trackEvent } from "@/lib/analytics";
-import { EIENDOM_CITIES, type NavEntry } from "@/lib/navigation";
-import { stripHash } from "@/lib/stripHash";
+import { EIENDOM_CITIES, stripHash, type NavEntry } from "@/lib/navigation";
 
 const useIsoLayoutEffect =
   typeof window !== "undefined" ? useLayoutEffect : useEffect;

--- a/src/components/verktoy/ValuationPriceCalculator.tsx
+++ b/src/components/verktoy/ValuationPriceCalculator.tsx
@@ -6,6 +6,29 @@ import { Input } from "@/components/Input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/Select";
 import { RiInformationLine } from "@remixicon/react";
 
+// Pricing tables are pure constants — hoisted to module scope so they are not
+// re-created each render and don't need to be effect dependencies.
+const basePrices = {
+  enkel: { min: 15000, max: 30000 },
+  standard: { min: 30000, max: 60000 },
+  omfattende: { min: 60000, max: 150000 },
+};
+
+const complexityMultipliers = {
+  standard: 1.0,
+  middels: 1.3,
+  høy: 1.6,
+};
+
+// Area multipliers (for larger properties)
+const getAreaMultiplier = (area: number) => {
+  if (area < 500) return 0.8;
+  if (area < 1000) return 1.0;
+  if (area < 2000) return 1.2;
+  if (area < 5000) return 1.5;
+  return 2.0;
+};
+
 export function ValuationPriceCalculator() {
   // Input state
   const [areal, setAreal] = useState(1000);
@@ -16,29 +39,6 @@ export function ValuationPriceCalculator() {
   // Calculated values
   const [estimertPris, setEstimertPris] = useState(0);
   const [prisRange, setPrisRange] = useState<{ min: number; max: number }>({ min: 0, max: 0 });
-
-  // Base prices
-  const basePrices = {
-    enkel: { min: 15000, max: 30000 },
-    standard: { min: 30000, max: 60000 },
-    omfattende: { min: 60000, max: 150000 },
-  };
-
-  // Complexity multipliers
-  const complexityMultipliers = {
-    standard: 1.0,
-    middels: 1.3,
-    høy: 1.6,
-  };
-
-  // Area multipliers (for larger properties)
-  const getAreaMultiplier = (area: number) => {
-    if (area < 500) return 0.8;
-    if (area < 1000) return 1.0;
-    if (area < 2000) return 1.2;
-    if (area < 5000) return 1.5;
-    return 2.0;
-  };
 
   // Calculate on input change
   useEffect(() => {

--- a/src/lib/blog/images.ts
+++ b/src/lib/blog/images.ts
@@ -10,7 +10,7 @@ export async function getBlurDataURL(url: string | null) {
     const base64 = Buffer.from(buffer).toString("base64");
 
     return `data:image/png;base64,${base64}`;
-  } catch (error) {
+  } catch {
     return "data:image/webp;base64,AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
   }
 }

--- a/src/lib/email/discord.ts
+++ b/src/lib/email/discord.ts
@@ -1,5 +1,6 @@
 import "server-only"
-import type { SubscribeSource } from "./subscribe"
+import { HIGH_INTENT, type SubscribeSource } from "./subscribe"
+import { sanitizeDiscordValue } from "./sanitize"
 
 const WEBHOOK = process.env.DISCORD_WEBHOOK_URL
 
@@ -24,16 +25,8 @@ const SOURCE_LABEL: Record<SubscribeSource, string> = {
 
 // Pages that match a hard-intent signal get a high-priority colour stripe in
 // Discord so they jump out of the digest. Marketing-funnel signups are
-// brand-neutral; intake forms are light-blue.
-const HIGH_INTENT: SubscribeSource[] = [
-  "verdivurdering-intake",
-  "beslutningsgrunnlag",
-  "service-modal",
-  "kontakt",
-  "eiendommer",
-  "investorportal",
-  "naringsmegler",
-]
+// brand-neutral; intake forms are light-blue. The high-intent set is the
+// shared HIGH_INTENT constant from subscribe.ts (single source of truth).
 const WARM_GREY = 0x2c2825
 const LIGHT_BLUE = 0xcbeef2
 
@@ -68,7 +61,11 @@ export async function notifyLead(args: Args): Promise<boolean> {
     { name: "🕐 Tidspunkt", value: timestamp, inline: true },
   ]
   if (args.firstName) {
-    fields.push({ name: "👤 Navn", value: args.firstName, inline: true })
+    fields.push({
+      name: "👤 Navn",
+      value: sanitizeDiscordValue(args.firstName, 200),
+      inline: true,
+    })
   }
   if (args.pageUrl) {
     fields.push({ name: "🔗 Side", value: args.pageUrl, inline: false })
@@ -83,7 +80,7 @@ export async function notifyLead(args: Args): Promise<boolean> {
   if (args.intake) {
     const intakeFields = Object.entries(args.intake)
       .filter(([, v]) => v !== undefined && v !== "")
-      .map(([k, v]) => `**${k}:** ${v}`)
+      .map(([k, v]) => `**${sanitizeDiscordValue(k, 60)}:** ${sanitizeDiscordValue(v)}`)
       .join("\n")
     if (intakeFields) {
       fields.push({

--- a/src/lib/email/sanitize.ts
+++ b/src/lib/email/sanitize.ts
@@ -1,0 +1,20 @@
+/**
+ * Neutralize Discord-markdown metacharacters and newlines in a user-supplied
+ * value before it is interpolated into embed markdown the team reads as trusted
+ * (`**${k}:** ${v}`). Without this, a submitter can forge extra labelled lines,
+ * masked links, or `@`-style noise inside a lead notification.
+ *
+ * Idempotent — safe to call on already-cleaned input. Shared by `discord.ts`
+ * (the universal choke point for every lead source) and the per-form `clean()`
+ * in `naringsmegler-lead.ts`.
+ */
+export function sanitizeDiscordValue(
+  v: string | number | undefined | null,
+  max = 500,
+): string {
+  return String(v ?? "")
+    .replace(/[\r\n*_`~|[\]]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, max)
+}

--- a/src/lib/email/subscribe.ts
+++ b/src/lib/email/subscribe.ts
@@ -52,7 +52,17 @@ const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
 const RESEND_CONFIGURED = () =>
   Boolean(AUDIENCE_ID && process.env.RESEND_API_KEY)
 
-const HIGH_INTENT: SubscribeSource[] = [
+/**
+ * Sales-qualified sources: warrant a durable destination (Discord/CRM) and a
+ * curated `crm_leads` row rather than the lightweight `web_signups` table.
+ *
+ * SINGLE SOURCE OF TRUTH — imported by `discord.ts` (color/label tier) and
+ * `supabase/leads.ts` (CRM-vs-web_signups routing). Previously this list was
+ * duplicated in all three files and drifted: `leads.ts` omitted
+ * `investorportal`, so investor-portal leads silently landed in `web_signups`
+ * instead of the CRM. Keep this the only definition.
+ */
+export const HIGH_INTENT: SubscribeSource[] = [
   "verdivurdering-intake",
   "beslutningsgrunnlag",
   "service-modal",

--- a/src/lib/forms/schemas.ts
+++ b/src/lib/forms/schemas.ts
@@ -1,0 +1,89 @@
+import { z } from "zod"
+
+/**
+ * Input-validation schemas for the lead/contact server actions.
+ *
+ * Each schema mirrors the action's existing required-field set and length caps —
+ * the goal is to centralize and enforce validation (and reject oversized/
+ * malformed payloads before they reach business logic), NOT to tighten what a
+ * legitimate visitor can submit. Discord-markdown neutralization is handled
+ * separately at the choke point (lib/email/sanitize.ts); these schemas are the
+ * structural gate (shape, required fields, length, email format).
+ *
+ * Convention: FormData yields "" for empty fields; `optionalText` treats blank
+ * as absent so optional fields don't become empty strings downstream.
+ */
+
+const optionalText = (max: number) =>
+  z
+    .string()
+    .trim()
+    .max(max)
+    .transform((v) => (v.length > 0 ? v : undefined))
+    .optional()
+
+const requiredText = (max: number, message = "Påkrevd felt mangler.") =>
+  z.string().trim().min(1, message).max(max)
+
+/** Lowercased, format-validated email. */
+const email = z
+  .string()
+  .trim()
+  .toLowerCase()
+  .pipe(z.email("Fyll inn en gyldig e-postadresse."))
+
+// ── newsletter (footer / lead-magnet signup) ────────────────────────────────
+export const newsletterSchema = z.object({
+  email,
+  source: optionalText(60),
+  pageUrl: optionalText(200),
+  firstName: optionalText(200),
+})
+
+// ── CTA lead modal (service-page request) ───────────────────────────────────
+// formType is optional to match the action's existing behavior (it defaults to
+// "" when absent); name + email are the only hard requirements.
+export const ctaLeadSchema = z.object({
+  formType: optionalText(100),
+  name: requiredText(200, "Fyll inn navn."),
+  email,
+  phone: optionalText(50),
+  pageUrl: optionalText(200),
+  fields: z.record(z.string(), z.string()).optional(),
+})
+
+// ── verdivurdering / beslutningsgrunnlag intake (hardest intent) ─────────────
+export const verdivurderingIntakeSchema = z.object({
+  email,
+  firstName: optionalText(200),
+  propertyType: requiredText(100, "Velg eiendomstype."),
+  location: requiredText(100, "Fyll inn sted."),
+  purpose: requiredText(100, "Velg formål."),
+  address: optionalText(400),
+  company: optionalText(200),
+  areal: optionalText(50),
+  leie: optionalText(50),
+  size: optionalText(50),
+  horizon: optionalText(50),
+  phone: optionalText(50),
+  notes: optionalText(2000),
+  page: optionalText(200),
+  intakeSource: optionalText(60),
+})
+
+// ── investor-portal access request ──────────────────────────────────────────
+export const investorAccessSchema = z.object({
+  name: requiredText(200, "Fyll inn navn."),
+  email,
+  company: optionalText(200),
+  mandate: optionalText(500),
+})
+
+// ── kontakt (contact inquiry) ───────────────────────────────────────────────
+export const contactInquirySchema = z.object({
+  name: requiredText(200, "Fyll inn navn."),
+  email,
+  phone: optionalText(50),
+  service: requiredText(200, "Velg tjeneste."),
+  message: optionalText(2000),
+})

--- a/src/lib/stripHash.ts
+++ b/src/lib/stripHash.ts
@@ -1,4 +1,0 @@
-/** Strip hash fragment from a path string. */
-export function stripHash(path: string): string {
-  return path.split("#")[0];
-}

--- a/src/lib/supabase/leads.ts
+++ b/src/lib/supabase/leads.ts
@@ -1,6 +1,6 @@
 import "server-only"
 import { getSupabase, isSupabaseConfigured } from "./server"
-import type { SubscribeSource } from "@/lib/email/subscribe"
+import { HIGH_INTENT, type SubscribeSource } from "@/lib/email/subscribe"
 
 type RecordSignupArgs = {
   email: string
@@ -12,16 +12,9 @@ type RecordSignupArgs = {
   alreadySubscribed?: boolean
 }
 
-// Sources that are sales-qualified and warrant a row in the curated CRM.
-// Everything else lands in the lightweight web_signups table.
-const HIGH_INTENT: SubscribeSource[] = [
-  "verdivurdering-intake",
-  "beslutningsgrunnlag",
-  "service-modal",
-  "kontakt",
-  "eiendommer",
-  "naringsmegler",
-]
+// HIGH_INTENT (sales-qualified → curated CRM; everything else → lightweight
+// web_signups) is the shared constant from subscribe.ts — the single source of
+// truth across subscribe/discord/leads. Do not redefine it here.
 
 // Visitor-facing Norwegian terms → crm_leads `property_type` enum values.
 // The enum is: kontor, industri, lager, butikk, senter, tomt.
@@ -88,7 +81,6 @@ export async function recordSignup(args: RecordSignupArgs): Promise<boolean> {
 async function insertWebSignup(
   // Loosely typed because the @supabase/supabase-js generic is heavy and
   // we don't have generated types for this project yet.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   supabase: any,
   args: RecordSignupArgs,
 ): Promise<boolean> {
@@ -108,7 +100,6 @@ async function insertWebSignup(
 }
 
 async function insertCrmLead(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   supabase: any,
   args: RecordSignupArgs,
 ): Promise<boolean> {
@@ -119,15 +110,14 @@ async function insertCrmLead(
   // Build the lead row. Most fields default to NULL / empty array when the
   // intake didn't supply them; only firma_navn, kontakt_navn, kontakt_epost
   // are NOT NULL at the schema level.
+  const sted = intakeString(intake, "Sted")
   const leadRow = {
     firma_navn: intakeString(intake, "Bedrift") ?? "Ukjent (skjema-innsending)",
     kontakt_navn: args.firstName ?? "Ukjent",
     kontakt_epost: args.email,
     kontakt_telefon: intakeString(intake, "Telefon") ?? null,
     behov_type_eiendom: mapPropertyType(intakeString(intake, "Eiendomstype")),
-    behov_geografi: intakeString(intake, "Sted")
-      ? [intakeString(intake, "Sted")!]
-      : [],
+    behov_geografi: sted ? [sted] : [],
     tidshorisont: intakeString(intake, "Tidshorisont") ?? null,
     behov_beskrivelse: intakeString(intake, "Bakgrunn") ?? null,
     notater: intakeString(intake, "Beskjed") ?? null,
@@ -148,7 +138,11 @@ async function insertCrmLead(
   }
 
   // Activity timeline entry so the lead shows up with context in the CRM's
-  // activity feed instead of appearing as an empty new row.
+  // activity feed instead of appearing as an empty new row. Best-effort: the
+  // lead row is already durably saved, so an activity failure must NOT discard
+  // that success (returning false here would report the lead as lost and, for a
+  // high-intent source with Discord also down, surface a false error to the
+  // visitor). Log it and still report success.
   const summary = buildActivitySummary(args, intake)
   const { error: actErr } = await supabase.from("crm_activities").insert({
     type: "notat",
@@ -158,8 +152,10 @@ async function insertCrmLead(
     utført_av: "system: advantiestate.no",
   })
   if (actErr) {
-    console.error("Supabase crm_activities.insert error:", actErr)
-    return false
+    console.error(
+      "Supabase crm_activities.insert error (lead saved, activity skipped):",
+      actErr,
+    )
   }
   return true
 }

--- a/tests/naringsmegler-qa-regression.spec.ts
+++ b/tests/naringsmegler-qa-regression.spec.ts
@@ -46,11 +46,11 @@ test("markedskart reacts to same-page hash changes (ISSUE-001)", async ({
   // behaviour is unchanged, only the wait is more patient (fixes CI flake).
   await expect(
     page.getByRole("button", { name: "Prime yield" }),
-  ).toHaveAttribute("aria-pressed", "true", { timeout: 15_000 });
+  ).toHaveAttribute("aria-pressed", "true", { timeout: 25_000 });
   await page.evaluate(() => {
     window.location.hash = "#leie";
   });
   await expect(
     page.getByRole("button", { name: "Markedsleie" }),
-  ).toHaveAttribute("aria-pressed", "true", { timeout: 15_000 });
+  ).toHaveAttribute("aria-pressed", "true", { timeout: 25_000 });
 });

--- a/tests/presserom.spec.ts
+++ b/tests/presserom.spec.ts
@@ -234,9 +234,11 @@ test("B8: /presserom JSON-LD — Dataset med distribution.contentUrl, ingen node
   const blocks = await page.locator(LD).allTextContents();
   expect(blocks.length, "JSON-LD blocks på /presserom").toBeGreaterThan(0);
 
-  // Alle blokker skal parses uten feil  const parsed: any[] = blocks.map((b) => JSON.parse(b));
+  // Alle blokker skal parses uten feil
+  const parsed: any[] = blocks.map((b) => JSON.parse(b));
 
-  // Minst én Dataset-blokk  const dataset = parsed.find((b: any) => b["@type"] === "Dataset");
+  // Minst én Dataset-blokk
+  const dataset = parsed.find((b: any) => b["@type"] === "Dataset");
   expect(dataset, "Dataset JSON-LD blokk").toBeTruthy();
 
   // distribution.contentUrl skal slutte med /presserom/markedstall.csv

--- a/tests/presserom.spec.ts
+++ b/tests/presserom.spec.ts
@@ -234,13 +234,9 @@ test("B8: /presserom JSON-LD — Dataset med distribution.contentUrl, ingen node
   const blocks = await page.locator(LD).allTextContents();
   expect(blocks.length, "JSON-LD blocks på /presserom").toBeGreaterThan(0);
 
-  // Alle blokker skal parses uten feil
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const parsed: any[] = blocks.map((b) => JSON.parse(b));
+  // Alle blokker skal parses uten feil  const parsed: any[] = blocks.map((b) => JSON.parse(b));
 
-  // Minst én Dataset-blokk
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const dataset = parsed.find((b: any) => b["@type"] === "Dataset");
+  // Minst én Dataset-blokk  const dataset = parsed.find((b: any) => b["@type"] === "Dataset");
   expect(dataset, "Dataset JSON-LD blokk").toBeTruthy();
 
   // distribution.contentUrl skal slutte med /presserom/markedstall.csv
@@ -300,11 +296,7 @@ test(`B10: /blog/${CODEHAGEN_SLUG} Article.author @id → /personer/christer-hag
     waitUntil: "domcontentloaded",
   });
 
-  const blocks = await page.locator(LD).allTextContents();
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const parsed: any[] = blocks.map((b) => JSON.parse(b));
-
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const blocks = await page.locator(LD).allTextContents();  const parsed: any[] = blocks.map((b) => JSON.parse(b));
   const article = parsed.find((b: any) => b["@type"] === "Article");
   expect(article, "Article JSON-LD blokk på bloggpost").toBeTruthy();
 

--- a/tests/unit/formSchemas.test.ts
+++ b/tests/unit/formSchemas.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from "vitest"
+import {
+  newsletterSchema,
+  ctaLeadSchema,
+  verdivurderingIntakeSchema,
+  investorAccessSchema,
+  contactInquirySchema,
+} from "@/lib/forms/schemas"
+
+// Validation gate for the lead/contact server actions. These lock the
+// required-field sets + email format + that blank optional fields become
+// undefined (not "") so they drop out of the Discord notification.
+
+describe("newsletterSchema", () => {
+  it("accepts a valid email and lowercases + trims it", () => {
+    const r = newsletterSchema.safeParse({ email: "  Ola@Example.NO " })
+    expect(r.success).toBe(true)
+    if (r.success) expect(r.data.email).toBe("ola@example.no")
+  })
+
+  it("rejects a malformed email", () => {
+    expect(newsletterSchema.safeParse({ email: "not-an-email" }).success).toBe(
+      false,
+    )
+    expect(newsletterSchema.safeParse({ email: "" }).success).toBe(false)
+  })
+
+  it("turns a blank optional field into undefined", () => {
+    const r = newsletterSchema.safeParse({ email: "a@b.no", firstName: "" })
+    expect(r.success).toBe(true)
+    if (r.success) expect(r.data.firstName).toBeUndefined()
+  })
+})
+
+describe("verdivurderingIntakeSchema", () => {
+  const base = {
+    email: "a@b.no",
+    propertyType: "Kontor",
+    location: "Bodø",
+    purpose: "Vurderer salg",
+  }
+
+  it("accepts the hard-intent minimum (email + type + location + purpose)", () => {
+    expect(verdivurderingIntakeSchema.safeParse(base).success).toBe(true)
+  })
+
+  it("rejects when a required field is missing", () => {
+    expect(
+      verdivurderingIntakeSchema.safeParse({ ...base, location: "" }).success,
+    ).toBe(false)
+    expect(
+      verdivurderingIntakeSchema.safeParse({ ...base, purpose: "" }).success,
+    ).toBe(false)
+  })
+
+  it("caps an over-long free-text field", () => {
+    const r = verdivurderingIntakeSchema.safeParse({
+      ...base,
+      notes: "x".repeat(5000),
+    })
+    expect(r.success).toBe(false)
+  })
+})
+
+describe("ctaLeadSchema", () => {
+  it("requires name + valid email; formType is optional", () => {
+    expect(
+      ctaLeadSchema.safeParse({ name: "Ola", email: "a@b.no" }).success,
+    ).toBe(true)
+    expect(
+      ctaLeadSchema.safeParse({ name: "", email: "a@b.no" }).success,
+    ).toBe(false)
+    expect(
+      ctaLeadSchema.safeParse({ name: "Ola", email: "bad" }).success,
+    ).toBe(false)
+  })
+})
+
+describe("investorAccessSchema", () => {
+  it("requires name + valid email; company/mandate optional", () => {
+    expect(
+      investorAccessSchema.safeParse({ name: "Kari", email: "k@i.no" }).success,
+    ).toBe(true)
+    expect(
+      investorAccessSchema.safeParse({ name: "", email: "k@i.no" }).success,
+    ).toBe(false)
+  })
+})
+
+describe("contactInquirySchema", () => {
+  it("requires name + email + service", () => {
+    expect(
+      contactInquirySchema.safeParse({
+        name: "Ola",
+        email: "a@b.no",
+        service: "Verdsettelse",
+      }).success,
+    ).toBe(true)
+    expect(
+      contactInquirySchema.safeParse({
+        name: "Ola",
+        email: "a@b.no",
+        service: "",
+      }).success,
+    ).toBe(false)
+  })
+})

--- a/tests/unit/leads.test.ts
+++ b/tests/unit/leads.test.ts
@@ -6,18 +6,25 @@ import { describe, it, expect, vi, beforeEach } from "vitest"
 // ---------------------------------------------------------------------------
 
 const inserted: Array<{ table: string; row: unknown }> = []
+// When true, the crm_activities insert reports an error — used to prove the
+// activity write is best-effort and never discards a saved crm_leads row.
+let failActivities = false
 
 const fakeClient = {
   from: (table: string) => ({
     insert: (row: unknown) => {
       inserted.push({ table, row })
+      const err =
+        table === "crm_activities" && failActivities
+          ? { message: "activity insert failed" }
+          : null
       return {
         select: () => ({
           single: async () => ({ data: { id: "lead-1" }, error: null }),
         }),
         // Thenable so `await supabase.from(t).insert(row)` resolves cleanly
-        then: (resolve: (v: { error: null }) => void) =>
-          resolve({ error: null }),
+        then: (resolve: (v: { error: unknown }) => void) =>
+          resolve({ error: err }),
       }
     },
   }),
@@ -88,6 +95,7 @@ describe("buildActivitySummary", () => {
 describe("recordSignup routing", () => {
   beforeEach(() => {
     inserted.splice(0) // reset the captured inserts
+    failActivities = false
   })
 
   it("routes HIGH_INTENT 'kontakt' → crm_leads then crm_activities", async () => {
@@ -123,6 +131,32 @@ describe("recordSignup routing", () => {
       firstName: "Ola Nordmann",
       intake: { Type: "Verdsettelse", Telefon: "999 88 777" },
     })
+    expect(ok).toBe(true)
+    expect(inserted[0]?.table).toBe("crm_leads")
+    expect(inserted[1]?.table).toBe("crm_activities")
+  })
+
+  // Regression: the three HIGH_INTENT lists (subscribe/discord/leads) drifted —
+  // leads.ts omitted 'investorportal', so investor-portal leads silently landed
+  // in web_signups instead of the curated CRM. Consolidated to one shared
+  // constant; this locks investorportal to crm_leads.
+  it("routes HIGH_INTENT 'investorportal' → crm_leads then crm_activities", async () => {
+    const ok = await recordSignup({
+      email: "investor@example.no",
+      source: "investorportal",
+      firstName: "Kari Investor",
+    })
+    expect(ok).toBe(true)
+    expect(inserted[0]?.table).toBe("crm_leads")
+    expect(inserted[1]?.table).toBe("crm_activities")
+  })
+
+  // Regression: a crm_activities insert failure must NOT discard the already
+  // saved crm_leads row (it previously returned false, reporting the lead as
+  // lost). The activity is best-effort; the lead still counts as recorded.
+  it("returns true when the lead saved but crm_activities insert fails", async () => {
+    failActivities = true
+    const ok = await recordSignup({ email: "a@b.no", source: "kontakt" })
     expect(ok).toBe(true)
     expect(inserted[0]?.table).toBe("crm_leads")
     expect(inserted[1]?.table).toBe("crm_activities")


### PR DESCRIPTION
Full-repo `/improve` audit (first since 2026-06-10) — implemented the safe high-leverage findings AND, per follow-up request, the three deferred plans (014/015/016) into this PR. 11 commits; build + lint + 188 unit tests green locally.

## Lead pipeline (the headline)
- **HIGH_INTENT drift fixed.** The list was duplicated in 3 files and `leads.ts` omitted `investorportal`. Unified to one exported constant.
- **investorportal actually reaches the CRM now.** `requestInvestorAccess` called `notifyLead()` directly (Discord-only) — it never hit Supabase at all. Re-routed through `subscribe()`, so investor access requests land in `crm_leads` (your decision). Verified via Supabase MCP: schema-safe, 0 stranded rows.
- `crm_activities` failure no longer discards a saved `crm_leads` row. +3 regression tests.

## Security — Discord-markdown injection (finding #3, fully closed)
- Shared `sanitizeDiscordValue()` at the `discord.ts` choke point (all `notifyLead` sources) **and** the two direct-fetch embed builders in `onboarding.ts` (`submitOnboarding` + the `#nettside` secondary webhook) that bypass the choke point.

## Plan 016 — zod input validation
- zod 4 schemas (`lib/forms/schemas.ts`) for all 5 lead/contact actions, applied via `safeParse`. Closes the newsletter (no email check) and contact-inquiry (no validation) gaps. Mirrors existing required-sets/caps; +9 schema unit tests.

## Plan 015 — a11y tab semantics
- MarkedsinnsiktShell subtab/sector controls now use `role="tablist"`/`role="tab"` (was `aria-selected` on bare buttons). Lint **20 → 0 warnings**; the 3 `aria-selected` tests still pass.

## Plan 014 — dependency security
- `@content-collections/core` 0.8→0.15, `fumadocs-core` 15→16. Clears 5 of 9 audit advisories incl. **serialize-javascript RCE** + **path-to-regexp ReDoS**. core 0.15 retired schema-as-function → migrated the 9 collection schemas to `z.object({…})` (field defs unchanged). Remaining 4 advisories are build/dev-chain only (flatted via eslint; esbuild/uuid via the content build pipeline on trusted MDX).

## Also
- DRY: removed duplicate `stripHash`.
- Lint hygiene across the repo (eslint `_`-convention, dead disables, useEffect const-hoist, OG alt).
- CI repair: fixed a presserom spec I'd mangled removing disable comments; bumped the pre-existing markedskart flake timeout (15s→25s).
- Plans 014/015/016 marked DONE in the index; 013 SUPERSEDED banner.

## Verification
`pnpm build` green (content-collections codegen, all 9 collections), `pnpm lint` 0/0, `pnpm test:unit` 188 passed, `pnpm audit` 9→4 (remaining build-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added Zod-based validation and normalization for CTA leads, investor access, newsletter, onboarding contact inquiries, and verdivurdering intake, improving form error handling.
  * Strengthened Discord/message sanitization and made CRM activity recording best-effort to avoid misreporting leads.
  * Improved tab and ARIA semantics in the Markedsinnsikt UI for better accessibility.
* **Refactor**
  * Centralized shared sanitization utilities and form schemas for consistent input handling.
* **Chores**
  * Updated linting rules, added schema validation tests, and refreshed SEO/planning documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->