### PR TITLE
fix(rates): rett 10-års statsobligasjon til Norges Bank-nivå

### DIFF
--- a/src/components/markedsinnsikt/marketData.ts
+++ b/src/components/markedsinnsikt/marketData.ts
@@ -20,7 +20,9 @@ export const QUARTERS = [
 
 export const RATES = {
   swap5y: [1.2, 1.45, 1.65, 1.95, 2.3, 2.85, 3.4, 3.85, 4.1, 4.25, 4.3, 4.35, 4.2, 4.05, 3.95, 3.9, 3.85, 3.8, 3.85, 3.82],
-  gov10y: [0.95, 1.2, 1.4, 1.65, 1.95, 2.4, 2.95, 3.3, 3.55, 3.65, 3.7, 3.75, 3.6, 3.5, 3.4, 3.45, 3.45, 3.5, 3.55, 3.55],
+  // 10-års statsobligasjon — kalibrert mot Norges Bank GOVT_GENERIC_RATES
+  // (2025-snitt 3,99 %; Q4 2025-endepunkt forankret der). Var tidligere ~0,4 pp lavt.
+  gov10y: [0.95, 1.2, 1.4, 1.65, 1.95, 2.4, 2.95, 3.3, 3.55, 3.65, 3.7, 3.75, 3.85, 3.75, 3.65, 3.7, 3.8, 3.9, 3.95, 3.99],
 }
 
 export type Segment = "kontor" | "handel" | "logistikk"

--- a/src/components/markedsinnsikt/portalSeries.ts
+++ b/src/components/markedsinnsikt/portalSeries.ts
@@ -141,7 +141,7 @@ export const PORTAL_RATES = {
 }
 export const PORTAL_RATES_F = {
   swap5y: [3.75, 3.65, 3.55, 3.5],
-  gov10y: [3.5, 3.45, 3.4, 3.4],
+  gov10y: [3.9, 3.85, 3.8, 3.8],
   styringsrente: [3.75, 3.5, 3.25, 3.0],
 }
 


### PR DESCRIPTION
Valideringen mot Norges Bank GOVT_GENERIC_RATES viste at portalens 10-års statsobligasjon (3,55 %) lå ~0,4 pp under faktisk nivå (2025-snitt 3,985 %).

- `RATES.gov10y` Q4 2025-endepunkt 3,55 → **3,99**, recent tail løftet jevnt (ingen kink).
- `PORTAL_RATES_F.gov10y` prognose-tail justert (3,5→3,9 start, faller mot 3,8).
- Vises på /markedsinnsikt ("10 år stat"). 5Y SWAP (3,82) og styringsrente (4,0) er korrekte for Q4 2025 og uendret.

Note: Norges Bank-rentene ligger allerede i Supabase `crm_market_rate_curve` (auto-fôret); portal-kobling utsatt per avtale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated 10-year government bond rate data with recalibrated forecast values.

* **Documentation**
  * Added documentation for market rate calibration methodology and baseline adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->