### PR TITLE
fix(seo): redirect død person-URL + vercel.app-alias til www

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -28,6 +28,21 @@ const nextConfig = {
         permanent: true,
       },
       {
+        // The production *.vercel.app alias serves the same content as the
+        // custom domain — keep it out of the index by sending it to www.
+        // Exact host match: per-commit preview deploys use a different host
+        // (advantiestate-git-*.vercel.app) and are unaffected, so previews work.
+        source: "/:path*",
+        has: [
+          {
+            type: "host",
+            value: "advantiestate.vercel.app",
+          },
+        ],
+        destination: "https://www.advantiestate.no/:path*",
+        permanent: true,
+      },
+      {
         source: "/tjenester/verdsettelse",
         destination: "/tjenester/verdivurdering",
         permanent: true,
@@ -105,6 +120,13 @@ const nextConfig = {
         source:
           "/kunder/hvordan-vi-hjalp-en-investor-realisere-25-hoyere-avkastning",
         destination: "/kunder/investor-avkastning",
+        permanent: true,
+      },
+      {
+        // Removed team member (no longer with the company). The page 404s but
+        // Google still has the URL indexed — send it to the team listing.
+        source: "/personer/thomas-knutsen-johansen",
+        destination: "/personer",
         permanent: true,
       },
     ];


### PR DESCRIPTION
Rydder de to reelle funnene fra Search Console / GTM tag-coverage (resten av «Not tagged»-rapporten var foreldede crawls + selve preview-domenet).

### Endringer (`next.config.mjs`)
| Redirect | Fra | Til | Hvorfor |
|---|---|---|---|
| 301 | `/personer/thomas-knutsen-johansen` | `/personer` | Ansatt sluttet; siden 404-er men er fortsatt indeksert av Google |
| 301 | host `advantiestate.vercel.app/*` | `https://www.advantiestate.no/*` | Produksjons-aliaset serverte samme innhold og ble crawlet → ut av indeksen |

Vercel-redirecten speiler det eksisterende apex-host-mønsteret (`advantiestate.no` → www). **Eksakt host-match** betyr at per-commit preview-deploys (`advantiestate-git-*.vercel.app`) er upåvirket — previews fungerer som før.

### Verifisering
- ✅ `pnpm build` grønn · `pnpm lint` grønn
- ⏳ Etter deploy: `curl -I https://advantiestate.vercel.app/` skal gi 308 → www; `/personer/thomas-knutsen-johansen` skal gi 308 → /personer

### Ikke i denne PR-en
GTM «Add another administrator» er en konto-handling i tagmanager.google.com (kun eier kan gjøre den).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added permanent URL redirects for domain consolidation
  * Redirects removed team member profile to team listing page

<!-- end of auto-generated comment: release notes by coderabbit.ai -->