### PR TITLE
Front Tromsø/Bodø/Alta i analyseportalens yield-inngang

### DIFF
--- a/src/components/analyseportal/AnalyseportalShell.tsx
+++ b/src/components/analyseportal/AnalyseportalShell.tsx
@@ -348,13 +348,15 @@ export function AnalyseportalShell({ analyst }: { analyst: AnalystCard | null })
               </div>
               <h2>{view.focusTitle}</h2>
             </div>
-            <div className="ap-focus-r">
-              <div className="ap-focus-val">
-                {view.focusValue}
-                <span className="u">{view.focusUnit}</span>
+            {view.focusAside ?? (
+              <div className="ap-focus-r">
+                <div className="ap-focus-val">
+                  {view.focusValue}
+                  <span className="u">{view.focusUnit}</span>
+                </div>
+                <div className="ap-focus-delta">{view.focusDelta}</div>
               </div>
-              <div className="ap-focus-delta">{view.focusDelta}</div>
-            </div>
+            )}
           </div>
 
           {/* chart card */}

--- a/src/components/analyseportal/sectorViews.tsx
+++ b/src/components/analyseportal/sectorViews.tsx
@@ -104,6 +104,9 @@ export interface ViewSpec {
   focusValue: string
   focusUnit: string
   focusDelta: ReactNode
+  /** Optional richer focus block (e.g. a multi-city strip) that replaces the
+   *  default single big-number focus-r when present. */
+  focusAside?: ReactNode
   chartTitle: string
   legend: ReactNode
   chart: ReactNode
@@ -247,8 +250,25 @@ function viewYield(s: ViewState): ViewSpec {
   )
 
   const spreadBps = Math.round(spread * 100)
+
+  // Entry view (kontor) leads with the three headline markets — Tromsø, Bodø
+  // and Alta — so a Bodø/Alta investor sees their own market up top, not just
+  // Tromsø. Per-city yield exists only as the published kontor snapshot
+  // (CITY_META), so the strip is kontor-only; other segments keep the single
+  // big-number focus rather than inventing per-segment city series.
+  const isKontor = seg === "kontor"
+  const HEADLINE_CITIES: { city: PortalCity; note: string }[] = [
+    { city: "Tromsø", note: "Størst i nord" },
+    { city: "Bodø", note: "Vårt hjemmemarked" },
+    { city: "Alta", note: "Inngang Finnmark" },
+  ]
+
   return {
-    focusTitle: (
+    focusTitle: isKontor ? (
+      <>
+        Prime yield kontor, <span className="it">by for by.</span>
+      </>
+    ) : (
       <>
         Prime yield {segLabel(seg).toLowerCase()},{" "}
         <span className="it">Tromsø sentrum.</span>
@@ -261,6 +281,33 @@ function viewYield(s: ViewState): ViewSpec {
         <Delta n={d12} unit=" bps" /> siste 12 mnd · spread {fmtPct2p(spread)} mot SWAP
       </>
     ),
+    focusAside: isKontor ? (
+      <div className="ap-focus-aside">
+        <div className="ap-focus-cities">
+          {HEADLINE_CITIES.map(({ city, note }) => {
+            const cm = CITY_META.find((m) => m.name === city)
+            if (!cm) return null
+            return (
+              <div className="ap-focus-city" key={city}>
+                <div className="cy">
+                  <span className="dot" style={{ background: CITY_COLOR[city] }} />
+                  {city}
+                </div>
+                <div className="vl">
+                  {fmtComma(cm.yieldPct, 2)}
+                  <span className="u">%</span>
+                </div>
+                <div className="nt">{note}</div>
+              </div>
+            )
+          })}
+        </div>
+        <div className="ap-focus-cities-foot">
+          Prime kontor · {PORTAL_LATEST.quarter} · spread {fmtPct2p(spread)} mot
+          5-års SWAP
+        </div>
+      </div>
+    ) : undefined,
     chartTitle: "Yield mot rentemarkedet — kvartalsvis",
     legend: <PortalLegend items={series} hidden={s.hidden} onToggle={s.onToggleHidden} />,
     chart: (

--- a/src/styles/advanti-design.css
+++ b/src/styles/advanti-design.css
@@ -9568,19 +9568,22 @@ h1, h2, h3 {
 .ap-focus-val .u { font-size: 0.35em; font-style: italic; color: var(--warm-grey-85); margin-left: 4px; }
 .ap-focus-delta { font-size: 13px; color: var(--warm-grey-85); margin-top: 12px; }
 
-/* Multi-city focus strip (yield entry view): Tromsø · Bodø · Alta side by side. */
-.ap-focus-aside { text-align: right; }
-.ap-focus-cities { display: flex; justify-content: flex-end; gap: 32px; }
+/* Multi-city focus band (yield entry view): a deliberate full-width stat row —
+   Tromsø · Bodø · Alta — under the heading, hairline-separated. Always wraps to
+   its own row (width:100%) rather than crowding the heading on the right, so the
+   three markets read as one intentional band at every desktop column width. */
+.ap-focus-aside { width: 100%; margin-top: 10px; padding-top: 22px; border-top: var(--hairline); text-align: left; }
+.ap-focus-cities { display: flex; flex-wrap: wrap; justify-content: flex-start; gap: clamp(28px, 6vw, 72px); }
 .ap-focus-city { text-align: left; }
 .ap-focus-city .cy { display: flex; align-items: center; gap: 7px; font-size: 11px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--warm-grey-85); font-weight: 500; margin-bottom: 8px; }
 .ap-focus-city .cy .dot { width: 8px; height: 8px; border-radius: 50%; flex: none; }
-.ap-focus-city .vl { font-family: var(--font-display); font-size: clamp(28px, 3.4vw, 40px); font-weight: 400; letter-spacing: -0.03em; line-height: 0.95; font-variant-numeric: tabular-nums; }
+.ap-focus-city .vl { font-family: var(--font-display); font-size: clamp(30px, 3.4vw, 42px); font-weight: 400; letter-spacing: -0.03em; line-height: 0.95; font-variant-numeric: tabular-nums; }
 .ap-focus-city .vl .u { font-size: 0.38em; font-style: italic; color: var(--warm-grey-85); margin-left: 3px; }
 .ap-focus-city .nt { font-size: 12px; color: var(--warm-grey-85); margin-top: 8px; }
-.ap-focus-cities-foot { font-size: 13px; color: var(--warm-grey-85); margin-top: 16px; }
+.ap-focus-cities-foot { font-size: 13px; color: var(--warm-grey-85); margin-top: 18px; }
 @media (max-width: 640px) {
-  .ap-focus-cities { gap: 20px; }
-  .ap-focus-city .vl { font-size: 26px; }
+  .ap-focus-cities { gap: 24px; }
+  .ap-focus-city .vl { font-size: 28px; }
 }
 
 .ap-delta { font-weight: 600; font-variant-numeric: tabular-nums; white-space: nowrap; }

--- a/src/styles/advanti-design.css
+++ b/src/styles/advanti-design.css
@@ -9568,6 +9568,21 @@ h1, h2, h3 {
 .ap-focus-val .u { font-size: 0.35em; font-style: italic; color: var(--warm-grey-85); margin-left: 4px; }
 .ap-focus-delta { font-size: 13px; color: var(--warm-grey-85); margin-top: 12px; }
 
+/* Multi-city focus strip (yield entry view): Tromsø · Bodø · Alta side by side. */
+.ap-focus-aside { text-align: right; }
+.ap-focus-cities { display: flex; justify-content: flex-end; gap: 32px; }
+.ap-focus-city { text-align: left; }
+.ap-focus-city .cy { display: flex; align-items: center; gap: 7px; font-size: 11px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--warm-grey-85); font-weight: 500; margin-bottom: 8px; }
+.ap-focus-city .cy .dot { width: 8px; height: 8px; border-radius: 50%; flex: none; }
+.ap-focus-city .vl { font-family: var(--font-display); font-size: clamp(28px, 3.4vw, 40px); font-weight: 400; letter-spacing: -0.03em; line-height: 0.95; font-variant-numeric: tabular-nums; }
+.ap-focus-city .vl .u { font-size: 0.38em; font-style: italic; color: var(--warm-grey-85); margin-left: 3px; }
+.ap-focus-city .nt { font-size: 12px; color: var(--warm-grey-85); margin-top: 8px; }
+.ap-focus-cities-foot { font-size: 13px; color: var(--warm-grey-85); margin-top: 16px; }
+@media (max-width: 640px) {
+  .ap-focus-cities { gap: 20px; }
+  .ap-focus-city .vl { font-size: 26px; }
+}
+
 .ap-delta { font-weight: 600; font-variant-numeric: tabular-nums; white-space: nowrap; }
 .ap-delta.up { color: var(--delta-up); }
 .ap-delta.down { color: var(--delta-down); }


### PR DESCRIPTION
## Hva
Inngangsvisningen på `/analyseportal` (Yield & renter → Kontor) ledet med kun «Prime yield kontor, *Tromsø sentrum.*». En investor/eier i Bodø eller Alta så ikke sitt eget marked øverst. Nå viser fokus-feltet et **tre-by-band — Tromsø, Bodø, Alta** — med publiserte Q4 2025-snapshots (6,10 / 6,35 / 6,75 %), så flere markeder fanger besøkende ved inngang.

## Detaljer
- `viewYield` leder med en hårlinje-separert tre-by-band på kontor; faller tilbake til enkelttall på Handel/Logistikk/Hotell (ingen syntetiske per-segment-byserier).
- Tall fra `CITY_META` (publisert release), fargeprikker fra `CITY_COLOR`.
- Data-ærlig: Bodø/Alta har ekte publiserte yield-tall; Altas «estimert»-flagg gjelder kun den historiske *leie*-kurven.

## Design review
Kjørt `/design-review` mot live rendering. Fant og fikset FINDING-001: stripen brøt ned som utilsiktet reflow ved reell kolonnebredde → promotert til bevisst fullbredde stat-band. Verifisert desktop 1440, mobil 390, og fallback på andre segmenter. Ingen konsollfeil.

🤖 Generated with [Claude Code](https://claude.com/claude-code)