### PR TITLE
fix(people): remove unverified certifications, keep only MNEF

### DIFF
--- a/src/content/people/christer-hagen.mdx
+++ b/src/content/people/christer-hagen.mdx
@@ -14,7 +14,6 @@ education:
     year: 2016
 certifications:
   - MNEF (Medlemskap i Norges Eiendomsmeglerforbund)
-  - Sertifisert Verdsetter - DCF Analyse
 specializations:
   - Salg av næringseiendom
   - Komplekse verdivurderinger

--- a/src/content/people/daniel-adamsen.mdx
+++ b/src/content/people/daniel-adamsen.mdx
@@ -11,7 +11,6 @@ education:
     year: 2006
 certifications:
   - MNEF (Medlemskap i Norges Eiendomsmeglerforbund)
-  - Statsautorisert Næringsmegler
 specializations:
   - Eiendomsfinansiering
   - Investeringsanalyse

--- a/src/content/people/ole-ostensen.mdx
+++ b/src/content/people/ole-ostensen.mdx
@@ -17,9 +17,6 @@ education:
     year: 2004
 certifications:
   - MNEF (Medlemskap i Norges Eiendomsmeglerforbund)
-  - Statsautorisert Næringsmegler
-  - Sertifisert Verdsetter (MRICS)
-  - Godkjent Voldgiftsdommer
 specializations:
   - Eiendomsverdivurdering
   - Juridisk eiendomsrådgivning

--- a/src/content/people/tobias-bronder.mdx
+++ b/src/content/people/tobias-bronder.mdx
@@ -14,8 +14,6 @@ education:
     year: 2014
 certifications:
   - MNEF (Medlemskap i Norges Eiendomsmeglerforbund)
-  - Statsautorisert Næringsmegler
-  - Google Analytics Sertifisering
 specializations:
   - Digital markedsføring av eiendom
   - Transaksjonsledelse


### PR DESCRIPTION
## What
Removes professional certifications that the team does not actually hold from four partner profiles, keeping only **MNEF** (which is real for Christer, Daniel, Ole and Tobias).

Removed:
- **christer-hagen** — Sertifisert Verdsetter - DCF Analyse
- **daniel-adamsen** — Statsautorisert Næringsmegler
- **ole-ostensen** — Statsautorisert Næringsmegler, Sertifisert Verdsetter (MRICS), Godkjent Voldgiftsdommer
- **tobias-bronder** — Statsautorisert Næringsmegler, Google Analytics Sertifisering

Unchanged: Håvard Nome (RERA Lisens — confirmed real), Mathias Nilssen (no certs).

## Why
These titles were published live on `/personer/[slug]` (sidebar, `page.tsx:275-285`). Claiming professional-body membership / accreditations the holder doesn't have is exposure under markedsføringsloven and NEF rules. Grep confirms no other surface (presserom bylines, JSON-LD, blog author bios) referenced the removed titles.

Surfaced during a `/plan-eng-review` of a broader site-leverage batch; flagged as P1 and fixed first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated team member certifications across multiple profiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->