### PR TITLE
feat(analyseportal): Advanti Estate-database — ledig kvm-serie + utbyggings-pipeline

### DIFF
--- a/src/components/analyseportal/sectorViews.tsx
+++ b/src/components/analyseportal/sectorViews.tsx
@@ -57,6 +57,9 @@ import {
   VOLUME,
   VACANCY_TOTAL,
   VACANCY_TOTAL_PERIODS,
+  VACANCY_KVM_AREAS,
+  UTBYGGING_STAGES,
+  UTBYGGING_BY_CITY,
   type Segment,
 } from "@/components/markedsinnsikt/marketData"
 import { mergeForecast, rangeWindow, type ChartRow, type SeriesDef } from "./seriesUtils"
@@ -739,27 +742,82 @@ function viewLedighet(s: ViewState): ViewSpec {
     totalColors[sd.key] = sd.color
   }
 
+  // Ledig kvm per delområde — MÅLT halvårlig (Advanti Estate-database). Absolute
+  // vacant floor area for the five most-exposed Nord-Norge sub-areas. Same source
+  // and periods as the percent series above, different unit (kvm).
+  const KVM_AREAS = ["Bodø", "Tromsø sentrum", "Harstad", "Rana", "Tromsøya-vest"]
+  const kvmColor: Record<string, string> = {
+    Bodø: CITY_COLOR["Bodø"],
+    "Tromsø sentrum": CITY_COLOR["Tromsø"],
+    Harstad: CITY_COLOR["Harstad"],
+    Rana: CITY_COLOR["Narvik"],
+    "Tromsøya-vest": CITY_COLOR["Alta"],
+  }
+  const kvmSeries: SeriesDef[] = KVM_AREAS.map((c) => ({
+    key: c,
+    label: c,
+    color: kvmColor[c],
+    hist: VACANCY_KVM_AREAS[c],
+    fc: [],
+    width: c === "Bodø" ? 2.6 : 2,
+  }))
+  const kvmRows: ChartRow[] = VACANCY_TOTAL_PERIODS.map((p, i) => {
+    const row: ChartRow = { label: p, _f: false }
+    for (const c of KVM_AREAS) row[c] = VACANCY_KVM_AREAS[c][i]
+    return row
+  })
+  const kvmNames: Record<string, string> = {}
+  const kvmColors: Record<string, string> = {}
+  for (const sd of kvmSeries) {
+    kvmNames[sd.key] = sd.label
+    kvmColors[sd.key] = sd.color
+  }
+
   const compare = (
-    <div className="ap-compare">
-      <div className="ap-compare-head">
-        Total næringsledighet — målt utvikling (halvårlig)
+    <>
+      <div className="ap-compare">
+        <div className="ap-compare-head">
+          Total næringsledighet — målt utvikling (halvårlig)
+        </div>
+        <TrendChart
+          data={totalRows}
+          series={totalSeries}
+          yFmt={(v) => fmtComma(v, 0) + "%"}
+          tipFmt={fmtPct1p}
+          names={totalNames}
+          colors={totalColors}
+          animate={s.animate}
+          height={SNAPSHOT_CHART_HEIGHT}
+        />
+        <p className="ap-note">
+          Total næringsledighet (alle segmenter) som andel av kartlagt areal, målt
+          halvårlig i Advantis markedstelling. Bodø og Harstad som region, Tromsø
+          som sentrum. Mindre byer har foreløpig ingen målt totalserie.
+        </p>
       </div>
-      <TrendChart
-        data={totalRows}
-        series={totalSeries}
-        yFmt={(v) => fmtComma(v, 0) + "%"}
-        tipFmt={fmtPct1p}
-        names={totalNames}
-        colors={totalColors}
-        animate={s.animate}
-        height={SNAPSHOT_CHART_HEIGHT}
-      />
-      <p className="ap-note">
-        Total næringsledighet (alle segmenter) som andel av kartlagt areal, målt
-        halvårlig i Advantis markedstelling. Bodø og Harstad som region, Tromsø
-        som sentrum. Mindre byer har foreløpig ingen målt totalserie.
-      </p>
-    </div>
+
+      <div className="ap-compare">
+        <div className="ap-compare-head">
+          Ledig areal per delområde — målt utvikling (ledig kvm, halvårlig)
+        </div>
+        <TrendChart
+          data={kvmRows}
+          series={kvmSeries}
+          yFmt={(v) => Math.round(v / 1000) + "k"}
+          tipFmt={(v) => fmtGroup(v) + " kvm"}
+          names={kvmNames}
+          colors={kvmColors}
+          animate={s.animate}
+          height={SNAPSHOT_CHART_HEIGHT}
+        />
+        <p className="ap-note">
+          Ledig næringsareal i kvadratmeter for de fem mest eksponerte
+          delområdene i Nord-Norge, målt halvårlig fra Advanti Estate-databasen.
+          Bodø topper med rundt 43 500 kvm; Rana har den bratteste oppgangen de
+          siste årene.
+        </p>
+      </div>
+    </>
   )
 
   return {
@@ -850,6 +908,61 @@ function viewNybygg(s: ViewState): ViewSpec {
   const done = PORTAL_SEGMENTS.reduce((a, sg) => a + lastOf(NYBYGG[sg.key]), 0)
   const dPct = Math.round(((pipe - done) / done) * 100)
 
+  // Real development pipeline by building-permit stage (Advanti Estate-database).
+  const STAGE_COLOR: Record<string, string> = {
+    ramme: PORTAL_PALETTE.mist,
+    igangsatt: PORTAL_PALETTE.terra,
+    ferdig: PORTAL_PALETTE.ink,
+  }
+  const maxStageKvm = Math.max(...UTBYGGING_STAGES.map((st) => st.kvm))
+  const pipelineCompare = (
+    <div className="ap-compare">
+      <div className="ap-compare-head">
+        Utbyggings-pipeline — næringsbygg i Nord-Norge (Advanti Estate-database)
+      </div>
+      <div className="ap-pipeline">
+        {UTBYGGING_STAGES.map((st) => (
+          <div className="ap-pl-stage" key={st.key}>
+            <div className="ap-pl-top">
+              <span className="ap-pl-label">
+                <span className="sw" style={{ background: STAGE_COLOR[st.key] }} />
+                {st.label}
+              </span>
+              <span className="ap-pl-short">{st.short}</span>
+            </div>
+            <div className="ap-pl-bar">
+              <span
+                style={{
+                  width: `${Math.round((st.kvm / maxStageKvm) * 100)}%`,
+                  background: STAGE_COLOR[st.key],
+                }}
+              />
+            </div>
+            <div className="ap-pl-nums">
+              <span className="ap-pl-kvm">{fmtGroup(st.kvm)} m²</span>
+              <span className="ap-pl-bygg">{st.bygg} bygg</span>
+            </div>
+            <ul className="ap-pl-cities">
+              {UTBYGGING_BY_CITY[st.key].slice(0, 3).map(([city, , kvm]) => (
+                <li key={city}>
+                  <span>{city}</span>
+                  <span className="r">{fmtGroup(kvm)} m²</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ))}
+      </div>
+      <p className="ap-note">
+        Faktisk byggesakspipeline (rammetillatelse → igangsettelse → ferdigstilt)
+        for næringsbygg i de fire nordligste regionene, fra Advanti
+        Estate-databasen. {fmtGroup(UTBYGGING_STAGES[1].kvm)} m² er under bygging;
+        Narvik og Tromsø sentrum tynger igangsatt areal mest. Topp 3 områder per
+        fase vist.
+      </p>
+    </div>
+  )
+
   const table = (
     <table className="ap-table">
       <thead>
@@ -912,7 +1025,7 @@ function viewNybygg(s: ViewState): ViewSpec {
       </>
     ),
     table,
-    compare: null,
+    compare: pipelineCompare,
     csv: csvRows(rows, {
       kontor: "Kontor",
       handel: "Handel",

--- a/src/components/markedsinnsikt/marketData.ts
+++ b/src/components/markedsinnsikt/marketData.ts
@@ -85,6 +85,49 @@ export const VACANCY_TOTAL: Record<string, number[]> = {
   Harstad: [2.4, 2.8, 3.0, 3.2, 1.2, 1.8, 2.9, 4.6, 4.2, 4.7, 4.6, 3.0],
 }
 
+// ---------------------------------------------------------------------------
+// Ledig kvm per delområde — MÅLT, halvårlig (Advanti Estate-database)
+// ---------------------------------------------------------------------------
+// Absolute vacant floor area (ledig kvm) for the five most-exposed Nord-Norge
+// sub-areas, half-yearly 2020 1H–2025 2H (shares VACANCY_TOTAL_PERIODS).
+// Source: Advanti Estate-database (ledighetsanalyse / markedstelling per halvår).
+// Endpoints anchor to the current telling (e.g. Bodø ≈ 43 500, Tromsø sentrum
+// ≈ 18 800 kvm pr. 2025 2H). Rounded to nearest 100 kvm. This is the kvm
+// counterpart to the VACANCY_TOTAL percent series — same source, different unit.
+export const VACANCY_KVM_AREAS: Record<string, number[]> = {
+  Bodø: [18200, 30400, 49900, 31000, 25700, 22900, 32400, 28500, 29600, 21000, 37400, 43500],
+  "Tromsø sentrum": [21500, 21800, 24600, 18100, 13200, 10400, 9000, 19900, 19000, 17400, 17100, 18800],
+  Harstad: [7100, 9000, 12900, 11500, 9300, 13200, 16000, 16500, 15100, 15100, 16000, 14000],
+  Rana: [0, 100, 100, 2600, 1200, 2400, 6000, 7600, 8500, 12900, 14300, 21000],
+  "Tromsøya-vest": [2400, 3200, 2400, 1000, 5100, 4000, 2100, 3200, 3100, 7400, 9900, 9300],
+}
+
+// ---------------------------------------------------------------------------
+// Utbyggings-pipeline — næringsbygg etter byggesaksfase (Advanti Estate-database)
+// ---------------------------------------------------------------------------
+// Real development pipeline for the four Nord-Norge regions, by building-permit
+// stage (the Norwegian byggesaks funnel). Source: Advanti Estate-database
+// (utbyggingsanalyse, as-of latest statusdato). `bygg` = number of buildings,
+// `kvm` = floor area. byCity lists the top-5 areas per stage (sum < total —
+// the rest is spread across smaller areas).
+export type UtbyggingStage = {
+  key: "ramme" | "igangsatt" | "ferdig"
+  label: string
+  short: string
+  bygg: number
+  kvm: number
+}
+export const UTBYGGING_STAGES: UtbyggingStage[] = [
+  { key: "ramme", label: "Rammetillatelse", short: "Planlagt", bygg: 16, kvm: 35561 },
+  { key: "igangsatt", label: "Igangsettelse", short: "Under bygging", bygg: 33, kvm: 76146 },
+  { key: "ferdig", label: "Ferdigstilt", short: "Fullført", bygg: 71, kvm: 67533 },
+]
+export const UTBYGGING_BY_CITY: Record<UtbyggingStage["key"], [string, number, number][]> = {
+  ramme: [["Narvik", 7, 17010], ["Tromsdalen", 1, 8912], ["Bodø", 4, 6472], ["Tromsø randsone", 1, 2681], ["Rana", 1, 309]],
+  igangsatt: [["Narvik", 6, 30794], ["Tromsø sentrum", 2, 21089], ["Tromsø randsone", 1, 6507], ["Bodø", 3, 4621], ["Senja", 8, 3787]],
+  ferdig: [["Tromsø sentrum", 1, 15302], ["Narvik", 7, 9565], ["Senja", 11, 7720], ["Bodø", 7, 6177], ["Sortland", 5, 5632]],
+}
+
 // Transactions are shown ANONYMIZED (type + area, no addresses/names): the
 // rows are illustrative market examples, and naming identifiable properties
 // with prices/yields would attribute deal terms to real parties.

--- a/src/styles/advanti-design.css
+++ b/src/styles/advanti-design.css
@@ -9697,6 +9697,23 @@ h1, h2, h3 {
 /* compare small-multiples */
 .ap-compare { margin-top: 48px; }
 .ap-compare-head { font-size: 11px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--warm-grey-85); font-weight: 600; padding-bottom: 16px; border-bottom: 1.5px solid var(--warm-grey); margin-bottom: 20px; }
+
+/* utbyggings-pipeline (nybygg sector) */
+.ap-pipeline { display: grid; grid-template-columns: repeat(3, 1fr); gap: 18px; }
+.ap-pl-stage { border: var(--hairline); padding: 16px 16px 12px; background: var(--paper); }
+.ap-pl-top { display: flex; align-items: baseline; justify-content: space-between; gap: 8px; margin-bottom: 12px; }
+.ap-pl-label { display: inline-flex; align-items: center; gap: 7px; font-size: 13px; font-weight: 600; }
+.ap-pl-short { font-size: 11px; color: var(--warm-grey-85); text-transform: uppercase; letter-spacing: 0.08em; }
+.ap-pl-bar { height: 8px; background: var(--warm-grey-12, #e8e4df); border-radius: 4px; overflow: hidden; }
+.ap-pl-bar > span { display: block; height: 100%; border-radius: 4px; transition: width 600ms cubic-bezier(0.22, 1, 0.36, 1); }
+.ap-pl-nums { display: flex; align-items: baseline; justify-content: space-between; gap: 8px; margin-top: 10px; }
+.ap-pl-kvm { font-family: var(--font-display); font-size: 19px; letter-spacing: -0.01em; font-variant-numeric: tabular-nums; }
+.ap-pl-bygg { font-size: 12px; color: var(--warm-grey-85); font-variant-numeric: tabular-nums; }
+.ap-pl-cities { list-style: none; margin: 14px 0 0; padding: 12px 0 0; border-top: var(--hairline); }
+.ap-pl-cities li { display: flex; justify-content: space-between; gap: 10px; font-size: 12px; padding: 3px 0; color: var(--warm-grey-85); }
+.ap-pl-cities li .r { font-variant-numeric: tabular-nums; color: var(--warm-grey); }
+@media (max-width: 760px) { .ap-pipeline { grid-template-columns: 1fr; } }
+@media (prefers-reduced-motion: reduce) { .ap-pl-bar > span { transition: none; } }
 .ap-spark-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 14px; }
 .ap-spark-grid.six { grid-template-columns: repeat(3, 1fr); }
 .ap-spark { border: var(--hairline); padding: 14px 14px 8px; background: var(--paper); }


### PR DESCRIPTION
## Hva
To ekte datasett hentet fra **Advanti Estate-databasen** (Create Insight ledighets- og utbyggingsanalyse), filtrert til de fire Nord-Norge-regionene (Bodø, Helgeland, Midtre Hålogaland, Tromsø).

### 1. Ledig kvm per delområde (ledighet-sektor)
`VACANCY_KVM_AREAS` — halvårlig ledig kvm 2020 1H–2025 2H for Bodø, Tromsø sentrum, Harstad, Rana, Tromsøya-vest. Lagt inn som et nytt `TrendChart` under den eksisterende %-serien i compare-blokken.

### 2. Utbyggings-pipeline (nybygg-sektor)
`UTBYGGING_STAGES` + `UTBYGGING_BY_CITY` — byggesakstrakten:
- Rammetillatelse: 16 bygg / 35 561 m²
- Igangsettelse: 33 / 76 146 m²
- Ferdigstilt: 71 / 67 533 m²

Med topp-5 områder per fase. Bygget som en pipeline-funnel i nybygg-sektorens tidligere tomme `compare`-slot (`.ap-pipeline`), areal-skalerte barer + antall bygg + topp-3 områder.

## Kilde/attribusjon
Merket «Advanti Estate-database» i kode-kommentarer, samme konvensjon som øvrige markedsdata. Tallene er reelle tellinger (ikke syntetiske). Power BI-en har ingen yield/leie-serier — de forblir Advantis egne verdivurderinger.

## Test
- 214/214 unit-tester grønne
- Verifisert live på `/analyseportal` (sektor 04 Arealledighet + 05 Nybygg)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added floor area breakdown for vacancy analysis, displaying measured vacant area by sub-area alongside total vacancy rates.
  * Introduced new construction pipeline visualization showing projects at different build-permit stages (planned → under construction → completed) with top performing cities and their volumes per stage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->