### PR TITLE
content: leie-tall-konsistens i 14 artikler (etter prime-re-ankring)

### DIFF
--- a/src/content/blog/investere-kontorlokaler-nord-norge.mdx
+++ b/src/content/blog/investere-kontorlokaler-nord-norge.mdx
@@ -47,9 +47,9 @@ Kontormarkedet i Nord-Norge er preget av stabil etterspørsel fra offentlig sekt
 <Summary
   title="Leienivåer · kr/m²/år"
   points={[
-    { title: "Sentralt Bodø/Tromsø", description: "Moderne kontorbygg 1 800–2 400, standard 1 400–1 800, eldre bygg 1 000–1 400." },
+    { title: "Sentralt Bodø/Tromsø", description: "Moderne kontorbygg 2 000–3 000, standard 1 500–2 000, eldre bygg 1 100–1 500." },
     { title: "Perifert", description: "Standard kontor 1 000–1 400, eldre kontor 800–1 200." },
-    { title: "Universitetsområder", description: "Moderne kontor 1 800–2 400, standard kontor 1 400–1 800." },
+    { title: "Universitetsområder", description: "Moderne kontor 2 000–3 000, standard kontor 1 500–2 000." },
   ]}
 />
 

--- a/src/content/blog/investere-naringseiendom-tromso.mdx
+++ b/src/content/blog/investere-naringseiendom-tromso.mdx
@@ -52,7 +52,7 @@ Kontormarkedet i Tromsø er preget av sterk etterspørsel fra universitet, sykeh
     { title: "Sentralt, moderne kontor", description: "1 900–2 500 kr/m²/år — det høyeste sjiktet i byen." },
     { title: "Standard kontor, sentrum", description: "1 500–1 900 kr/m²/år." },
     { title: "Perifert kontor", description: "1 100–1 500 kr/m²/år." },
-    { title: "Universitetsområdet", description: "1 800–2 400 kr/m²/år." },
+    { title: "Universitetsområdet", description: "2 000–3 000 kr/m²/år." },
   ]}
 />
 

--- a/src/content/blog/naringseiendomsmarkedet-bodo-2025.mdx
+++ b/src/content/blog/naringseiendomsmarkedet-bodo-2025.mdx
@@ -50,8 +50,8 @@ Kontormarkedet i Bodø er preget av stabil etterspørsel fra offentlig og privat
 <Summary
   title="Leiepriser kontor · 2025 (kr/m²/år)"
   points={[
-    { title: "Sentralt, moderne kontor", description: "1 800–2 400 kr/m²/år." },
-    { title: "Standard kontor, sentrum", description: "1 400–1 800 kr/m²/år." },
+    { title: "Sentralt, moderne kontor", description: "1 800–3 000 kr/m²/år." },
+    { title: "Standard kontor, sentrum", description: "1 400–2 000 kr/m²/år." },
     { title: "Perifert kontor", description: "1 000–1 400 kr/m²/år." },
     { title: "Coworking / fleksible løsninger", description: "2 000–3 000 kr/m²/år." },
   ]}

--- a/src/content/help/hva-koster-verdivurdering-naringseiendom.mdx
+++ b/src/content/help/hva-koster-verdivurdering-naringseiendom.mdx
@@ -105,7 +105,7 @@ En del av jobben er å forankre anslaget i faktiske markedsforhold. Avkastningsk
   ]}
 />
 
-Spennet illustrerer poenget: et lite utslag i avkastningskravet flytter verdien mye, og riktig forankring krever oppdaterte, lokale tall. Det samme gjelder leienivå — kontorleie ligger rundt 2 950 kr/m²/år i Tromsø mot 1 750 kr/m²/år i Mo i Rana ifølge Analyseportalen (Q4 2025). Disse forskjellene er en del av analysearbeidet som honoraret dekker.
+Spennet illustrerer poenget: et lite utslag i avkastningskravet flytter verdien mye, og riktig forankring krever oppdaterte, lokale tall. Det samme gjelder leienivå — kontorleie ligger rundt 3 003 kr/m²/år i Tromsø mot 2 475 kr/m²/år i Mo i Rana ifølge Analyseportalen (Q4 2025). Disse forskjellene er en del av analysearbeidet som honoraret dekker.
 
 <Note variant="caution">
   Markedstallene over er per Q4 2025 fra [Analyseportalen](/analyseportal) og oppdateres kvartalsvis — de endrer seg over tid. Bruk alltid de løpende tallene i Analyseportalen som kilde. Tallene her er ikke en pris på verdivurderingstjenesten, men eksempler på markedsdata en vurdering bygger på.

--- a/src/content/help/kontorledighet-bodo-tromso.mdx
+++ b/src/content/help/kontorledighet-bodo-tromso.mdx
@@ -8,7 +8,7 @@ categories:
 takeaways:
   - "Bodø ligger på 4,6 % og Tromsø på 3,4 % kontorledighet i Q4 2025 — begge er lave, men forskjellen forteller noe om markedsbalansen."
   - "Mesteparten av ledigheten i begge byene er strukturell friksjon, ikke konjunkturell ubalanse — derfor er retningen viktigere enn nivået."
-  - "Lavere ledighet i Tromsø henger sammen med høyere kontorleie (2 950 mot 2 400 kr/m²/år) og lavere prime yield (6,10 % mot 6,35 %)."
+  - "Bodø og Tromsø ligger nå nesten likt øverst på kontorleie (3 002 mot 3 003 kr/m²/år); ledighetsforskjellen forklares av markedsdybde og likviditet, ikke av et leie-gap, mens Tromsø fortsatt har lavere prime yield (6,10 % mot 6,35 %)."
   - "I små markeder kan én leietaker flytte tallet flere prosentpoeng, så les trenden over flere kvartaler med kildekritikk."
 related:
   - kontorledighet
@@ -19,7 +19,7 @@ faq:
   - question: "Hva er kontorledigheten i Bodø og Tromsø?"
     answer: "I Q4 2025 var kontorledigheten 4,6 % i Bodø og 3,4 % i Tromsø, ifølge Analyseportalen. Begge nivåene regnes som lave og indikerer relativt stramme kontormarkeder. Tromsø er det største kontormarkedet i Nord-Norge, mens Bodø er en voksende logistikkhubb. Tallene endres kvartalsvis."
   - question: "Hvorfor har Bodø høyere kontorledighet enn Tromsø?"
-    answer: "Forskjellen på 4,6 % i Bodø mot 3,4 % i Tromsø er moderat og ligger innenfor det som kan forklares av strukturell friksjon og enkeltleietakeres bevegelser. Tromsø har et større og mer likvid kontormarked, noe som henger sammen med høyere kontorleie (2 950 mot 2 400 kr/m²/år) og lavere prime yield (6,10 % mot 6,35 %)."
+    answer: "Forskjellen på 4,6 % i Bodø mot 3,4 % i Tromsø er moderat og ligger innenfor det som kan forklares av strukturell friksjon og enkeltleietakeres bevegelser. Tromsø har et større og mer likvid kontormarked. På kontorleie ligger byene nå nesten likt øverst (3 003 mot 3 002 kr/m²/år), så ledighetsforskjellen skyldes markedsdybde snarere enn et leie-gap; Tromsø har likevel lavere prime yield (6,10 % mot 6,35 %)."
   - question: "Er 4,6 % kontorledighet høyt eller lavt?"
     answer: "4,6 % regnes som lavt. Et kontormarked har alltid en viss strukturell ledighet fordi leietakere bytter lokaler og bygg rehabiliteres. Et nivå rundt 4–5 % indikerer normalt at markedet er nær balanse. Det er først ved en stigende trend over flere kvartaler at ledigheten signaliserer reell ubalanse."
   - question: "Hvordan påvirker kontorledighet leie og yield i Nord-Norge?"
@@ -44,8 +44,8 @@ Per Q4 2025 ligger kontorledigheten i Bodø på 4,6 % og i Tromsø på 3,4 %, if
   items={[
     { value: "4,6", unit: "%", label: "Kontorledighet Bodø (Q4 2025)" },
     { value: "3,4", unit: "%", label: "Kontorledighet Tromsø (Q4 2025)" },
-    { value: "2 400", unit: "kr/m²", label: "Kontorleie Bodø" },
-    { value: "2 950", unit: "kr/m²", label: "Kontorleie Tromsø" },
+    { value: "3 002", unit: "kr/m²", label: "Kontorleie Bodø" },
+    { value: "3 003", unit: "kr/m²", label: "Kontorleie Tromsø" },
   ]}
 />
 
@@ -65,19 +65,19 @@ Derfor er retningen viktigere enn absoluttverdien. Et stabilt nivå over flere k
 
 ## Hvordan ledighet henger sammen med leie og yield
 
-Lav ledighet, høy leie og lav yield følges typisk ad, og Bodø og Tromsø illustrerer mønsteret. Tromsø har lavest ledighet, høyest kontorleie og lavest avkastningskrav av de to. Det er ikke tilfeldig: et stramt marked gir utleiere forhandlingsmakt, understøtter leienivåene og reduserer risikoen investorer priser inn i yield.
+Lav ledighet, høy leie og lav yield følges typisk ad, og Bodø og Tromsø illustrerer mønsteret — men ikke mekanisk. På kontorleie ligger begge byene nå likt øverst (~3 000 kr/m²/år), mens Tromsø har lavest ledighet og lavest avkastningskrav av de to. At ledigheten er lavere i Tromsø skyldes ikke et leie-gap, men et større og mer likvid kontormarked: markedsdybden gjør at areal absorberes raskere og at strukturell friksjon slår mindre ut. Et stramt marked gir samtidig utleiere forhandlingsmakt og reduserer risikoen investorer priser inn i yield.
 
 <Example
   title="Bodø og Tromsø — ledighet, leie og prime yield (Q4 2025)"
   steps={[
     {
       label: "Bodø — ledighet / leie / prime yield",
-      value: "4,6 % / 2 400 / 6,35 %",
+      value: "4,6 % / 3 002 / 6,35 %",
       calculation: "Voksende logistikkhubb, Advantis hovedkontor"
     },
     {
       label: "Tromsø — ledighet / leie / prime yield",
-      value: "3,4 % / 2 950 / 6,10 %",
+      value: "3,4 % / 3 003 / 6,10 %",
       calculation: "Største kontormarkedet i Nord-Norge",
       isResult: true
     }
@@ -107,7 +107,7 @@ Praktisk innebærer det at du bør lese ledighetstallet sammen med kunnskap om d
     },
     {
       title: "Henger sammen med leie og yield",
-      description: "Lav ledighet i Tromsø følges av høyere leie (2 950 kr/m²) og lavere prime yield (6,10 %) enn i Bodø."
+      description: "Begge byene ligger likt øverst på leie (~3 000 kr/m²), så ledighetsforskjellen skyldes markedsdybde; Tromsø har likevel lavere prime yield (6,10 %) enn Bodø."
     },
     {
       title: "Små markeder svinger",

--- a/src/content/help/leie-kontor-bodo.mdx
+++ b/src/content/help/leie-kontor-bodo.mdx
@@ -6,7 +6,7 @@ author: havard-nome
 categories:
   - analysis
 takeaways:
-  - Gjennomsnittlig kontorleie i Bodø lå på 2 400 kr/m²/år i Q4 2025; lokaler med høy standard og sentral beliggenhet ligger over snittet.
+  - Gjennomsnittlig kontorleie i Bodø lå på 3 002 kr/m²/år i Q4 2025; lokaler med høy standard og sentral beliggenhet ligger over snittet.
   - Kontorledigheten var 4,6 prosent — et relativt stramt marked der gode lokaler går raskt, men der det fortsatt finnes valgmuligheter.
   - Listeleien er sjelden hele kostnaden. Felleskostnader, leieperiodens lengde og hva som er inkludert avgjør den reelle utgiften per måned.
   - Sammenlign alltid leien per kvadratmeter mot hva som faktisk inngår, ikke bare mot et annet bygg sitt listetall.
@@ -17,7 +17,7 @@ related:
   - kontorledighet
 faq:
   - question: "Hva koster det å leie kontor i Bodø?"
-    answer: "Gjennomsnittlig kontorleie i Bodø lå på 2 400 kr/m²/år i fjerde kvartal 2025, ifølge Analyseportalen. Det er et snitt for markedet — moderne lokaler med høy standard og sentral beliggenhet ligger over dette nivået, mens eldre eller mindre attraktive lokaler ligger under. Et kontor på 300 m² til snittleie tilsvarer en årlig grunnleie på 720 000 kroner, før felleskostnader."
+    answer: "Gjennomsnittlig kontorleie i Bodø lå på 3 002 kr/m²/år i fjerde kvartal 2025, ifølge Analyseportalen. Det er et snitt for markedet — moderne lokaler med høy standard og sentral beliggenhet ligger over dette nivået, mens eldre eller mindre attraktive lokaler ligger under. Et kontor på 300 m² til snittleie tilsvarer en årlig grunnleie på 900 600 kroner, før felleskostnader."
   - question: "Hvor mye kontorlokale er ledig i Bodø?"
     answer: "Kontorledigheten i Bodø var 4,6 prosent i fjerde kvartal 2025. Det er et relativt stramt marked: gode, sentrale lokaler leies ofte ut raskt, men det finnes fortsatt valgmuligheter for en leietaker som er ute i god tid. Markedsdata oppdateres kvartalsvis i Analyseportalen."
   - question: "Hva inngår i kontorleien utover selve leien?"
@@ -37,17 +37,17 @@ Skal du finne nye kontorlokaler i Bodø, er det første spørsmålet nesten allt
 
 ## Hva koster kontor i Bodø nå?
 
-Gjennomsnittlig kontorleie i Bodø lå på 2 400 kr/m²/år i fjerde kvartal 2025. Dette er et markedssnitt — det betyr at moderne lokaler med høy standard og sentral beliggenhet ligger over nivået, mens eldre lokaler eller lokaler i randsonen ligger under. Kontorledigheten var samtidig 4,6 prosent, som beskriver et relativt stramt marked der attraktive lokaler ikke blir stående lenge.
+Gjennomsnittlig kontorleie i Bodø lå på 3 002 kr/m²/år i fjerde kvartal 2025. Dette er et markedssnitt — det betyr at moderne lokaler med høy standard og sentral beliggenhet ligger over nivået, mens eldre lokaler eller lokaler i randsonen ligger under. Kontorledigheten var samtidig 4,6 prosent, som beskriver et relativt stramt marked der attraktive lokaler ikke blir stående lenge.
 
 <StatStrip
   items={[
-    { value: "2 400", unit: "kr/m²/år", label: "Kontorleie Bodø (snitt)" },
+    { value: "3 002", unit: "kr/m²/år", label: "Kontorleie Bodø (snitt)" },
     { value: "4,6", unit: "%", label: "Kontorledighet" },
     { value: "3 135", unit: "kr/m²/år", label: "Handelsleie (til sammenligning)" }
   ]}
 />
 
-Til sammenligning lå kontorleien i Tromsø — det største kontormarkedet i Nord-Norge — på 2 950 kr/m²/år i samme kvartal. Bodø er altså et rimeligere kontormarked enn Tromsø, men dyrere enn mindre byer som Harstad, der kontorleien lå på 1 875 kr/m²/år. For en leietaker er det nyttig å kjenne dette spennet når man vurderer om et tilbud er konkurransedyktig.
+Til sammenligning lå kontorleien i Tromsø — det største kontormarkedet i Nord-Norge — på 3 003 kr/m²/år i samme kvartal. Tromsø og Bodø ligger dermed likt øverst, rundt 3 000 kr/m²/år, mens mindre byer som Harstad ligger lavere, der kontorleien lå på 2 600 kr/m²/år. Spennet i landsdelen er moderat — rundt 500 kr mellom de rimeligste og dyreste byene — og for en leietaker er det nyttig å kjenne dette når man vurderer om et tilbud er konkurransedyktig.
 
 ## Hva listeleien faktisk betyr for budsjettet
 
@@ -57,12 +57,12 @@ Det er lett å feste seg ved kvadratmeterprisen, men den blir først konkret nå
   title="Årlig grunnleie for et kontor på 300 m² i Bodø sentrum"
   steps={[
     { label: "Areal", value: "300 m²" },
-    { label: "Markedsleie (Analyseportalen, Q4 2025)", value: "2 400 kr/m²/år" },
-    { label: "Årlig grunnleie", value: 720000, calculation: "300 × 2 400", isResult: true }
+    { label: "Markedsleie (Analyseportalen, Q4 2025)", value: "3 002 kr/m²/år" },
+    { label: "Årlig grunnleie", value: 900600, calculation: "300 × 3 002", isResult: true }
   ]}
 />
 
-Grunnleien på 720 000 kroner i året er imidlertid bare første post i regnestykket. På toppen kommer felleskostnader, og avhengig av kontrakten kan det også komme tilpasninger av lokalet, parkering og andre tillegg. Det reelle bildet får du først når alle disse postene er lagt sammen — og det er der to lokaler med tilsynelatende lik kvadratmeterpris kan vise seg å være svært ulike.
+Grunnleien på 900 600 kroner i året er imidlertid bare første post i regnestykket. På toppen kommer felleskostnader, og avhengig av kontrakten kan det også komme tilpasninger av lokalet, parkering og andre tillegg. Det reelle bildet får du først når alle disse postene er lagt sammen — og det er der to lokaler med tilsynelatende lik kvadratmeterpris kan vise seg å være svært ulike.
 
 ## Felleskostnader og hva som er inkludert
 
@@ -99,14 +99,14 @@ At markedet er relativt stramt vises også på transaksjonssiden. Et anonymisert
     },
     {
       title: "Sammenlign mot markedet",
-      description: "Hold tilbudet opp mot snittleien på 2 400 kr/m²/år og nivået i sammenlignbare bygg."
+      description: "Hold tilbudet opp mot snittleien på 3 002 kr/m²/år og nivået i sammenlignbare bygg."
     }
   ]}
 />
 
 ## Kort oppsummert
 
-Å leie kontor i Bodø handler om mer enn kvadratmeterprisen. Snittleien på 2 400 kr/m²/år og en ledighet på 4,6 prosent gir et bilde av et stramt, men tilgjengelig marked. Den reelle kostnaden avhenger av felleskostnader, leieperiode og hva som inngår — og en leietaker som forstår disse postene, forhandler fra et langt sterkere ståsted.
+Å leie kontor i Bodø handler om mer enn kvadratmeterprisen. Snittleien på 3 002 kr/m²/år og en ledighet på 4,6 prosent gir et bilde av et stramt, men tilgjengelig marked. Den reelle kostnaden avhenger av felleskostnader, leieperiode og hva som inngår — og en leietaker som forstår disse postene, forhandler fra et langt sterkere ståsted.
 
 <ReadMore
   items={[

--- a/src/content/help/leie-kontor-tromso.mdx
+++ b/src/content/help/leie-kontor-tromso.mdx
@@ -6,7 +6,7 @@ author: havard-nome
 categories:
   - analysis
 takeaways:
-  - Kontorleie i Tromsø ligger på rundt 2 950 kr/m²/år for gode sentrumslokaler (Analyseportalen, Q4 2025).
+  - Kontorleie i Tromsø ligger på rundt 3 003 kr/m²/år for gode sentrumslokaler (Analyseportalen, Q4 2025).
   - Med kontorledighet på 3,4 prosent er Tromsø det strammeste kontormarkedet i Nord-Norge — det gir utleier forhandlingsmakt.
   - "Som leietaker betaler du mer enn listeleien: felleskostnader, energi og tilpasning kommer i tillegg."
   - I et stramt marked lønner det seg å starte søket tidlig og sikre seg gode lokaler før kontrakten utløper.
@@ -17,7 +17,7 @@ related:
   - felleskostnader
 faq:
   - question: "Hva koster det å leie kontor i Tromsø?"
-    answer: "Gode kontorlokaler i Tromsø sentrum ligger på rundt 2 950 kr/m²/år (Analyseportalen, Q4 2025). Dette er det høyeste kontornivået i Nord-Norge. I tillegg til den nominelle leien kommer felleskostnader, energi og eventuell tilpasning av lokalet, så den reelle kostnaden per kvadratmeter blir høyere enn listeleien. Tallene endres kvartalsvis — se /analyseportal for oppdaterte nivåer."
+    answer: "Gode kontorlokaler i Tromsø sentrum ligger på rundt 3 003 kr/m²/år (Analyseportalen, Q4 2025). Tromsø og Bodø ligger likt øverst i Nord-Norge, rundt 3 000 kr/m². I tillegg til den nominelle leien kommer felleskostnader, energi og eventuell tilpasning av lokalet, så den reelle kostnaden per kvadratmeter blir høyere enn listeleien. Tallene endres kvartalsvis — se /analyseportal for oppdaterte nivåer."
   - question: "Hvor stramt er kontormarkedet i Tromsø?"
     answer: "Tromsø har en kontorledighet på 3,4 prosent (Analyseportalen, Q4 2025), som er det laveste i Nord-Norge. Til sammenligning ligger Bodø på 4,6 prosent. Lav ledighet betyr at det er få ledige lokaler, og at utleier har forhandlingsmakt. For leietaker innebærer det at gode lokaler går raskt og at det lønner seg å starte søket tidlig."
   - question: "Hva betaler en kontorleietaker i tillegg til selve leien?"
@@ -37,11 +37,11 @@ Skal du leie kontor i Tromsø, møter du Nord-Norges strammeste kontormarked. De
 
 ## Hva koster det å leie kontor i Tromsø?
 
-Tromsø er det største og dyreste kontormarkedet i Nord-Norge. Gode sentrumslokaler ligger på rundt 2 950 kr/m²/år, og lav ledighet holder nivået oppe. For en leietaker betyr det at prisbildet er mindre fleksibelt enn i mindre byer i regionen.
+Tromsø er det største kontormarkedet i Nord-Norge, og leienivået ligger helt i toppen — på linje med Bodø. Gode sentrumslokaler ligger på rundt 3 003 kr/m²/år, og lav ledighet holder nivået oppe. For en leietaker betyr det at prisbildet er mindre fleksibelt enn i mindre byer i regionen.
 
 <StatStrip
   items={[
-    { value: "2 950", unit: "kr/m²/år", label: "Kontorleie Tromsø sentrum" },
+    { value: "3 003", unit: "kr/m²/år", label: "Kontorleie Tromsø sentrum" },
     { value: "3,4", unit: "%", label: "Kontorledighet" },
     { value: "6,10", unit: "%", label: "Prime yield" }
   ]}
@@ -51,42 +51,42 @@ Tallene over er hentet fra Advantis [Analyseportal](/analyseportal) (Q4 2025). D
 
 ## Tromsø sammenlignet med resten av regionen
 
-Det er nyttig å se Tromsø-leien i kontekst. Sammenlignet med Bodø, som er regionens nest største kontormarked, betaler du både høyere leie og møter et strammere marked i Tromsø.
+Det er nyttig å se Tromsø-leien i kontekst. Sammenlignet med Bodø, som er regionens nest største kontormarked, ligger leien likt øverst, men du møter et strammere marked i Tromsø.
 
 <Example
   title="Kontorleie og ledighet — Tromsø vs Bodø (Q4 2025)"
   steps={[
     {
       label: "Tromsø — kontorleie",
-      value: "2 950 kr/m²/år",
+      value: "3 003 kr/m²/år",
       calculation: "Ledighet 3,4 %"
     },
     {
       label: "Bodø — kontorleie",
-      value: "2 400 kr/m²/år",
+      value: "3 002 kr/m²/år",
       calculation: "Ledighet 4,6 %"
     },
     {
       label: "Forskjell i leienivå",
-      value: "+550 kr/m²/år",
-      calculation: "Tromsø er det høyeste kontornivået i Nord-Norge",
+      value: "+1 kr/m²/år",
+      calculation: "Tromsø og Bodø ligger likt øverst i Nord-Norge",
       isResult: true
     }
   ]}
 />
 
-Forskjellen handler ikke om at Tromsø er «overpriset», men om at etterspørselen er sterkere relativt til tilbudet. Tromsø er regionens administrasjons- og kunnskapssentrum med universitet, sykehus og et bredt tjenestenæringsliv som alle konkurrerer om de samme sentrale lokalene. Innenfor byen finnes det også prisforskjeller mellom de mest sentrale sentrumsbyggene og randsonen, der nivåene ligger lavere.
+At markedet er strammere i Tromsø, handler ikke om at byen er «overpriset», men om at etterspørselen er sterkere relativt til tilbudet. Tromsø er regionens administrasjons- og kunnskapssentrum med universitet, sykehus og et bredt tjenestenæringsliv som alle konkurrerer om de samme sentrale lokalene. Innenfor byen finnes det også prisforskjeller mellom de mest sentrale sentrumsbyggene og randsonen, der nivåene ligger lavere.
 
 ## Hva du faktisk betaler — ut over listeleien
 
-Listeleien på 2 950 kr/m²/år er ikke hele regnestykket. Som leietaker bør du alltid be om en samlet oversikt over årlig totalkostnad før du sammenligner alternativer.
+Listeleien på 3 003 kr/m²/år er ikke hele regnestykket. Som leietaker bør du alltid be om en samlet oversikt over årlig totalkostnad før du sammenligner alternativer.
 
 <Summary
   title="Kostnadselementene i en kontorleie"
   points={[
     {
       title: "Nominell leie",
-      description: "Selve leien per kvadratmeter — i Tromsø sentrum rundt 2 950 kr/m²/år for gode lokaler.",
+      description: "Selve leien per kvadratmeter — i Tromsø sentrum rundt 3 003 kr/m²/år for gode lokaler.",
     },
     {
       title: "Felleskostnader",

--- a/src/content/help/naringseiendom-bodo.mdx
+++ b/src/content/help/naringseiendom-bodo.mdx
@@ -6,7 +6,7 @@ author: havard-nome
 categories:
   - analysis
 takeaways:
-  - Prime yield i Bodø ligger på 6,35 prosent (Q4 2025), med kontorleie rundt 2 400 kr/m²/år og kontorledighet på 4,6 prosent.
+  - Prime yield i Bodø ligger på 6,35 prosent (Q4 2025), med kontorleie rundt 3 000 kr/m²/år og kontorledighet på 4,6 prosent.
   - Bodø er en voksende logistikkhubb — logistikkledigheten er lav (2,4 prosent), og segmentet handles til høyere yield enn kontor.
   - Anonymiserte transaksjoner viser kontor i sentrum rundt 6,1 prosent og logistikk rundt 6,8 prosent — yield følger segment, beliggenhet og leietakerkvalitet.
   - Markedstall endres kvartalsvis; bruk Analyseportalen for ferske tall før du priser et konkret oppdrag.
@@ -19,7 +19,7 @@ faq:
   - question: "Hva er prime yield for næringseiendom i Bodø?"
     answer: "Prime yield i Bodø ligger på 6,35 prosent per Q4 2025 ifølge Analyseportalen. Prime yield gjelder de beste eiendommene — sentral beliggenhet, lange og solide leiekontrakter og høy bygningsstandard. Vanlige eiendommer handles til høyere yield. Tallet endres kvartalsvis, så sjekk Analyseportalen for ferske nivåer."
   - question: "Hva er leienivået for kontor i Bodø?"
-    answer: "Kontorleie i Bodø ligger rundt 2 400 kr/m²/år per Q4 2025. Til sammenligning er handelsleie omtrent 3 135 kr/m²/år og logistikkleie rundt 1 405 kr/m²/år. Dette er markedsnivåer for gode lokaler — oppnådd leie i den enkelte kontrakt varierer med beliggenhet, standard og leieperiode."
+    answer: "Kontorleie i Bodø ligger rundt 3 000 kr/m²/år per Q4 2025. Til sammenligning er handelsleie omtrent 3 135 kr/m²/år og logistikkleie rundt 1 405 kr/m²/år. Dette er markedsnivåer for gode lokaler — oppnådd leie i den enkelte kontrakt varierer med beliggenhet, standard og leieperiode."
   - question: "Hvor høy er kontorledigheten i Bodø?"
     answer: "Kontorledigheten i Bodø er 4,6 prosent per Q4 2025. Handelsledigheten ligger på 3,1 prosent og logistikkledigheten på 2,4 prosent. Den lave logistikkledigheten gjenspeiler at Bodø er en voksende logistikkhubb i Nord-Norge."
   - question: "Hvorfor handles logistikk til høyere yield enn kontor i Bodø?"
@@ -43,7 +43,7 @@ De viktigste nøkkeltallene for Bodø samler seg rundt tre størrelser: avkastni
 <StatStrip
   stats={[
     { value: "6,35 %", label: "Prime yield (Q4 2025)" },
-    { value: "2 400 kr", label: "Kontorleie per m²/år" },
+    { value: "3 002 kr", label: "Kontorleie per m²/år" },
     { value: "4,6 %", label: "Kontorledighet" }
   ]}
 />
@@ -59,7 +59,7 @@ Bodø er ikke ett marked, men flere. Kontor, handel og logistikk har ulike leien
   steps={[
     {
       label: "Kontor",
-      value: "2 400 kr/m²",
+      value: "3 002 kr/m²",
       calculation: "Ledighet 4,6 %"
     },
     {

--- a/src/content/help/naringseiendom-nord-norge.mdx
+++ b/src/content/help/naringseiendom-nord-norge.mdx
@@ -21,7 +21,7 @@ faq:
   - question: "Hvorfor er yield lavere i Tromsø enn i Narvik?"
     answer: "Yield speiler risiko og omsettelighet. Tromsø er regionens største kontormarked med flere kjøpere, dypere leietakermasse og høyere likviditet, og prises derfor til 6,10 %. Narvik er et tynnere marked med færre transaksjoner og lavere likviditet, og investorer krever en høyere avkastning på 6,90 % som kompensasjon."
   - question: "Hvor høyt er leienivået for kontor i Nord-Norge?"
-    answer: "Per Q4 2025 ligger prime kontorleie på 2 950 kr/m²/år i Tromsø og 2 400 kr/m²/år i Bodø, mens de mindre byene ligger lavere — Alta 1 950, Harstad 1 875, Narvik 1 820 og Mo i Rana 1 750 kr/m²/år. Leien varierer også sterkt mellom segment og beliggenhet."
+    answer: "Per Q4 2025 ligger prime kontorleie på 3 003 kr/m²/år i Tromsø og 3 002 kr/m²/år i Bodø, mens de mindre byene ligger lavere — Alta 2 675, Harstad 2 600, Narvik 2 545 og Mo i Rana 2 475 kr/m²/år. Leien varierer også sterkt mellom segment og beliggenhet."
   - question: "Hvilke segmenter har høyest og lavest yield i regionen?"
     answer: "På tvers av Nord-Norge prises kontor lavest med en segmentyield rundt 6,10 %, handel rundt 6,55 % og logistikk høyest rundt 6,85 % per Q4 2025. Logistikk prises høyere fordi inntektsgrunnlaget ofte er mer single-tenant-avhengig og restverdien mer usikker."
 slug: naringseiendom-nord-norge
@@ -44,7 +44,7 @@ Nord-Norge dekker Nordland, Troms og Finnmark — et stort geografisk område me
   items={[
     { value: "6,10", unit: "%", label: "Lavest prime yield (Tromsø)" },
     { value: "6,90", unit: "%", label: "Høyest prime yield (Narvik)" },
-    { value: "2 950", unit: "kr/m²", label: "Høyest kontorleie (Tromsø)" },
+    { value: "3 003", unit: "kr/m²", label: "Høyest kontorleie (Tromsø)" },
     { value: "3,4", unit: "%", label: "Lavest kontorledighet (Tromsø)" }
   ]}
 />
@@ -58,12 +58,12 @@ Tabellen under viser de tre nøkkeltallene for alle de seks største markedene i
 <Example
   title="Prime yield · kontorleie · kontorledighet (Q4 2025)"
   steps={[
-    { label: "Tromsø", calculation: "Leie 2 950 kr/m² · ledighet 3,4 %", value: "6,10 %" },
-    { label: "Bodø", calculation: "Leie 2 400 kr/m² · ledighet 4,6 %", value: "6,35 %" },
-    { label: "Harstad", calculation: "Leie 1 875 kr/m² · ledighet 5,8 %", value: "6,55 %" },
-    { label: "Alta", calculation: "Leie 1 950 kr/m² · ledighet 6,2 %", value: "6,75 %" },
-    { label: "Mo i Rana", calculation: "Leie 1 750 kr/m² · ledighet 5,4 %", value: "6,80 %" },
-    { label: "Narvik", calculation: "Leie 1 820 kr/m² · ledighet 7,5 %", value: "6,90 %", isResult: true }
+    { label: "Tromsø", calculation: "Leie 3 003 kr/m² · ledighet 3,4 %", value: "6,10 %" },
+    { label: "Bodø", calculation: "Leie 3 002 kr/m² · ledighet 4,6 %", value: "6,35 %" },
+    { label: "Harstad", calculation: "Leie 2 600 kr/m² · ledighet 5,8 %", value: "6,55 %" },
+    { label: "Alta", calculation: "Leie 2 675 kr/m² · ledighet 6,2 %", value: "6,75 %" },
+    { label: "Mo i Rana", calculation: "Leie 2 475 kr/m² · ledighet 5,4 %", value: "6,80 %" },
+    { label: "Narvik", calculation: "Leie 2 545 kr/m² · ledighet 7,5 %", value: "6,90 %", isResult: true }
   ]}
 />
 
@@ -87,7 +87,7 @@ Tre forhold forklarer det meste av forskjellen mellom byene: markedsstørrelse, 
 
 Innenfor hver by varierer prisingen mellom kontor, handel og logistikk. På tvers av regionen ligger segmentyieldene per Q4 2025 på rundt 6,10 % for kontor, 6,55 % for handel og 6,85 % for logistikk. Logistikk prises høyere fordi inntektsgrunnlaget oftere hviler på én enkelt leietaker og restverdien er mer usikker.
 
-Leienivåene følger samme mønster med tydelige nivåforskjeller. I Bodø ligger prime kontorleie på 2 400 kr/m²/år, handel på 3 135 og logistikk på 1 405. I Tromsø er nivåene høyere: kontor 2 950, handel 3 635 og logistikk 1 655 kr/m²/år. Handel betaler altså mest per kvadratmeter, men prises samtidig til høyere yield enn kontor — leie og yield må alltid leses sammen.
+Leienivåene følger samme mønster med tydelige nivåforskjeller. Kontorleien ligger likt øverst i de to store byene, rundt 3 000 kr/m²/år i både Bodø og Tromsø. På handel og logistikk er Tromsø høyere: i Bodø ligger handel på 3 135 og logistikk på 1 405, mot 3 635 og 1 655 kr/m²/år i Tromsø. Handel betaler altså mest per kvadratmeter, men prises samtidig til høyere yield enn kontor — leie og yield må alltid leses sammen.
 
 ## Hvordan markedet faktisk omsettes
 

--- a/src/content/help/naringseiendom-nordland.mdx
+++ b/src/content/help/naringseiendom-nordland.mdx
@@ -21,9 +21,9 @@ faq:
   - question: "Hvorfor er yielden høyere i Mo i Rana og Narvik enn i Bodø?"
     answer: "Yield er et uttrykk for risiko og likviditet. Mo i Rana og Narvik har færre potensielle kjøpere, lengre omsetningstid og et mer konsentrert næringsliv enn Bodø. Investorer krever derfor et høyere avkastningskrav for å kompensere for at en eiendom kan ta lengre tid å selge og at markedet er mer sårbart for enkeltaktører."
   - question: "Hvilke segmenter dominerer næringseiendomsmarkedet i Nordland?"
-    answer: "Nordland har en tydelig industri- og logistikkprofil drevet av havn, kraftforedlende industri og samferdsel. Mo i Rana og Narvik er utpregede industri- og logistikkbyer, mens Bodø kombinerer et voksende kontormarked med en fremvoksende logistikkhubb. Kontorleien i Bodø lå på 2 400 kr/m²/år i Q4 2025, mens de mindre byene ligger lavere."
+    answer: "Nordland har en tydelig industri- og logistikkprofil drevet av havn, kraftforedlende industri og samferdsel. Mo i Rana og Narvik er utpregede industri- og logistikkbyer, mens Bodø kombinerer et voksende kontormarked med en fremvoksende logistikkhubb. Kontorleien i Bodø lå på 3 002 kr/m²/år i Q4 2025, mens de mindre byene ligger noe lavere."
   - question: "Hvor mye lavere er kontorleien i Mo i Rana og Narvik enn i Bodø?"
-    answer: "Ifølge Analyseportalen (Q4 2025) lå kontorleien på 2 400 kr/m²/år i Bodø, mot 1 750 kr/m²/år i Mo i Rana og 1 820 kr/m²/år i Narvik. Leienivået følger byenes størrelse, etterspørselsdybde og næringsstruktur. Tallene oppdateres hvert kvartal i Analyseportalen."
+    answer: "Ifølge Analyseportalen (Q4 2025) lå kontorleien på 3 002 kr/m²/år i Bodø, mot 2 475 kr/m²/år i Mo i Rana og 2 545 kr/m²/år i Narvik. Leienivået følger byenes størrelse, etterspørselsdybde og næringsstruktur, men forskjellen mot Bodø er moderat. Tallene oppdateres hvert kvartal i Analyseportalen."
 slug: naringseiendom-nordland
 ---
 
@@ -63,24 +63,24 @@ Bodø er i ferd med å etablere seg som en logistikkhubb, samtidig som byen beho
   steps={[
     {
       label: "Bodø — kontorleie",
-      value: "2 400 kr/m²/år",
+      value: "3 002 kr/m²/år",
       calculation: "Kontorledighet 4,6 % — voksende logistikkhubb"
     },
     {
       label: "Mo i Rana — kontorleie",
-      value: "1 750 kr/m²/år",
+      value: "2 475 kr/m²/år",
       calculation: "Kontorledighet 5,4 % — industri og logistikk"
     },
     {
       label: "Narvik — kontorleie",
-      value: "1 820 kr/m²/år",
+      value: "2 545 kr/m²/år",
       calculation: "Kontorledighet 7,5 % — lavere likviditet",
       isResult: true
     }
   ]}
 />
 
-Leienivået følger byenes størrelse og etterspørselsdybde. Bodø ligger klart høyest på kontor, mens Mo i Rana og Narvik ligger lavere — men det er i industri- og logistikksegmentet disse byene har sin egentlige styrke, ikke i kontormarkedet alene.
+Leienivået følger byenes størrelse og etterspørselsdybde. Bodø ligger høyest på kontor, mens Mo i Rana og Narvik ligger noe lavere — men forskjellen er moderat, og det er i industri- og logistikksegmentet disse byene har sin egentlige styrke, ikke i kontormarkedet alene.
 
 <Note variant="caution">
   Alle markedstall i denne artikkelen er hentet fra [Analyseportalen](/analyseportal) og gjelder Q4 2025. Markedsdata endres hvert kvartal — yield, leienivå og ledighet beveger seg med tilbud, etterspørsel og rentebildet. Sjekk [Analyseportalen](/analyseportal) for oppdaterte tall. Transaksjonseksempler er anonymiserte illustrasjoner og gjengir ikke konkrete eiendommer.

--- a/src/content/help/naringseiendom-tromso.mdx
+++ b/src/content/help/naringseiendom-tromso.mdx
@@ -6,7 +6,7 @@ author: havard-nome
 categories:
   - analysis
 takeaways:
-  - Tromsø er Nord-Norges største kontormarked, med lav ledighet på 3,4 prosent og den høyeste kontorleien i regionen på 2 950 kr/m²/år (Q4 2025).
+  - Tromsø er Nord-Norges største kontormarked, med lav ledighet på 3,4 prosent og en kontorleie på 3 003 kr/m²/år (Q4 2025) — på linje med Bodø øverst i regionen, rundt 3 000 kr/m².
   - Prime yield ligger på 6,10 prosent — det laveste avkastningskravet blant byene Advanti dekker, et uttrykk for dyp etterspørsel og lav opplevd risiko.
   - Leie og ledighet varierer mye mellom kontor, handel og logistikk; les alltid tallet for riktig segment.
   - Markedstall endres hvert kvartal — bruk Analyseportalen for live tall før du tar en beslutning.
@@ -19,7 +19,7 @@ faq:
   - question: "Hva er prime yield for næringseiendom i Tromsø?"
     answer: "Prime yield i Tromsø lå på 6,10 prosent i Q4 2025 ifølge Advantis Analyseportal. Det er det laveste avkastningskravet blant byene Advanti dekker i Nord-Norge, og reflekterer at Tromsø er regionens største og mest likvide kontormarked med dyp etterspørsel og lav opplevd risiko. Prime yield gjelder de beste eiendommene med solide leietakere og sentral beliggenhet; sekundære eiendommer prises på et høyere avkastningskrav."
   - question: "Hva koster det å leie kontor i Tromsø?"
-    answer: "Kontorleie i Tromsø lå på 2 950 kr/m²/år i Q4 2025 ifølge Analyseportalen, som er det høyeste leienivået i Nord-Norge. Til sammenligning lå handel på 3 635 kr/m²/år og logistikk på 1 655 kr/m²/år. Tallene er markedsleie for sentrale lokaler av god standard; faktisk leie i en konkret kontrakt avhenger av beliggenhet, standard, kontraktslengde og insentiver."
+    answer: "Kontorleie i Tromsø lå på 3 003 kr/m²/år i Q4 2025 ifølge Analyseportalen, på linje med Bodø øverst i regionen, rundt 3 000 kr/m²/år. Til sammenligning lå handel på 3 635 kr/m²/år og logistikk på 1 655 kr/m²/år. Tallene er markedsleie for sentrale lokaler av god standard; faktisk leie i en konkret kontrakt avhenger av beliggenhet, standard, kontraktslengde og insentiver."
   - question: "Hvor høy er kontorledigheten i Tromsø?"
     answer: "Kontorledigheten i Tromsø var 3,4 prosent i Q4 2025, et lavt nivå som indikerer et stramt marked der tilbudet er knapt. Handel lå på 2,8 prosent og logistikk på 1,9 prosent. Lav ledighet gir utleiere forhandlingsmakt og understøtter både leienivå og verdsettelse, men i et lite marked kan enkeltleietakere flytte tallet en del fra kvartal til kvartal."
   - question: "Hvor finner jeg oppdaterte markedstall for Tromsø?"
@@ -43,12 +43,12 @@ Tre nøkkeltall rammer inn kontormarkedet i Tromsø: avkastningskravet på de be
 <StatStrip
   items={[
     { value: "6,10", unit: "%", label: "Prime yield (Q4 2025)" },
-    { value: "2 950", unit: "kr/m²/år", label: "Kontorleie (Q4 2025)" },
+    { value: "3 003", unit: "kr/m²/år", label: "Kontorleie (Q4 2025)" },
     { value: "3,4", unit: "%", label: "Kontorledighet (Q4 2025)" }
   ]}
 />
 
-Prime yield på 6,10 prosent er det laveste avkastningskravet blant byene Advanti følger i Nord-Norge — lavere enn Bodø (6,35 prosent) og klart lavere enn mindre markeder som Narvik (6,90 prosent). Et lavt yield-krav betyr at investorer er villige til å betale mer per krone leieinntekt, fordi den opplevde risikoen er lav. Samtidig er kontorleien på 2 950 kr/m²/år den høyeste i regionen, mens ledigheten på 3,4 prosent ligger lavt og signaliserer et marked der tilbudet er knapt.
+Prime yield på 6,10 prosent er det laveste avkastningskravet blant byene Advanti følger i Nord-Norge — lavere enn Bodø (6,35 prosent) og klart lavere enn mindre markeder som Narvik (6,90 prosent). Et lavt yield-krav betyr at investorer er villige til å betale mer per krone leieinntekt, fordi den opplevde risikoen er lav. Samtidig ligger kontorleien på 3 003 kr/m²/år likt øverst med Bodø, rundt 3 000 kr/m², mens ledigheten på 3,4 prosent ligger lavt og signaliserer et marked der tilbudet er knapt.
 
 ## Leie og ledighet varierer mellom segmentene
 
@@ -59,8 +59,8 @@ Ett samlet bytall skjuler store forskjeller mellom eiendomstypene. Kontor, hande
   steps={[
     {
       label: "Kontor",
-      value: "2 950 kr/m² · 3,4 %",
-      calculation: "Høyeste kontorleie i Nord-Norge; lav ledighet"
+      value: "3 003 kr/m² · 3,4 %",
+      calculation: "På linje med Bodø øverst i regionen; lav ledighet"
     },
     {
       label: "Handel",

--- a/src/content/help/naringsmegler-bodo.mdx
+++ b/src/content/help/naringsmegler-bodo.mdx
@@ -23,7 +23,7 @@ faq:
   - question: "Hva koster det å bruke næringsmegler i Bodø?"
     answer: "Honorar avtales per oppdrag og avhenger av oppdragstype, eiendommens størrelse og kompleksitet. Salgsoppdrag prises ofte som en provisjon av oppnådd salgssum, mens utleie- og rådgivningsoppdrag kan ha fast honorar eller timepris. Be alltid om et konkret tilbud før oppdraget starter."
   - question: "Hvordan ser næringseiendomsmarkedet i Bodø ut nå?"
-    answer: "Per Q4 2025 ligger prime yield i Bodø på 6,35 prosent, kontorleie på 2 400 kr/m²/år og kontorledigheten på 4,6 prosent, ifølge Analyseportalen. Det er et stabilt og relativt likvid regionalt marked med en voksende logistikkhubb. Tallene oppdateres kvartalsvis."
+    answer: "Per Q4 2025 ligger prime yield i Bodø på 6,35 prosent, kontorleie på 3 002 kr/m²/år og kontorledigheten på 4,6 prosent, ifølge Analyseportalen. Det er et stabilt og relativt likvid regionalt marked med en voksende logistikkhubb. Tallene oppdateres kvartalsvis."
 slug: naringsmegler-bodo
 ---
 
@@ -78,12 +78,12 @@ Bodø er et stabilt og relativt likvid regionalt marked, og fungerer som en voks
 <StatStrip
   items={[
     { value: "6,35", unit: "%", label: "Prime yield, Bodø (Q4 2025)" },
-    { value: "2 400", unit: "kr/m²/år", label: "Kontorleie, prime" },
+    { value: "3 002", unit: "kr/m²/år", label: "Kontorleie, prime" },
     { value: "4,6", unit: "%", label: "Kontorledighet" }
   ]}
 />
 
-Yield og leie varierer mellom segmentene. Kontor leier på 2 400 kr/m²/år med 4,6 % ledighet, handel ligger høyere på 3 135 kr/m²/år med 3,1 % ledighet, mens logistikk leier på 1 405 kr/m²/år med svært lav ledighet på 2,4 %. Den lave logistikkledigheten understreker hvorfor Bodø beskrives som en voksende logistikkhubb — etterspørselen etter lager- og logistikkareal er strammere enn tilbudet.
+Yield og leie varierer mellom segmentene. Kontor leier på 3 002 kr/m²/år med 4,6 % ledighet, handel ligger høyere på 3 135 kr/m²/år med 3,1 % ledighet, mens logistikk leier på 1 405 kr/m²/år med svært lav ledighet på 2,4 %. Den lave logistikkledigheten understreker hvorfor Bodø beskrives som en voksende logistikkhubb — etterspørselen etter lager- og logistikkareal er strammere enn tilbudet.
 
 For å gjøre tallene konkrete kan vi se på to anonymiserte transaksjoner fra markedet. De illustrerer hvordan yield og volum spiller sammen i ulike segmenter.
 

--- a/src/content/help/naringsmegler-tromso.mdx
+++ b/src/content/help/naringsmegler-tromso.mdx
@@ -8,7 +8,7 @@ categories:
 takeaways:
   - Tromsø er det største kontormarkedet i Nord-Norge, med lav ledighet på 3,4 prosent og prime yield rundt 6,10 prosent (Q4 2025).
   - En næringsmegler i Tromsø kobler lokal markedskunnskap med verdivurdering, transaksjonsrådgivning og utleie.
-  - Kontorleie ligger høyere enn ellers i landsdelen (2 950 kr/m²/år), drevet av et stramt sentrumsmarked.
+  - Kontorleie ligger helt i toppen av landsdelen, likt med Bodø rundt 3 000 kr/m²/år (3 003 kr/m²/år), drevet av et stramt sentrumsmarked.
   - Markedstall endrer seg kvartalsvis — bruk Analyseportalen for ferske tall før du forhandler.
 related:
   - naringseiendom-tromso
@@ -23,7 +23,7 @@ faq:
   - question: "Hva er prime yield i Tromsø?"
     answer: "Prime yield i Tromsø lå på 6,10 prosent i fjerde kvartal 2025 ifølge Analyseportalen — det laveste avkastningskravet i landsdelen. Prime yield beskriver avkastningskravet for de beste eiendommene med lang kontrakt og solid leietaker, og fungerer som referansepunkt når andre eiendommer skal prises."
   - question: "Hva koster det å leie kontor i Tromsø?"
-    answer: "Kontorleie i Tromsø lå på 2 950 kr/m²/år i fjerde kvartal 2025 ifølge Analyseportalen, det høyeste kontorleienivået i Nord-Norge. Handelsareal lå høyere (3 635 kr/m²/år) og logistikk lavere (1 655 kr/m²/år). Hva en konkret eiendom oppnår avhenger av beliggenhet, standard og kontraktslengde."
+    answer: "Kontorleie i Tromsø lå på 3 003 kr/m²/år i fjerde kvartal 2025 ifølge Analyseportalen, på linje med Bodø øverst i Nord-Norge — begge ligger rundt 3 000 kr/m²/år. Handelsareal lå høyere (3 635 kr/m²/år) og logistikk lavere (1 655 kr/m²/år). Hva en konkret eiendom oppnår avhenger av beliggenhet, standard og kontraktslengde."
 slug: naringsmegler-tromso
 ---
 
@@ -53,12 +53,12 @@ Tromsø skiller seg ut i landsdelen med lav ledighet og det laveste avkastningsk
 <StatStrip
   items={[
     { value: "6,10", unit: "%", label: "Prime yield (Q4 2025)" },
-    { value: "2 950", unit: "kr/m²/år", label: "Kontorleie" },
+    { value: "3 003", unit: "kr/m²/år", label: "Kontorleie" },
     { value: "3,4", unit: "%", label: "Kontorledighet" }
   ]}
 />
 
-Prime yield på 6,10 prosent er det laveste i Nord-Norge — til sammenligning ligger Bodø på 6,35 prosent og Narvik på 6,90 prosent. Et lavere avkastningskrav betyr at investorer er villige til å betale mer per krone leieinntekt, fordi de oppfatter risikoen som lavere. Kontorledigheten på 3,4 prosent er også landsdelens laveste, og forklarer hvorfor kontorleien på 2 950 kr/m²/år ligger over alle de andre byene.
+Prime yield på 6,10 prosent er det laveste i Nord-Norge — til sammenligning ligger Bodø på 6,35 prosent og Narvik på 6,90 prosent. Et lavere avkastningskrav betyr at investorer er villige til å betale mer per krone leieinntekt, fordi de oppfatter risikoen som lavere. Kontorledigheten på 3,4 prosent er også landsdelens laveste, og forklarer hvorfor kontorleien på 3 003 kr/m²/år ligger helt i toppen — likt med Bodø øverst, rundt 3 000 kr/m²/år.
 
 ## Leie og ledighet per segment
 
@@ -69,7 +69,7 @@ Markedet er ikke ett tall, men flere. Leienivå og ledighet varierer mellom kont
   steps={[
     {
       label: "Kontor",
-      value: "2 950 kr/m²/år",
+      value: "3 003 kr/m²/år",
       calculation: "Ledighet 3,4 % — landsdelens største kontormarked"
     },
     {

--- a/src/content/help/verdivurdering-naringseiendom-bodo.mdx
+++ b/src/content/help/verdivurdering-naringseiendom-bodo.mdx
@@ -7,7 +7,7 @@ categories:
   - valuation
 takeaways:
   - En verdivurdering i Bodø bygger på to metoder — yield-basert kapitalisering og diskontert kontantstrøm (DCF) — som bør gi samme svar.
-  - "Det lokale markedet leverer de avgjørende forutsetningene: prime yield rundt 6,35 prosent og kontorleie rundt 2 400 kr/m²/år (Analyseportalen, Q4 2025)."
+  - "Det lokale markedet leverer de avgjørende forutsetningene: prime yield rundt 6,35 prosent og kontorleie rundt 3 002 kr/m²/år (Analyseportalen, Q4 2025)."
   - Yield-valget styrer verdien mer enn noe annet tall — derfor må det forankres i faktiske transaksjoner i samme by og segment.
   - Bruk markedstall som utgangspunkt, men juster for beliggenhet, leietakerprofil og kontraktslengde på den konkrete eiendommen.
 related:
@@ -17,7 +17,7 @@ related:
   - prime-yield
 faq:
   - question: "Hvordan verdsettes næringseiendom i Bodø?"
-    answer: "Verdivurdering i Bodø bygger på to metoder som krysspeiler hverandre: yield-basert kapitalisering, der netto leieinntekt deles på et avkastningskrav, og diskontert kontantstrøm (DCF), der fremtidige kontantstrømmer neddiskonteres. Begge forankres i lokale markedstall — for Bodø en prime yield rundt 6,35 prosent og kontorleie rundt 2 400 kr/m²/år ifølge Analyseportalen (Q4 2025)."
+    answer: "Verdivurdering i Bodø bygger på to metoder som krysspeiler hverandre: yield-basert kapitalisering, der netto leieinntekt deles på et avkastningskrav, og diskontert kontantstrøm (DCF), der fremtidige kontantstrømmer neddiskonteres. Begge forankres i lokale markedstall — for Bodø en prime yield rundt 6,35 prosent og kontorleie rundt 3 002 kr/m²/år ifølge Analyseportalen (Q4 2025)."
   - question: "Hva er prime yield i Bodø?"
     answer: "Prime yield i Bodø ligger på rundt 6,35 prosent ifølge Analyseportalen (Q4 2025). Prime yield gjelder de beste eiendommene — sentral beliggenhet, solide leietakere og lange kontrakter — og er gulvet i markedet. Eiendommer med mer risiko verdsettes med høyere avkastningskrav, altså lavere verdi per krone leieinntekt. Tallene endres kvartalsvis."
   - question: "Hvorfor betyr yield-valget så mye for verdien?"
@@ -49,12 +49,12 @@ Det som gjør vurderingen *lokal*, er forutsetningene. For Bodø henter vi to n�
 <StatStrip
   items={[
     { value: "6,35", unit: "%", label: "Prime yield, Bodø" },
-    { value: "2 400", unit: "kr/m²/år", label: "Kontorleie, Bodø" },
+    { value: "3 002", unit: "kr/m²/år", label: "Kontorleie, Bodø" },
     { value: "4,6", unit: "%", label: "Kontorledighet, Bodø" }
   ]}
 />
 
-Prime yield på 6,35 prosent gjelder de beste eiendommene — sentral beliggenhet, solide leietakere og lange kontrakter. Det er gulvet i markedet; eiendommer med mer risiko verdsettes med et høyere avkastningskrav og dermed lavere verdi per krone leieinntekt. Kontorleien på 2 400 kr/m²/år er utgangspunktet for å normalisere inntektssiden, mens en lav ledighet på 4,6 prosent forteller at kontormarkedet i Bodø er relativt stramt.
+Prime yield på 6,35 prosent gjelder de beste eiendommene — sentral beliggenhet, solide leietakere og lange kontrakter. Det er gulvet i markedet; eiendommer med mer risiko verdsettes med et høyere avkastningskrav og dermed lavere verdi per krone leieinntekt. Kontorleien på 3 002 kr/m²/år er utgangspunktet for å normalisere inntektssiden, mens en lav ledighet på 4,6 prosent forteller at kontormarkedet i Bodø er relativt stramt.
 
 <Note variant="caution">
   Tallene over er per Q4 2025 fra Analyseportalen og endres kvartalsvis. Bruk dem som utgangspunkt, men hent alltid ferske tall fra [analyseportalen](/analyseportal) før en faktisk vurdering. Transaksjonseksempelet lenger nede er en anonymisert illustrasjon, ikke en konkret eiendom.
@@ -62,15 +62,15 @@ Prime yield på 6,35 prosent gjelder de beste eiendommene — sentral beliggenhe
 
 ## Et yield-basert regneeksempel
 
-La oss verdsette et tenkt kontorbygg i Bodø sentrum på 4 200 m². Vi bruker kontorleien på 2 400 kr/m²/år som markedsinput, trekker fra et normalisert nivå for eier- og driftskostnader, og kapitaliserer netto leieinntekt med prime yield på 6,35 prosent.
+La oss verdsette et tenkt kontorbygg i Bodø sentrum på 4 200 m². Vi bruker kontorleien på 3 002 kr/m²/år som markedsinput, trekker fra et normalisert nivå for eier- og driftskostnader, og kapitaliserer netto leieinntekt med prime yield på 6,35 prosent.
 
 <Example
   title="Yield-basert verdi — kontorbygg Bodø sentrum (illustrativt)"
   steps={[
     {
       label: "Brutto leieinntekt",
-      value: "10 080 000",
-      calculation: "4 200 m² × 2 400 kr/m²/år"
+      value: "12 608 400",
+      calculation: "4 200 m² × 3 002 kr/m²/år"
     },
     {
       label: "Eierkostnader (anslag)",
@@ -79,19 +79,19 @@ La oss verdsette et tenkt kontorbygg i Bodø sentrum på 4 200 m². Vi bruker ko
     },
     {
       label: "Netto leieinntekt (NOI)",
-      value: "9 000 000",
+      value: "11 528 400",
       calculation: "Grunnlag for kapitalisering"
     },
     {
       label: "Markedsverdi",
-      value: "141 700 000",
-      calculation: "9 000 000 ÷ 6,35 %",
+      value: "181 500 000",
+      calculation: "11 528 400 ÷ 6,35 %",
       isResult: true
     }
   ]}
 />
 
-Tallene for areal og leie er hentet fra markedet, mens kostnadsanslaget er en illustrasjon — i en reell vurdering bygges det opp post for post fra regnskap og budsjett. Poenget er hvor mye yield-valget styrer resultatet: hadde vi brukt 6,85 prosent i stedet for 6,35 prosent, ville verdien falt fra rundt 142 til om lag 131 mnok. Et halvt prosentpoeng flytter altså verdien med over ti millioner.
+Tallene for areal og leie er hentet fra markedet, mens kostnadsanslaget er en illustrasjon — i en reell vurdering bygges det opp post for post fra regnskap og budsjett. Poenget er hvor mye yield-valget styrer resultatet: hadde vi brukt 6,85 prosent i stedet for 6,35 prosent, ville verdien falt fra rundt 182 til om lag 168 mnok. Et halvt prosentpoeng flytter altså verdien med over ti millioner.
 
 ## Yield må forankres i faktiske handler
 


### PR DESCRIPTION
Konsistens-sweep etter at prime kontorleie ble re-ankret (PR #86). 14 hjelpe-/blogg-artikler siterte de gamle tallene (Bodø 2 400, Tromsø 2 950, osv.) — nå rettet.

## Endringer
- **Tall oppdatert** til nye prime-nivåer: kontor Tromsø 3 003 / Bodø 3 002 / Harstad 2 600 / Alta 2 675 / Narvik 2 545 / Mo 2 475; handel + logistikk for mindre byer tilsvarende.
- **Narrativ reframet** der gamle relasjoner brøt:
  - Tromsø ≈ Bodø på kontor (~3 000) — ikke lenger «Tromsø høyest».
  - Moderat spenn (~500 kr) i stedet for «over 1 200 kr».
  - Ledighetsforskjell Tromsø/Bodø forklart av markedsdybde, ikke leie-gap.
- **DCF-eksempel regnet om** (verdivurdering-bodo): 4 200 m² × 3 002 → NOI 11 528 400 → ÷ 6,35 % = 181,5 mnok.

## Uendret
yield-%, ledighet-%, Bodø/Tromsø handel (3 135/3 635) + logistikk (1 405/1 655), arealer, årstall.

## Verifisert
MDX kompilerer, DCF-matematikk sjekket, narrativ-reframing spot-sjekket. 2 filer korrekt urørt (false positives: energikostnader/årstall).

🤖 Generated with [Claude Code](https://claude.com/claude-code)