### PR TITLE
fix(nav): forgiving hover-intent + visible active underline

### DIFF
--- a/src/components/site/Nav.tsx
+++ b/src/components/site/Nav.tsx
@@ -199,7 +199,7 @@ export function Nav({ groups }: NavProps) {
     closeTimer.current = window.setTimeout(() => {
       hoverOpened.current = null;
       setOpenGroup(null);
-    }, 140);
+    }, 240);
   };
   const openByHover = (id: GroupId) => {
     if (!canHover.current) return;
@@ -392,10 +392,17 @@ export function Nav({ groups }: NavProps) {
     [],
   );
 
+  // Hover-intent (E1A): the LEAVE handler lives on the links row / panel shell,
+  // not on each trigger — so sweeping the cursor across the 30px gaps between
+  // triggers never schedules a close. Entering a trigger just switches which
+  // group is open; only leaving the whole row (or the panel) starts the timer.
   const hoverProps = (id: GroupId) => ({
     onMouseEnter: () => openByHover(id),
-    onMouseLeave: scheduleClose,
   });
+  const linksRowHoverProps = {
+    onMouseEnter: cancelClose,
+    onMouseLeave: scheduleClose,
+  };
   const panelHoverProps = {
     onMouseEnter: cancelClose,
     onMouseLeave: scheduleClose,
@@ -550,7 +557,7 @@ export function Nav({ groups }: NavProps) {
           <span className="sub">Estate</span>
         </Link>
 
-        <div className="nav-links">
+        <div className="nav-links" {...linksRowHoverProps}>
           <button
             type="button"
             className="nav-group-btn"

--- a/src/styles/advanti-design.css
+++ b/src/styles/advanti-design.css
@@ -252,7 +252,10 @@ h1, h2, h3 {
   font-size: 13px;
   font-weight: 500;
   letter-spacing: -0.005em;
-  transition: all 0.2s ease;
+  /* Explicit properties (not `all`): background snaps on hover; colour + border
+     follow the nav's transparent→solid colour change at the same 0.35s. */
+  transition: background-color 0.2s ease, color 0.35s ease,
+    border-color 0.35s ease;
   white-space: nowrap;
   flex-shrink: 0;
 }
@@ -348,10 +351,20 @@ h1, h2, h3 {
   cursor: pointer;
 }
 .nav-group-btn::after {
-  content: " ▾";
+  content: "▾";
+  display: inline-block;
+  margin-left: 4px;
   font-size: 10px;
   opacity: 0.65;
   vertical-align: middle;
+  transition: transform 200ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+/* Flip the chevron while the group is open — a clear open/close affordance. */
+.nav-group-btn[aria-expanded="true"]::after {
+  transform: rotate(180deg);
+}
+@media (prefers-reduced-motion: reduce) {
+  .nav-group-btn::after { transition: none; }
 }
 /* Hover kun på ekte pekere — touch får ingen sticky hover-tilstand (Emil). */
 @media (hover: hover) {
@@ -372,11 +385,19 @@ h1, h2, h3 {
   outline-offset: 2px;
 }
 
-/* Active-trail: accent underline replaces the old inline fontWeight (E6). */
+/* Active-trail: underline replaces the old inline fontWeight (E6). Uses
+   currentColor so it stays visible in BOTH nav states — dark (warm-grey) on the
+   solid white bar, light (warm-white) over the dark hero. The old pale --accent
+   underline was invisible on the light surface. */
 .nav-links a[aria-current="page"],
 .nav-group-btn[data-active="true"] {
-  border-bottom: 1.5px solid var(--accent);
+  border-bottom: 2px solid currentColor;
   padding-bottom: 2px;
+}
+/* Open trigger already shows the accent pill — drop the underline so it doesn't
+   read as a stray line under the rounded pill. */
+.nav-group-btn[data-active="true"][aria-expanded="true"] {
+  border-bottom-color: transparent;
 }
 
 /* Open trigger gets a soft pill (reference look). Negative margin cancels the
@@ -419,6 +440,17 @@ h1, h2, h3 {
     opacity 160ms ease-out,
     transform 220ms cubic-bezier(0.22, 1, 0.36, 1),
     visibility 0s linear 240ms;
+}
+/* Hover bridge: a transparent strip spanning the 6px gap between the bar and
+   the card, so moving the cursor from a trigger down into the panel never
+   crosses dead space (which would start the close timer). */
+.nav-panel-shell::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: -10px;
+  height: 10px;
 }
 .nav-panel-shell.open {
   transform: translateX(-50%) translateY(0);


### PR DESCRIPTION
## Hva

Fikser to ting brukeren meldte på navbaren, pluss litt emil-design-engineering-polish.

### 1. Panelet lukket seg før neste meny (sveip høyre→venstre)
- Flyttet lukke-timeren fra hver enkelt trigger til hele `.nav-links`-raden, så sveiping over mellomrommene (30px) mellom triggerne ikke lenger starter en lukking midtveis.
- Økte hover-intent-forsinkelsen `140ms → 240ms`.
- La til en gjennomsiktig hover-bro over det 6px døde mellomrommet mellom baren og panelkortet.

### 2. Aktiv-understrek usynlig på hvit bakgrunn
- Var `border-bottom: 1.5px solid var(--accent)` (`#cbeef2`, blek cyan – usynlig på den hvite solid-baren). Nå `2px solid currentColor` → mørk på hvit bar, lys over mørk hero. Synlig i begge nav-tilstander, ingen layout-shift.
- Skjuler understreken når gruppen er åpen (pillen signaliserer allerede tilstanden).

### Polish (emil-design-engineering)
- Byttet `transition: all` på `.nav-cta` med eksplisitte properties.
- Chevron roterer 180° når gruppen er åpen (med `prefers-reduced-motion`-guard).

## Test
- `pnpm lint` grønn.
- Lys-tema, eksisterende tokens, ingen nye farger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)