### PR TITLE
Hjelpesenter-forsiden: ruter i stedet for flat liste (LISTE-ANATOMI)

### DIFF
--- a/src/app/(help)/help/page.tsx
+++ b/src/app/(help)/help/page.tsx
@@ -90,6 +90,23 @@ export default function HelpCenter() {
       .filter((s): s is { slug: string; title: string } => s !== null),
   }))
 
+  // "Bla på tema" — one card per canonical category, previewing the top 3
+  // articles (curated popRank first, then newest) and linking to the full
+  // category page. New articles grow the category page, not this front page.
+  const categoryCards = HELP_CATEGORY_META.map((c) => {
+    const inCat = libraryItems.filter((it) => it.categorySlug === c.slug)
+    const top = [...inCat]
+      .sort((a, b) => {
+        const ra = a.popRank ?? Infinity
+        const rb = b.popRank ?? Infinity
+        if (ra !== rb) return ra - rb
+        return Date.parse(b.updated) - Date.parse(a.updated)
+      })
+      .slice(0, 3)
+      .map((t) => ({ slug: t.slug, title: t.title }))
+    return { slug: c.slug, title: c.title, count: inCat.length, top }
+  })
+
   return (
     <>
       <SubHero
@@ -175,6 +192,87 @@ export default function HelpCenter() {
                     </li>
                   ))}
                 </ul>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* MEST LEST — curated top list */}
+      {popularDto.length > 0 && (
+        <section className="section-tight" style={{ paddingTop: 8, paddingBottom: 48 }}>
+          <div className="wrap">
+            <div className="head-compact" style={{ marginBottom: 24 }}>
+              <span className="eyebrow">Mest lest</span>
+              <div>
+                <h2>
+                  Start med <span className="italic">det folk faktisk leser.</span>
+                </h2>
+              </div>
+            </div>
+
+            <div className="hs-mostread">
+              {popularDto.map((a, i) => (
+                <Link
+                  key={a.slug}
+                  className="hs-mr"
+                  href={`/help/article/${a.slug}`}
+                  prefetch={false}
+                >
+                  <span className="mn">{String(i + 1).padStart(2, "0")}</span>
+                  <span className="mt">{a.title}</span>
+                  <span className="mtag">{a.category}</span>
+                </Link>
+              ))}
+            </div>
+          </div>
+        </section>
+      )}
+
+      {/* BLA PÅ TEMA — category browse cards */}
+      <section className="section-tight" style={{ paddingTop: 8, paddingBottom: 48 }}>
+        <div className="wrap">
+          <div className="head-compact" style={{ marginBottom: 24 }}>
+            <span className="eyebrow">Bla på tema</span>
+            <div>
+              <h2>
+                {HELP_CATEGORY_META.length} temaer{" "}
+                <span className="italic">å utforske.</span>
+              </h2>
+              <p>
+                Bla deg inn i ett område — hvert tema har sin egen side med hele
+                listen.
+              </p>
+            </div>
+          </div>
+
+          <div className="hs-browse">
+            {categoryCards.map((c, i) => (
+              <div className="hs-cat" key={c.slug}>
+                <div className="chead">
+                  <div>
+                    <span className="pre">
+                      Tema · {String(i + 1).padStart(2, "0")}
+                    </span>
+                    <h3>{c.title}</h3>
+                  </div>
+                  <span className="cn">{c.count}</span>
+                </div>
+                <ul className="links">
+                  {c.top.map((a) => (
+                    <li key={a.slug}>
+                      <Link href={`/help/article/${a.slug}`} prefetch={false}>
+                        <span className="li-arrow" aria-hidden="true">
+                          →
+                        </span>
+                        {a.title}
+                      </Link>
+                    </li>
+                  ))}
+                </ul>
+                <Link className="seeall" href={`/help/category/${c.slug}`}>
+                  Se alle {c.count} <span className="sa" aria-hidden="true">→</span>
+                </Link>
               </div>
             ))}
           </div>

--- a/src/components/help/HelpLibrary.tsx
+++ b/src/components/help/HelpLibrary.tsx
@@ -165,13 +165,14 @@ export function HelpLibrary({
         </div>
 
         {q.length === 0 && (
-          <div className="hs-sort">
-            <span className="lbl">Sorter</span>
+          <div className="hs-sort" role="group" aria-label="Sorter">
+            <span className="lbl" aria-hidden="true">Sorter</span>
             {SORTS.map((s) => (
               <button
                 key={s.key}
                 type="button"
                 className="hs-sortbtn"
+                aria-pressed={sort === s.key}
                 data-on={sort === s.key ? "1" : undefined}
                 onClick={() => setSort(s.key)}
               >

--- a/src/components/help/HelpLibrary.tsx
+++ b/src/components/help/HelpLibrary.tsx
@@ -1,9 +1,14 @@
 "use client"
 
 import Link from "next/link"
-import { useMemo, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 
 import { foldNo } from "@/lib/blog/help-data"
+
+// Front-page index is capped — the design rule: never render 100+ rows at once.
+// "Vis flere" reveals more; search/filter narrows the set rather than expanding
+// the wall. The exhaustive list lives on the category pages.
+const PAGE = 12
 
 export interface LibraryItem {
   slug: string
@@ -72,6 +77,7 @@ export function HelpLibrary({
   const [cat, setCat] = useState<string>("all")
   const [filter, setFilter] = useState("")
   const [sort, setSort] = useState<SortKey>("popular")
+  const [visible, setVisible] = useState(PAGE)
 
   const counts = useMemo(() => {
     const map: Record<string, number> = {}
@@ -92,6 +98,13 @@ export function HelpLibrary({
     })
     return sortItems(filtered, q ? "popular" : sort)
   }, [items, cat, q, sort])
+
+  // Reset the visible window whenever the result set changes, so a new
+  // filter/search/sort always starts from the top of a fresh, capped list.
+  useEffect(() => {
+    setVisible(PAGE)
+  }, [q, cat, sort])
+  const shown = list.slice(0, visible)
 
   const reset = () => {
     setCat("all")
@@ -170,8 +183,9 @@ export function HelpLibrary({
       </div>
 
       {list.length > 0 ? (
+        <>
         <div className="hs-index">
-          {list.map((it) => (
+          {shown.map((it) => (
             <Link
               key={it.slug}
               className="hs-row"
@@ -196,6 +210,15 @@ export function HelpLibrary({
             </Link>
           ))}
         </div>
+        {list.length > visible && (
+          <div className="hs-loadmore">
+            <button type="button" onClick={() => setVisible((v) => v + PAGE)}>
+              Vis flere{" "}
+              <span className="lm-count">({list.length - visible} igjen)</span>
+            </button>
+          </div>
+        )}
+        </>
       ) : (
         <div className="hs-empty">
           <div className="em-mark" aria-hidden="true">

--- a/src/components/help/HelpLibrary.tsx
+++ b/src/components/help/HelpLibrary.tsx
@@ -225,9 +225,9 @@ export function HelpLibrary({
           <div className="em-mark" aria-hidden="true">
             ⌕
           </div>
-          <h4>
+          <h3>
             Ingen treff <span className="q">her.</span>
-          </h4>
+          </h3>
           <p>
             Vi fant ingen artikler som matcher
             {q ? ` «${filter.trim()}»` : " filteret"}

--- a/src/styles/advanti-design.css
+++ b/src/styles/advanti-design.css
@@ -10520,7 +10520,7 @@ h1, h2, h3 {
 .hs-mr { display: grid; grid-template-columns: 30px 1fr auto; align-items: baseline; gap: 16px; padding: 16px 2px; border-bottom: var(--hairline); text-decoration: none; color: var(--warm-grey); transition: background 0.15s, padding 0.15s; }
 .hs-mr .mn { font-family: var(--font-display); font-size: 17px; color: var(--accent-soft); font-variant-numeric: tabular-nums; }
 .hs-mr .mt { font-family: var(--font-display); font-size: 18px; font-weight: 400; letter-spacing: -0.01em; line-height: 1.2; }
-.hs-mr .mtag { font-size: 10px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--warm-grey-85); white-space: nowrap; }
+.hs-mr .mtag { font-size: 10.5px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--warm-grey-85); white-space: nowrap; }
 @media (hover: hover) { .hs-mr:hover { background: var(--accent-faint); padding-left: 12px; padding-right: 12px; } }
 
 /* ---- Bla på tema (category browse cards) ---- */

--- a/src/styles/advanti-design.css
+++ b/src/styles/advanti-design.css
@@ -10690,6 +10690,10 @@ h1, h2, h3 {
   .hs-search .kbd { display: none; }
   .hs-sort { width: 100%; margin-left: 0; }
   .hs-herostats { gap: 32px; }
+  /* Mest lest: drop the nowrap category tag onto its own line so long
+     Norwegian titles don't get squeezed by the auto tag column on phones. */
+  .hs-mr { grid-template-columns: 30px 1fr; align-items: start; }
+  .hs-mr .mtag { grid-column: 2; margin-top: 4px; }
 }
 /* Honour reduce-motion for the v2 hover nudges + FAQ marker rotation. */
 @media (prefers-reduced-motion: reduce) {

--- a/src/styles/advanti-design.css
+++ b/src/styles/advanti-design.css
@@ -10515,6 +10515,40 @@ h1, h2, h3 {
   .hs-path .steps a:hover .sa { transform: translateX(3px); color: var(--warm-grey); }
 }
 
+/* ---- Mest lest (curated top list) ---- */
+.hs-mostread { display: grid; grid-template-columns: 1fr 1fr; gap: 0 48px; border-top: var(--hairline); }
+.hs-mr { display: grid; grid-template-columns: 30px 1fr auto; align-items: baseline; gap: 16px; padding: 16px 2px; border-bottom: var(--hairline); text-decoration: none; color: var(--warm-grey); transition: background 0.15s, padding 0.15s; }
+.hs-mr .mn { font-family: var(--font-display); font-size: 17px; color: var(--accent-soft); font-variant-numeric: tabular-nums; }
+.hs-mr .mt { font-family: var(--font-display); font-size: 18px; font-weight: 400; letter-spacing: -0.01em; line-height: 1.2; }
+.hs-mr .mtag { font-size: 10px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--warm-grey-85); white-space: nowrap; }
+@media (hover: hover) { .hs-mr:hover { background: var(--accent-faint); padding-left: 12px; padding-right: 12px; } }
+
+/* ---- Bla på tema (category browse cards) ---- */
+.hs-browse { display: grid; grid-template-columns: repeat(3, 1fr); border-top: var(--hairline); border-left: var(--hairline); }
+.hs-cat { border-right: var(--hairline); border-bottom: var(--hairline); padding: 26px 26px 22px; display: flex; flex-direction: column; transition: background 0.3s; }
+.hs-cat .chead { display: flex; align-items: flex-start; justify-content: space-between; gap: 12px; margin-bottom: 16px; }
+.hs-cat .pre { font-size: 10.5px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--warm-grey-85); font-variant-numeric: tabular-nums; }
+.hs-cat h3 { font-size: 21px; font-weight: 400; letter-spacing: -0.015em; line-height: 1.12; margin-top: 7px; }
+.hs-cat .cn { font-size: 12px; color: var(--warm-grey-85); font-variant-numeric: tabular-nums; white-space: nowrap; padding-top: 2px; }
+.hs-cat .links { list-style: none; display: flex; flex-direction: column; border-top: 1px solid rgba(215,208,200,0.55); }
+.hs-cat .links a { display: flex; align-items: baseline; gap: 8px; padding: 8px 0; font-size: 14px; line-height: 1.35; text-decoration: none; color: var(--warm-grey); border-bottom: 1px solid rgba(215,208,200,0.55); transition: color 0.15s; }
+.hs-cat .links a .li-arrow { color: var(--accent-soft); transition: transform 0.15s; }
+.hs-cat .seeall { margin-top: auto; padding-top: 16px; display: inline-flex; align-items: center; gap: 7px; font-size: 13px; text-decoration: none; color: var(--warm-grey); }
+.hs-cat .seeall .sa { color: var(--warm-grey-85); transition: transform 0.15s; }
+@media (hover: hover) {
+  .hs-cat:hover { background: var(--accent-faint); }
+  .hs-cat .links a:hover { color: var(--warm-grey-85); }
+  .hs-cat .links a:hover .li-arrow { transform: translateX(2px); }
+  .hs-cat .seeall:hover .sa { transform: translateX(3px); }
+}
+
+/* ---- Vis flere (capped index) ---- */
+.hs-loadmore { display: flex; justify-content: center; padding: 28px 0 4px; }
+.hs-loadmore button { appearance: none; cursor: pointer; font-family: var(--font-body); font-size: 14px; color: var(--warm-grey); background: transparent; border: 1px solid var(--warm-grey); border-radius: 999px; padding: 12px 26px; display: inline-flex; align-items: center; gap: 9px; transition: background 0.15s, color 0.15s; }
+.hs-loadmore button:hover { background: var(--warm-grey); color: var(--warm-white); }
+.hs-loadmore .lm-count { color: var(--warm-grey-85); font-variant-numeric: tabular-nums; }
+.hs-loadmore button:hover .lm-count { color: rgba(243,241,239,0.6); }
+
 /* ---- Library: toolbar + index ---- */
 .hs-lib-head { display: flex; justify-content: space-between; align-items: flex-end; gap: 24px; flex-wrap: wrap; margin-bottom: 28px; }
 .hs-lib-head h2 { font-size: clamp(30px, 3.4vw, 46px); font-weight: 400; letter-spacing: -0.02em; line-height: 1.04; }
@@ -10623,12 +10657,17 @@ h1, h2, h3 {
 .hs-pill:focus-visible, .hs-chip:focus-visible, .hs-sortbtn:focus-visible,
 .hs-res:focus-visible, .hs-row:focus-visible, .hs-qa summary:focus-visible,
 .hs-search input:focus-visible, .hs-empty .clearbtn:focus-visible,
-.hs-empty .ghostbtn:focus-visible, .hs-res-cta:focus-visible {
+.hs-empty .ghostbtn:focus-visible, .hs-res-cta:focus-visible,
+.hs-mr:focus-visible, .hs-cat .links a:focus-visible, .hs-cat .seeall:focus-visible,
+.hs-loadmore button:focus-visible {
   outline: 2px solid var(--warm-grey); outline-offset: 2px; border-radius: 4px;
 }
 @media (max-width: 980px) {
   .hs-paths { grid-template-columns: 1fr; border-left: 0; }
   .hs-path { border-right: 0; }
+  .hs-browse { grid-template-columns: 1fr; border-left: 0; }
+  .hs-cat { border-right: 0; }
+  .hs-mostread { grid-template-columns: 1fr; gap: 0; }
   .hs-faq-grid { grid-template-columns: 1fr; gap: 36px; }
   .art-prevnext { grid-template-columns: 1fr; }
   .art-prevnext a.next { text-align: left; align-items: flex-start; border-left: 0; border-top: var(--hairline); }

--- a/src/styles/advanti-design.css
+++ b/src/styles/advanti-design.css
@@ -10614,8 +10614,8 @@ h1, h2, h3 {
 
 .hs-empty { padding: 64px 14px; text-align: center; border-bottom: var(--hairline); }
 .hs-empty .em-mark { font-family: var(--font-display); font-size: 44px; color: var(--warm-grey-75); }
-.hs-empty h4 { font-family: var(--font-display); font-size: 24px; font-weight: 400; margin: 12px 0 8px; }
-.hs-empty h4 .q { font-style: italic; color: var(--warm-grey-85); }
+.hs-empty h3 { font-family: var(--font-display); font-size: 24px; font-weight: 400; margin: 12px 0 8px; }
+.hs-empty h3 .q { font-style: italic; color: var(--warm-grey-85); }
 .hs-empty p { font-size: 14.5px; color: var(--warm-grey-85); max-width: 44ch; margin: 0 auto 22px; line-height: 1.55; }
 .hs-empty-actions { display: inline-flex; gap: 12px; flex-wrap: wrap; justify-content: center; }
 .hs-empty .clearbtn { appearance: none; cursor: pointer; font-family: var(--font-body); font-size: 13.5px; background: var(--warm-grey); color: var(--warm-white); border: none; padding: 11px 20px; border-radius: 4px; }

--- a/src/styles/advanti-design.css
+++ b/src/styles/advanti-design.css
@@ -10549,6 +10549,16 @@ h1, h2, h3 {
 .hs-loadmore .lm-count { color: var(--warm-grey-85); font-variant-numeric: tabular-nums; }
 .hs-loadmore button:hover .lm-count { color: rgba(243,241,239,0.6); }
 
+/* Coarse-pointer touch-target floor — matches .ks-toc a / .ks-feedback / .btn-sm.
+   The compact preview links (category cards, "Se alle", reading-path steps) and
+   the load-more button are otherwise ~30-43px, below the 44px touch minimum. */
+@media (pointer: coarse) {
+  .hs-cat .links a { min-height: 44px; align-items: center; }
+  .hs-cat .seeall { min-height: 44px; }
+  .hs-loadmore button { min-height: 44px; }
+  .hs-path .steps a { min-height: 44px; }
+}
+
 /* ---- Library: toolbar + index ---- */
 .hs-lib-head { display: flex; justify-content: space-between; align-items: flex-end; gap: 24px; flex-wrap: wrap; margin-bottom: 28px; }
 .hs-lib-head h2 { font-size: clamp(30px, 3.4vw, 46px); font-weight: 400; letter-spacing: -0.02em; line-height: 1.04; }

--- a/src/styles/advanti-design.css
+++ b/src/styles/advanti-design.css
@@ -10686,11 +10686,15 @@ h1, h2, h3 {
   .hs-path, .hs-path .steps a .sa, .hs-row, .hs-row .rarrow, .hs-res,
   .hs-res .rarrow, .hs-pill, .hs-chip, .hs-sortbtn, .hs-search, .hs-minisearch,
   .hs-faq-aside .askmore, .hs-qa summary::after,
-  .art-prevnext a, .ks-art-author .av {
+  .art-prevnext a, .ks-art-author .av,
+  .hs-mr, .hs-cat, .hs-cat .links a, .hs-cat .links a .li-arrow,
+  .hs-cat .seeall, .hs-cat .seeall .sa, .hs-loadmore button {
     transition: none !important;
   }
   .hs-row:hover { padding-left: 14px; padding-right: 14px; }
-  .hs-row:hover .rarrow, .hs-path .steps a:hover .sa { transform: none; }
+  .hs-mr:hover { padding-left: 2px; padding-right: 2px; }
+  .hs-row:hover .rarrow, .hs-path .steps a:hover .sa,
+  .hs-cat .links a:hover .li-arrow, .hs-cat .seeall:hover .sa { transform: none; }
 }
 
 /* ============================================================


### PR DESCRIPTION
Implements the **HJELPESENTER-LISTE-ANATOMI** design (Claude Design handoff): the `/help` front page should **route and preview, not catalog**. At 125 articles a flat index is a wall the reader skims tired; the exhaustive list belongs on the category pages (which already exist).

## What changed
Zone order is now **Søk → Start her → Mest lest → Bla på tema → kappet indeks**. The hero, search, "Start her"/løp and index already existed; this adds the two missing router zones and caps the index:

- **Mest lest** (`hs-mostread`/`hs-mr`) — 5–6 curated `POPULAR_ARTICLES`, numbered, 2-col.
- **Bla på tema** (`hs-browse`/`hs-cat`) — one card per canonical category (`HELP_CATEGORY_META`) with its top 3 articles (curated popRank → recency) + **"Se alle N →"** to `/help/category/<slug>`. New articles grow the category page, not the front page — scales indefinitely.
- **Capped index** (`HelpLibrary`) — renders 12 rows + **"Vis flere (N igjen)"**; the window resets on filter/search/sort. Default sort stays **Mest lest** (not Nyeste); rows keep `prefetch={false}`.

## Design fidelity
- New CSS ported into `advanti-design.css` using the existing tokens, matching the `hs-*` vocabulary already in production, with hover/focus-visible states and the 980px mobile collapse.
- `pnpm build` green. Verified in the prerendered `/help`: 6 category cards, 5 Mest-lest rows, 6 "Se alle →" → `/help/category/`, and the "Vis flere" button (113 remaining).

## Notes
- Reading-path "løp" content is unchanged (already driven by `HELP_PATHS`).
- Per the anatomy's linking model: front page previews, category page lists all, article answers — every card has a path to the full category.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Most Read" section to help page showing popular articles
  * Added "Browse by Topic" section with category cards displaying top articles per category
  * Implemented "Load More" functionality to help articles list with pagination

* **Style**
  * Updated help interface design and styling for new content sections

<!-- end of auto-generated comment: release notes by coderabbit.ai -->