### PR TITLE
fix(seo): site-audit batch — titles, redirect-links, orphans, broken avatar

### DIFF
--- a/content-collections.ts
+++ b/content-collections.ts
@@ -212,6 +212,12 @@ export const HelpPost = defineCollection({
   include: "*.mdx",
   schema: z.object({
     title: z.string(),
+    // Optional SEO <title> override. The authored `title` doubles as the
+    // visible H1 and can be long/descriptive; `seoTitle` (when set) is the
+    // SERP-tuned variant the article page feeds to the <title> tag instead,
+    // so the H1 stays human-readable while the title stays under ~60 chars
+    // (incl. the " – Advanti" suffix). Mirrors BlogPost.seoTitle.
+    seoTitle: z.string().optional(),
     updatedAt: z.string(),
     summary: z.string(),
     author: z.string(),

--- a/src/app/(help)/help/article/[slug]/page.tsx
+++ b/src/app/(help)/help/article/[slug]/page.tsx
@@ -62,10 +62,13 @@ export async function generateMetadata({
     return
   }
 
-  const { title, summary } = post
+  const { title, seoTitle, summary } = post
 
   return constructMetadata({
-    title: `${title} – Advanti Kunnskapsbase`,
+    // `seoTitle` (when authored) is the SERP-tuned <title>; otherwise the
+    // visible H1 title. Suffix kept short (" – Advanti") so titles stay under
+    // Google's ~60-char SERP limit — long descriptive H1s set their own seoTitle.
+    title: `${seoTitle ?? title} – Advanti`,
     description: summary,
     image: `/api/og/help?title=${encodeURIComponent(
       title,

--- a/src/app/verktoy/page.tsx
+++ b/src/app/verktoy/page.tsx
@@ -60,6 +60,30 @@ const GROUPS: Group[] = [
         cta: "Åpne",
       },
       {
+        href: "/verktoy/roi-kalkulator",
+        title: (
+          <>
+            ROI-<span className="italic">kalkulator</span>
+          </>
+        ),
+        description:
+          "Beregn avkastning på investering (ROI) for næringseiendom — total avkastning inkludert leieinntekter og verdiøkning over tid.",
+        badge: "Kalkulator",
+        cta: "Åpne",
+      },
+      {
+        href: "/verktoy/boliglan-kalkulator",
+        title: (
+          <>
+            Låne<span className="italic">kalkulator</span>
+          </>
+        ),
+        description:
+          "Beregn månedlige kostnader, total rentekostnad og nedbetalingsplan for næringslån — og få oversikt over finansieringen av eiendommen.",
+        badge: "Kalkulator",
+        cta: "Åpne",
+      },
+      {
         href: "/verdivurdering",
         title: (
           <>

--- a/src/content/help/avkastningskrav-diskonteringsrente.mdx
+++ b/src/content/help/avkastningskrav-diskonteringsrente.mdx
@@ -201,7 +201,7 @@ Nettopp fordi avkastningskravet er så avgjørende, bør en verdivurdering aldri
   description="Advanti bygger diskonteringsrenten på verifiserte, sammenlignbare transaksjoner i Nord-Norge — ikke gjetning."
   primaryAction={{
     label: "Bestill verdivurdering",
-    href: "/tjenester/verdsettelse"
+    href: "/tjenester/verdivurdering"
   }}
   secondaryAction={{
     label: "Snakk med en rådgiver",

--- a/src/content/help/baerekraftig-naringseiendom.mdx
+++ b/src/content/help/baerekraftig-naringseiendom.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Bærekraftig næringseiendom: verdi, krav og sertifisering"
+seoTitle: "Bærekraftig næringseiendom: krav og verdi"
 updatedAt: 2026-06-15
 summary: "Bærekraft påvirker både leie, finansiering og verdi i næringseiendom. Lær hva som driver den grønne premien, hvilke krav som gjelder og hvordan du sertifiserer."
 author: christer-hagen

--- a/src/content/help/banklan-kredittvurdering.mdx
+++ b/src/content/help/banklan-kredittvurdering.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Slik kredittvurderer banken et lån til næringseiendom"
+seoTitle: "Banklån til næringseiendom: kredittvurdering"
 updatedAt: 2026-06-15
 summary: "Når du søker banklån til næringseiendom, måler banken kontantstrøm, leietakers soliditet, WAULT og sikkerhet — slik vekter den hver del."
 author: christer-hagen

--- a/src/content/help/budgivning-naringseiendom.mdx
+++ b/src/content/help/budgivning-naringseiendom.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Budprosess på næringseiendom — slik foregår budgivning"
+seoTitle: "Budgivning på næringseiendom"
 updatedAt: 2026-06-15
 summary: "Budgivning på næringseiendom følger ikke boligens regler — ingen forbrukervern, ingen budjournal. Slik foregår prosessen fra prospekt til signert avtale."
 author: christer-hagen

--- a/src/content/help/byggetillatelse-byggesak.mdx
+++ b/src/content/help/byggetillatelse-byggesak.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Byggetillatelse og byggesaksprosessen for næringsbygg"
+seoTitle: "Byggetillatelse for næringsbygg"
 updatedAt: 2026-06-15
 summary: "Reguleringsplanen sier hva du kan bygge — byggetillatelsen gir deg lov til å faktisk gjøre det. Slik fungerer byggesaken etter plan- og bygningsloven."
 author: christer-hagen

--- a/src/content/help/csrd-baerekraftsrapportering.mdx
+++ b/src/content/help/csrd-baerekraftsrapportering.mdx
@@ -1,5 +1,6 @@
 ---
 title: "CSRD og bærekraftsrapportering for eiendomsselskaper"
+seoTitle: "CSRD og bærekraftsrapportering i eiendom"
 updatedAt: 2026-06-15
 summary: "CSRD gjør bærekraftsrapportering obligatorisk og standardisert. Slik fungerer kravene for eiendomsselskaper, og hvorfor også mindre eiere berøres gjennom verdikjeden."
 author: christer-hagen

--- a/src/content/help/eiendomsforvaltning-naringseiendom.mdx
+++ b/src/content/help/eiendomsforvaltning-naringseiendom.mdx
@@ -1,5 +1,6 @@
 ---
 title: Eiendomsforvaltning, forretningsførsel og asset management — forskjellen
+seoTitle: "Eiendomsforvaltning vs asset management"
 updatedAt: 2026-06-15
 summary: "Eiendomsforvaltning, forretningsførsel og asset management er tre distinkte tjenester i eie- og driftsfasen. Her er hva hver av dem dekker."
 author: christer-hagen

--- a/src/content/help/energimerking-naringsbygg.mdx
+++ b/src/content/help/energimerking-naringsbygg.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Energimerking av næringsbygg — krav og reglene fra 2026"
+seoTitle: "Energimerking av næringsbygg: krav 2026"
 updatedAt: 2026-06-15
 summary: "Energimerking er lovpålagt ved salg og utleie av næringsbygg, og energiklassen påvirker både leietakere, banker og verdi. Slik fungerer ordningen — og hva som endres."
 author: christer-hagen

--- a/src/content/help/eu-taksonomi-eiendom.mdx
+++ b/src/content/help/eu-taksonomi-eiendom.mdx
@@ -187,7 +187,7 @@ Du trenger ikke å være rapporteringspliktig selv for å bli berørt — kraven
   }}
   secondaryAction={{
     label: "Se verdsettelse",
-    href: "/tjenester/verdsettelse"
+    href: "/tjenester/verdivurdering"
   }}
   size="default"
 />

--- a/src/content/help/felleskostnader-vs-driftskostnader.mdx
+++ b/src/content/help/felleskostnader-vs-driftskostnader.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Felleskostnader vs driftskostnader: hva er forskjellen?"
+seoTitle: "Felleskostnader vs driftskostnader"
 updatedAt: 2026-06-15
 summary: "Driftskostnader er totalkostnaden ved å drive bygget, mens felleskostnader er den delen som viderefaktureres leietakerne. Slik henger de sammen."
 author: christer-hagen
@@ -180,7 +181,7 @@ For en investor som leser et regnskap er derfor det viktigste spørsmålet ikke 
   }}
   secondaryAction={{
     label: "Se verdivurdering",
-    href: "/tjenester/verdsettelse"
+    href: "/tjenester/verdivurdering"
   }}
   size="default"
 />

--- a/src/content/help/forsikring-naringseiendom.mdx
+++ b/src/content/help/forsikring-naringseiendom.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Forsikring av næringseiendom — bygning, avbrudd og ansvar"
+seoTitle: "Forsikring av næringseiendom"
 updatedAt: 2026-06-15
 summary: "Forsikring av næringseiendom dekker bygning, tap av leieinntekt og ansvar. Se hvilke poster som inngår og hvordan premien påvirker NOI og verdi."
 author: christer-hagen

--- a/src/content/help/fritaksmetoden-eiendom.mdx
+++ b/src/content/help/fritaksmetoden-eiendom.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Fritaksmetoden forklart — derfor selges eiendom som aksjer"
+seoTitle: "Fritaksmetoden ved eiendomssalg forklart"
 publishedAt: 2026-06-15
 updatedAt: 2026-06-15
 summary: "Fritaksmetoden gjør at et selskap selger aksjer skattefritt. Sammen med dokumentavgiften er dette hovedgrunnen til at norsk næringseiendom handles som aksjer."

--- a/src/content/help/gronn-leieavtale.mdx
+++ b/src/content/help/gronn-leieavtale.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Grønn leieavtale — innhold og hvorfor det lønner seg"
+seoTitle: "Grønn leieavtale: innhold og gevinst"
 updatedAt: 2026-06-15
 summary: "En grønn leieavtale er en næringsleiekontrakt med klausuler om energibruk, datadeling og samarbeid om bærekraft — og den løser det klassiske insentivproblemet mellom utleier og leietaker."
 author: christer-hagen

--- a/src/content/help/hva-er-wault.mdx
+++ b/src/content/help/hva-er-wault.mdx
@@ -195,7 +195,7 @@ For å vurdere en eiendom riktig bør du derfor kombinere WAULT med en gjennomga
   description="Advanti analyserer leietidsprofil, WAULT og kontraktsrisiko som del av en helhetlig verdivurdering av næringseiendom."
   primaryAction={{
     label: "Få en verdivurdering",
-    href: "/tjenester/verdsettelse"
+    href: "/tjenester/verdivurdering"
   }}
   secondaryAction={{
     label: "Kontakt oss",

--- a/src/content/help/kjope-naringseiendom.mdx
+++ b/src/content/help/kjope-naringseiendom.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Hvordan kjøpe næringseiendom: prosessen steg for steg"
+seoTitle: "Kjøpe næringseiendom: prosessen"
 publishedAt: 2026-06-12
 updatedAt: 2026-06-15
 summary: "Kjøp av næringseiendom følger en definert prosess fra strategi til overtakelse. Her er fasene, aktørene og de vanligste feilene du bør unngå."

--- a/src/content/help/latent-skatt-skatterabatt.mdx
+++ b/src/content/help/latent-skatt-skatterabatt.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Latent skatt og skatterabatt ved kjøp av eiendoms-AS"
+seoTitle: "Latent skatt og skatterabatt ved AS-kjøp"
 updatedAt: 2026-06-15
 summary: "Når du kjøper et eiendoms-AS, overtar du selskapets latente skatt. Skatterabatten er prisavslaget som kompenserer for dette — og et sentralt forhandlingspunkt."
 author: christer-hagen

--- a/src/content/help/leieinsentiver-effektiv-leie.mdx
+++ b/src/content/help/leieinsentiver-effektiv-leie.mdx
@@ -1,5 +1,6 @@
 ---
 title: Leiefritak og insentiver — slik påvirker de effektiv leie
+seoTitle: "Leieinsentiver og effektiv leie"
 updatedAt: 2026-06-15
 summary: "Leieinsentiver som leiefritak og tilpasningsbidrag senker den effektive leien under den nominelle. Lær å regne ut effektiv leie og hvorfor den styrer verdien."
 author: christer-hagen

--- a/src/content/help/leietakertilpasning.mdx
+++ b/src/content/help/leietakertilpasning.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Leietakertilpasning og MVA: hvem eier, hvem betaler"
+seoTitle: "Leietakertilpasning og MVA-håndtering"
 updatedAt: 2026-06-15
 summary: "Leietakertilpasning kobler leie og avgift: hvem eier tilpasningen, hvem betaler, og når kan utleier trekke fra inngående MVA på arbeidet?"
 author: christer-hagen

--- a/src/content/help/mva-pa-naringseiendom.mdx
+++ b/src/content/help/mva-pa-naringseiendom.mdx
@@ -1,5 +1,6 @@
 ---
 title: "MVA på næringseiendom: registrering, fradrag og justering"
+seoTitle: "MVA på næringseiendom: regler og fradrag"
 updatedAt: 2026-06-15
 summary: "Utleie av næringseiendom er som hovedregel unntatt MVA, men frivillig registrering gir fradragsrett. Lær mekanismen for registrering, fradrag og justering."
 author: christer-hagen

--- a/src/content/help/reforhandling-leiekontrakt.mdx
+++ b/src/content/help/reforhandling-leiekontrakt.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Reforhandling, opsjoner og fornyelse av leiekontrakt"
+seoTitle: "Reforhandling og fornyelse av leiekontrakt"
 updatedAt: 2026-06-15
 summary: "Når en næringsleiekontrakt nærmer seg utløp, avgjøres mye av verdien: reforhandling, opsjoner og fornyelse styrer leienivå, ledighetsrisiko og kontantstrøm."
 author: christer-hagen

--- a/src/content/help/rentesikring-naringseiendom.mdx
+++ b/src/content/help/rentesikring-naringseiendom.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Rentesikring av lån — fastrente, renteswap og rentetak"
+seoTitle: "Rentesikring: fastrente, swap og rentetak"
 updatedAt: 2026-06-15
 summary: "Renten er den største enkeltkostnaden for en belånt investor. Slik virker fastrente, renteswap og rentetak — og når passer hvilket verktøy."
 author: christer-hagen

--- a/src/content/help/selge-naringseiendom.mdx
+++ b/src/content/help/selge-naringseiendom.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Hvordan selge næringseiendom: salgsprosessen steg for steg"
+seoTitle: "Selge næringseiendom: salgsprosessen"
 publishedAt: 2026-06-15
 updatedAt: 2026-06-15
 summary: "Salg av næringseiendom følger en definert prosess fra forberedelse og prising til markedsføring, forhandling og oppgjør. Her er fasene som gir best pris."

--- a/src/content/help/tomtefeste-naringseiendom.mdx
+++ b/src/content/help/tomtefeste-naringseiendom.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Tomtefeste av næringstomt — festeavgift og innløsning"
+seoTitle: "Tomtefeste: festeavgift og innløsning"
 updatedAt: 2026-06-15
 summary: "Tomtefeste betyr at du eier bygget men leier grunnen mot festeavgift. Slik påvirker festeforholdet verdien, og slik fungerer innløsning av næringstomt."
 author: christer-hagen

--- a/src/content/help/trenger-jeg-naringsmegler.mdx
+++ b/src/content/help/trenger-jeg-naringsmegler.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Trenger du næringsmegler, eller kan du gjøre det selv?"
+seoTitle: "Trenger du næringsmegler?"
 updatedAt: 2026-06-15
 summary: "En næringsmegler koster honorar, men gir markedstilgang, prising og prosessledelse. Her er når det lønner seg å bruke megler — og når egen regi kan forsvares."
 author: christer-hagen

--- a/src/content/help/verdivurdering-naringseiendom-prosess.mdx
+++ b/src/content/help/verdivurdering-naringseiendom-prosess.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Slik gjennomfører Advanti en verdivurdering — steg for steg"
+seoTitle: "Slik gjennomføres en verdivurdering"
 updatedAt: 2026-06-15
 summary: "En verdivurdering hos Advanti følger en fast prosess fra befaring til ferdig rapport, der hver forutsetning forankres i dokumentert underlag fra eiendommen."
 author: christer-hagen

--- a/src/lib/listing/listings.ts
+++ b/src/lib/listing/listings.ts
@@ -131,6 +131,30 @@ function nok(value: number | null | undefined): number | undefined {
   return value === null || value === undefined ? undefined : value / 1_000_000
 }
 
+// Canonical broker portraits (Supabase `press` bucket) keyed by display name.
+// Mirrors the avatars in help-data.ts / the people collection.
+const PRESS_BUCKET =
+  "https://kukzjreikqbgbolxvqaj.supabase.co/storage/v1/object/public/press"
+const MEGLER_AVATAR_BY_NAME: Record<string, string> = {
+  "Christer Hagen": `${PRESS_BUCKET}/christer-hagen-web.jpg`,
+  "Mathias Nilssen": `${PRESS_BUCKET}/mathias-nilssen-web.jpg`,
+  "Håvard Nome": `${PRESS_BUCKET}/havard-nome-web.jpg`,
+}
+
+/**
+ * Guard against a megler avatar that isn't an absolute URL — a legacy CRM value
+ * like "/havard.jpg" points at a non-existent /public asset and makes
+ * next/image return 400 (a "broken image" SEO issue). When the avatar isn't an
+ * http(s) URL, fall back to the canonical press portrait by name. This survives
+ * a future CRM re-publish that would otherwise reintroduce the bad path.
+ */
+function normalizeMegler<T extends ListingMegler | undefined>(megler: T): T {
+  if (!megler) return megler
+  if (/^https?:\/\//i.test(megler.avatar)) return megler
+  const canonical = MEGLER_AVATAR_BY_NAME[megler.name]
+  return canonical ? { ...megler, avatar: canonical } : megler
+}
+
 type MdxListing = ReturnType<typeof getActiveListings>[number]
 
 function mapMdxToListing(post: MdxListing): Listing {
@@ -167,7 +191,7 @@ function mapMdxToListing(post: MdxListing): Listing {
     gallery: post.gallery,
     summary: post.summary,
     lede: post.lede,
-    megler: post.megler,
+    megler: normalizeMegler(post.megler),
     facts: post.facts,
     tenants: post.tenants,
     tenantsNote: post.tenantsNote,
@@ -337,7 +361,7 @@ export function mapProfileToListing(row: ProfileRow): Listing {
     photoCount: row.photo_count ?? undefined,
     summary: row.summary ?? "",
     lede: row.lede ?? undefined,
-    megler: row.megler ?? undefined,
+    megler: normalizeMegler(row.megler ?? undefined),
     facts: row.facts ?? undefined,
     tenantsNote: row.tenants_note ?? undefined,
     financials,


### PR DESCRIPTION
Fixes the actionable issues from the 2026-06-16 Ahrefs site audit (deltas vs the 06-13 crawl).

## 1. Title too long — was +43
Help articles emitted `<title>` = `{title} – Advanti Kunnskapsbase` (24-char suffix, inconsistent with the rest of the site). Shortened the suffix to ` – Advanti` and added an optional `seoTitle` frontmatter field on `HelpPost` (mirrors `BlogPost.seoTitle`) for the **22** articles whose descriptive H1 alone exceeds the limit — H1 stays human-readable, `<title>` is SERP-tuned. **All 127 built help titles ≤54 chars** (worst case 82 → 49).

## 2. Page has links to redirect — was +4
4 articles linked `/tjenester/verdsettelse` (301 → `/tjenester/verdivurdering`). Repointed to canonical.

## 3. Orphan pages — was +2
`/verktoy/roi-kalkulator` and `/verktoy/boliglan-kalkulator` were in the sitemap but had 0 internal inlinks — the `/verktoy` hub didn't list them. Added both to the hub (3 inlinks each now).

## 4. Broken image — 4 Alta listings
`next/image` returned 400 for Håvard's avatar: the CRM-published `megler.avatar` was the legacy relative path `/havard.jpg` (no `/public` asset) on 4 Alta listings. 
- **Data:** corrected the 4 `crm_property_listing_profiles` rows to the canonical press-bucket URL (live via ISR).
- **Code:** added `normalizeMegler()` — any non-`http` avatar falls back to the canonical press portrait by name, so a future CRM re-publish can't reintroduce the broken path.

## Verification
- `pnpm build` green (TS errors fail the build).
- 0 of 127 built help titles >60 chars; H1 decoupling confirmed.
- `/verktoy` HTML now links both calculators.

## Not addressed (infra, not source bugs)
- **Slow page (3):** `/verdivurdering` renders dynamically (likely intentional — lead form); the 2 static pages (~1.1s TTFB) are cold-start artifacts that clear on re-crawl. No source fix warranted without product context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)