### PR TITLE
feat: shadcn typeset on blog/help/location prose + error-message audit WIP

### DIFF
--- a/src/app/(blog)/blog/(index)/category/[slug]/page.tsx
+++ b/src/app/(blog)/blog/(index)/category/[slug]/page.tsx
@@ -138,7 +138,9 @@ export default async function BlogCategory({
           {articles.length === 0 && (
             <p className="mi-footnote" style={{ borderTop: 0 }}>
               <span className="source">
-                Ingen artikler i denne kategorien ennå. Kom tilbake snart.
+                Ingen artikler i denne kategorien ennå. Se{" "}
+                <Link href="/blog">alle innleggene i bloggen</Link> mens vi
+                fyller på.
               </span>
             </p>
           )}

--- a/src/app/(blog)/blog/(post)/[slug]/page.tsx
+++ b/src/app/(blog)/blog/(post)/[slug]/page.tsx
@@ -243,6 +243,7 @@ export default async function BlogArticle({
           <div className="ks-article">
             <article className="ks-art-body" id="art-main">
               <MDX
+                typography="typeset"
                 code={data.mdx}
                 images={images.map((image) => ({
                   ...image,

--- a/src/app/(help)/help/article/[slug]/page.tsx
+++ b/src/app/(help)/help/article/[slug]/page.tsx
@@ -226,7 +226,7 @@ export default async function HelpArticle({
                 </div>
               )}
 
-              <MDX code={data.mdx} images={images} />
+              <MDX typography="typeset" code={data.mdx} images={images} />
 
               {data.faq && data.faq.length >= 2 && (
                 <div className="ks-faq">

--- a/src/app/(help)/help/category/[slug]/page.tsx
+++ b/src/app/(help)/help/category/[slug]/page.tsx
@@ -136,7 +136,8 @@ export default async function HelpCategory({
           {/* ARTICLES LIST */}
           {articles.length === 0 ? (
             <p className="ks-art-lede">
-              Ingen artikler i denne kategorien ennå. Kom tilbake snart.
+              Ingen artikler i denne kategorien ennå. Se{" "}
+              <Link href="/help">hele hjelpesenteret</Link> mens vi fyller på.
             </p>
           ) : (
             <div className="ks-articles">

--- a/src/app/(help)/help/not-found.tsx
+++ b/src/app/(help)/help/not-found.tsx
@@ -5,12 +5,12 @@ export default function NotFound() {
     <div className="flex min-h-screen flex-col items-center justify-center gap-8">
       <h1 className="font-display text-6xl font-bold">404</h1>
       <p className="text-2xl font-medium">
-        Page not found. Back to{" "}
+        Vi fant ikke siden du leter etter. Tilbake til{" "}
         <Link
           href="/help"
           className="text-gray-600 underline underline-offset-4 transition-colors hover:text-black"
         >
-          Help Center
+          Hjelpesenteret
         </Link>
         .
       </p>

--- a/src/app/actions/naringsmegler-lead.ts
+++ b/src/app/actions/naringsmegler-lead.ts
@@ -62,7 +62,7 @@ export async function submitCityLead(
     return { ok: false, error: "Fyll ut navn, telefon og e-post." }
   }
   if (type && !(PROPERTY_TYPES as readonly string[]).includes(type)) {
-    return { ok: false, error: "Ugyldig eiendomstype." }
+    return { ok: false, error: "Velg en gyldig eiendomstype fra listen." }
   }
 
   const result = await subscribe({

--- a/src/app/actions/verdivurdering-intake.ts
+++ b/src/app/actions/verdivurdering-intake.ts
@@ -53,7 +53,10 @@ export async function subscribeVerdivurderingIntake(
     intakeSource: String(formData.get("intakeSource") ?? ""),
   })
   if (!parsed.success) {
-    return { ok: false, error: "Fyll ut alle påkrevde felt." }
+    return {
+      ok: false,
+      error: "Fyll ut e-post, eiendomstype, sted og formål for å sende forespørselen.",
+    }
   }
   const d = parsed.data
 

--- a/src/app/api/og/blog/[slug]/route.tsx
+++ b/src/app/api/og/blog/[slug]/route.tsx
@@ -94,6 +94,6 @@ export async function GET(
   } catch (e: unknown) {
     const msg = e instanceof Error ? e.message : "unknown"
     console.error(`Failed to generate blog OG image: ${msg}`)
-    return new Response(`Failed to generate OG image: ${msg}`, { status: 500 })
+    return new Response("Kunne ikke generere bildet.", { status: 500 })
   }
 }

--- a/src/app/api/og/brand/route.tsx
+++ b/src/app/api/og/brand/route.tsx
@@ -29,6 +29,6 @@ export async function GET() {
   } catch (e: unknown) {
     const msg = e instanceof Error ? e.message : "unknown"
     console.error(`Failed to generate brand OG image: ${msg}`)
-    return new Response(`Failed to generate OG image: ${msg}`, { status: 500 })
+    return new Response("Kunne ikke generere bildet.", { status: 500 })
   }
 }

--- a/src/app/api/og/help/route.tsx
+++ b/src/app/api/og/help/route.tsx
@@ -8,9 +8,10 @@ export async function GET(req: NextRequest) {
   try {
     const { searchParams } = new URL(req.url)
 
-    const title = searchParams.get("title") || "Help Center"
+    const title = searchParams.get("title") || "Kunnskapsbase"
     const summary =
-      searchParams.get("summary") || "Learn more about our platform"
+      searchParams.get("summary") ||
+      "Lær mer om Advanti og næringseiendom i Nord-Norge."
 
     return new ImageResponse(
       (
@@ -113,7 +114,7 @@ export async function GET(req: NextRequest) {
     )
   } catch (e: any) {
     console.error(`Failed to generate OG image: ${e.message}`)
-    return new Response(`Failed to generate OG image: ${e.message}`, {
+    return new Response("Kunne ikke generere bildet.", {
       status: 500,
     })
   }

--- a/src/app/api/og/listing/[slug]/route.tsx
+++ b/src/app/api/og/listing/[slug]/route.tsx
@@ -123,6 +123,6 @@ export async function GET(
   } catch (e: unknown) {
     const msg = e instanceof Error ? e.message : "unknown";
     console.error(`Failed to generate listing OG image: ${msg}`);
-    return new Response(`Failed to generate OG image: ${msg}`, { status: 500 });
+    return new Response("Kunne ikke generere bildet.", { status: 500 });
   }
 }

--- a/src/app/api/og/marked/[by]/route.tsx
+++ b/src/app/api/og/marked/[by]/route.tsx
@@ -44,7 +44,7 @@ export async function GET(
   // user-controlled text is ever rendered into the credited graphic.
   const city = LATEST_RELEASE.cities.find((c) => c.id === by)
   if (!city) {
-    return new Response("Not found", { status: 404 })
+    return new Response("Fant ikke byen.", { status: 404 })
   }
 
   // All display strings derived from validated numeric city data (never raw param).
@@ -361,6 +361,6 @@ export async function GET(
   } catch (e: unknown) {
     const msg = e instanceof Error ? e.message : "unknown"
     console.error(`Failed to generate market OG image for "${by}": ${msg}`)
-    return new Response(`Failed to generate OG image: ${msg}`, { status: 500 })
+    return new Response("Kunne ikke generere bildet.", { status: 500 })
   }
 }

--- a/src/app/eiendommer/dokument/[id]/route.ts
+++ b/src/app/eiendommer/dokument/[id]/route.ts
@@ -25,7 +25,10 @@ export async function GET(
 ) {
   const { id } = await params
   const supabase = getSupabase()
-  if (!supabase) return new NextResponse("Not available", { status: 503 })
+  if (!supabase) return new NextResponse(
+      "Tjenesten er midlertidig utilgjengelig. Prøv igjen om litt, eller ring oss på +47 984 53 571.",
+      { status: 503 },
+    )
 
   const { data } = await supabase
     .from("crm_property_listing_downloads")
@@ -39,11 +42,17 @@ export async function GET(
 
   // Open, published downloads only — never NDA rows, never unapproved/missing.
   if (!row || !row.public_approved || row.requires_nda || !row.storage_path) {
-    return new NextResponse("Not found", { status: 404 })
+    return new NextResponse(
+      "Dokumentet er ikke tilgjengelig. Det kan være fjernet, eller det krever en signert avtale. Ring oss på +47 984 53 571, så hjelper vi deg.",
+      { status: 404 },
+    )
   }
 
   const base = (process.env.SUPABASE_URL ?? "").replace(/\/+$/, "")
-  if (!base) return new NextResponse("Not available", { status: 503 })
+  if (!base) return new NextResponse(
+      "Tjenesten er midlertidig utilgjengelig. Prøv igjen om litt, eller ring oss på +47 984 53 571.",
+      { status: 503 },
+    )
   const url = `${base}/storage/v1/object/public/${PUBLIC_BUCKET}/${row.storage_path}`
 
   return NextResponse.redirect(url, {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,10 +2,20 @@
    Imported first so Tailwind base/components/utilities cascade after it;
    page layout uses the design's semantic classes, utilities win one-off tweaks. */
 @import "../styles/advanti-design.css";
+@import "./typeset.css";
 
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+.typeset-docs {
+  --typeset-font-body: var(--font-geist);
+  --typeset-font-heading: var(--font-geist);
+  --typeset-font-mono: var(--font-geist-mono);
+  --typeset-size: 15px;
+  --typeset-leading: 1.75;
+  --typeset-flow: 1.25em;
+}
 
 @layer base {
   :root {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,7 +7,7 @@ import { Nav } from "@/components/site/Nav";
 import { navGroups } from "@/lib/navigation";
 import { baseMetadata } from "@/lib/utils";
 import type { Viewport } from "next";
-import { Inter } from "next/font/google";
+import { Geist, Geist_Mono, Inter } from "next/font/google";
 import StructuredData from "@/components/StructuredData";
 import "./globals.css";
 
@@ -19,6 +19,18 @@ const inter = Inter({
   display: "swap",
   style: ["normal", "italic"],
   variable: "--font-inter",
+});
+
+// typeset (shadcn) fonts — only consumed inside .typeset-docs containers,
+// site-wide type stays on Inter per DESIGN.md.
+const geist = Geist({
+  subsets: ["latin"],
+  variable: "--font-geist",
+});
+
+const geistMono = Geist_Mono({
+  subsets: ["latin"],
+  variable: "--font-geist-mono",
 });
 
 // Site-wide metadata defaults. Every real page overrides these via
@@ -37,7 +49,7 @@ export default async function RootLayout({
   return (
     <html
       lang="nb"
-      className={inter.variable}
+      className={`${inter.variable} ${geist.variable} ${geistMono.variable}`}
       data-scroll-behavior="smooth"
     >
       <head>

--- a/src/app/presserom/FargeKopier.tsx
+++ b/src/app/presserom/FargeKopier.tsx
@@ -23,7 +23,9 @@ export function FargeKopier() {
       await navigator.clipboard.writeText(hex)
       melding = `${hex} kopiert`
     } catch {
-      // clipboard avslått — vis HEX-koden i toasten så den kan skrives av
+      // clipboard avslått — si fra at den ikke ble kopiert, og vis HEX-koden
+      // så den kan skrives av manuelt
+      melding = `Kopier manuelt: ${hex}`
     }
     setToast(melding)
     if (timer.current) clearTimeout(timer.current)

--- a/src/app/typeset.css
+++ b/src/app/typeset.css
@@ -3,488 +3,484 @@
  * https://ui.shadcn.com/docs/typeset.
  */
 
-@layer typeset {
-  .typeset {
-    --typeset-font-body: inherit;
-    --typeset-font-heading: var(--font-heading);
-    --typeset-font-mono: var(--font-mono);
-    --typeset-size: 1em;
-    --typeset-leading: 1.75;
-    --typeset-flow: 1.25em;
+.typeset {
+  --typeset-font-body: inherit;
+  --typeset-font-heading: var(--font-heading);
+  --typeset-font-mono: var(--font-mono);
+  --typeset-size: 1em;
+  --typeset-leading: 1.75;
+  --typeset-flow: 1.25em;
+}
+
+.typeset {
+  font-family: var(--typeset-font-body);
+  font-size: calc(var(--typeset-size) * 1.125);
+  line-height: var(--typeset-leading);
+  color: var(--color-foreground, currentColor);
+  overflow-wrap: break-word;
+  margin-trim: block-start;
+
+  @media (min-width: 48rem), print {
+    font-size: var(--typeset-size);
+  }
+
+  --typeset-muted: var(
+    --color-muted-foreground,
+    color-mix(in oklab, currentColor 60%, transparent)
+  );
+  --typeset-rule: var(
+    --color-border,
+    color-mix(in oklab, currentColor 20%, transparent)
+  );
+}
+
+.typeset
+  *:not(
+    :where(
+      .not-typeset,
+      [data-not-typeset],
+      .not-typeset *,
+      [data-not-typeset] *
+    )
+  ) {
+  /* Paragraphs. */
+  &:where(p) {
+    margin-block-start: var(--typeset-flow);
+    margin-block-end: 0;
+  }
+
+  /* Headings. */
+  &:where(h1, h2, h3, h4, h5, h6) {
+    color: var(--color-foreground, currentColor);
+    font-family: var(--typeset-font-heading);
+    font-weight: 600;
+    margin-block-end: 0;
+  }
+  &:where(h1) {
+    font-size: 1.75em;
+    line-height: 1.3;
+    margin-block-start: var(--typeset-flow);
+  }
+  &:where(h2) {
+    font-size: 1.25em;
+    line-height: 1.4;
+    margin-block-start: calc(var(--typeset-flow) * 1.4);
+  }
+  &:where(h3) {
+    font-size: 1.125em;
+    line-height: 1.45;
+    margin-block-start: var(--typeset-flow);
+  }
+  &:where(h4) {
+    font-size: 1em;
+    line-height: 1.5;
+    margin-block-start: var(--typeset-flow);
+  }
+  &:where(h5) {
+    font-size: 0.875em;
+    line-height: 1.5;
+    font-weight: 500;
+    color: var(--typeset-muted);
+    margin-block-start: calc(var(--typeset-flow) / 0.875);
+  }
+  &:where(h6) {
+    font-size: 0.8125em;
+    line-height: 1.5;
+    font-weight: 500;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--typeset-muted);
+    margin-block-start: calc(var(--typeset-flow) / 0.8125);
+  }
+  /* Anchors. */
+  &:where([id]) {
+    scroll-margin-block-start: var(--typeset-flow);
+  }
+
+  /* Headings own the space below them. */
+  &:where(h1 + *, h2 + *, h3 + *, h4 + *, h5 + *, h6 + *) {
+    margin-block-start: 1em;
+  }
+  &:where(:is(h1, h2, h3, h4) :is(code)) {
+    font-size: 0.9em;
+  }
+
+  /* Links. */
+  &:where(a) {
+    color: inherit;
+    font-weight: 500;
+    text-decoration-line: underline;
+    text-decoration-color: color-mix(in oklab, currentColor 30%, transparent);
+  }
+  &:where(a:hover) {
+    text-decoration-color: currentColor;
+  }
+  &:where(a:focus-visible) {
+    outline: 2px solid var(--color-ring, currentColor);
+    outline-offset: 2px;
+    border-radius: 0.125em;
+  }
+  &:where(:is(h1, h2, h3, h4, h5, h6) :is(a)) {
+    font-weight: inherit;
+  }
+
+  /* Inline semantics. */
+  &:where(strong, b) {
+    font-weight: 600;
+  }
+  &:where(:is(h1, h2, h3, h4) :is(strong, b)) {
+    font-weight: 600;
+  }
+  &:where(mark) {
+    background-color: color-mix(
+      in oklab,
+      oklch(0.86 0.17 95) 40%,
+      transparent
+    );
+    color: inherit;
+    padding: 0.05em 0.15em;
+    border-radius: 0.2em;
+  }
+  &:where(abbr[title]) {
+    text-decoration-line: underline;
+    text-decoration-style: dotted;
+    text-underline-offset: 0.2em;
+    cursor: help;
+  }
+  &:where(del, s) {
+    color: var(--typeset-muted);
+    text-decoration-line: line-through;
+  }
+  &:where(sup, sub) {
+    font-size: 0.75em;
+    line-height: 0;
+    position: relative;
+    vertical-align: baseline;
+  }
+  &:where(sup) {
+    top: -0.5em;
+  }
+  &:where(sub) {
+    bottom: -0.25em;
+  }
+  &:where(sup a) {
+    text-decoration-line: none;
+    font-weight: 500;
+  }
+
+  /* Lists. */
+  &:where(ul) {
+    list-style-type: disc;
+  }
+  &:where(ol) {
+    list-style-type: decimal;
+  }
+  &:where(ul ul) {
+    list-style-type: circle;
+  }
+  &:where(ul ul ul) {
+    list-style-type: square;
+  }
+  &:where(ol[type="a" i]) {
+    list-style-type: lower-alpha;
+  }
+  &:where(ol[type="i" i]) {
+    list-style-type: lower-roman;
+  }
+  &:where(ol[type="A" s]) {
+    list-style-type: upper-alpha;
+  }
+  &:where(ol[type="I" s]) {
+    list-style-type: upper-roman;
+  }
+  &:where(ul, ol) {
+    margin-block-start: var(--typeset-flow);
+    margin-block-end: 0;
+    padding-inline-start: 1.5em;
+  }
+  &:where(li) {
+    margin-block-start: 0.5em;
+    padding-inline-start: 0.4em;
+  }
+  &:where(li > p, li > ul, li > ol) {
+    margin-block-start: 0.5em;
+  }
+  &:where(ul > li)::marker {
+    color: var(--typeset-muted);
+  }
+  &:where(ol > li)::marker {
+    color: var(--typeset-muted);
+  }
+
+  /* GFM task lists. */
+  &:where(ul.contains-task-list) {
+    list-style-type: none;
+    padding-inline-start: 0.25em;
+  }
+  &:where(li.task-list-item > input[type="checkbox"]) {
+    margin-inline-end: 0.5em;
+    vertical-align: -0.1em;
+    accent-color: var(--color-primary, currentColor);
+  }
+
+  /* Disclosures. */
+  &:where(details) {
+    margin-block-start: var(--typeset-flow);
+    margin-block-end: 0;
+  }
+  &:where(summary) {
+    cursor: pointer;
+    font-weight: 500;
+  }
+  &:where(summary)::marker {
+    color: var(--typeset-muted);
+  }
+
+  /* Keyboard keys. */
+  &:where(kbd) {
+    font-family: inherit;
+    font-size: 0.85em;
+    font-weight: 500;
+    border: 1px solid var(--typeset-rule);
+    border-block-end-width: 2px;
+    border-radius: min(calc(var(--radius, 0.5em) * 0.6), 0.35em);
+    padding: 0.0625em 0.35em;
+  }
+
+  /* Definition lists. */
+  &:where(dl) {
+    margin-block-start: var(--typeset-flow);
+    margin-block-end: 0;
+  }
+  &:where(dt) {
+    font-weight: 500;
+    margin-block-start: 1em;
+  }
+  &:where(dt + dt) {
+    margin-block-start: 0.25em;
+  }
+  &:where(dd) {
+    margin-block-start: 0.25em;
+    margin-inline-start: 0;
+    padding-inline-start: 1em;
+    color: var(--typeset-muted);
+  }
+
+  /* Inline code. */
+  &:where(:not(pre) > code) {
+    background-color: var(
+      --color-muted,
+      color-mix(in oklab, currentColor 8%, transparent)
+    );
+    font-family: var(--typeset-font-mono);
+    font-size: 0.85em;
+    border-radius: min(calc(var(--radius, 0.5em) * 0.6), 0.35em);
+    padding: 0.125em 0.3em;
+  }
+
+  /* Code blocks. */
+  &:where(pre) {
+    background-color: var(
+      --color-muted,
+      color-mix(in oklab, currentColor 8%, transparent)
+    );
+    font-family: var(--typeset-font-mono);
+    font-size: 0.875em;
+    line-height: 1.5;
+    tab-size: 2;
+    direction: ltr;
+    border-radius: var(--radius, 0.5em);
+    padding: 0.75em 1em;
+    overflow-x: auto;
+    margin-block-start: calc(var(--typeset-flow) / 0.875);
+    margin-block-end: 0;
+  }
+  &:where(pre code) {
+    background-color: transparent;
+    font-family: inherit;
+    font-size: inherit;
+    padding: 0;
+    border-radius: 0;
+  }
+
+  /* Blockquote. */
+  &:where(blockquote) {
+    border-inline-start: 2px solid var(--typeset-rule);
+    padding-inline-start: 1em;
+    margin-block-start: var(--typeset-flow);
+    margin-block-end: 0;
+    margin-inline: 0;
+  }
+
+  /* Dividers. */
+  &:where(hr) {
+    border: 0;
+    border-block-start: 1px solid var(--typeset-rule);
+    margin-block-start: calc(var(--typeset-flow) * 2.4);
+    margin-block-end: 0;
+  }
+  &:where(hr + h1, hr + h2, hr + h3, hr + h4) {
+    margin-block-start: var(--typeset-flow);
+  }
+
+  /* GFM footnotes. */
+  &:where(.footnotes, [data-footnotes]) {
+    margin-block-start: calc(var(--typeset-flow) * 2);
+    border-block-start: 1px solid var(--typeset-rule);
+    padding-block-start: var(--typeset-flow);
+    font-size: 0.875em;
+    color: var(--typeset-muted);
+  }
+
+  /* Math. */
+  &:where(math[display="block"]) {
+    margin-block-start: var(--typeset-flow);
+    margin-block-end: 0;
+    overflow-x: auto;
+    overflow-y: hidden;
+    padding-block: 0.25em;
+  }
+
+  /* Media. */
+  &:where(img, video) {
+    border-radius: var(--radius, 0.5em);
+    max-width: 100%;
+    height: auto;
+    margin-block-start: var(--typeset-flow);
+    margin-block-end: 0;
+  }
+  &:where(p img) {
+    margin-block-start: 0;
+  }
+  &:where(figure) {
+    margin-block-start: var(--typeset-flow);
+    margin-block-end: 0;
+    margin-inline: 0;
+  }
+  &:where(figcaption, caption) {
+    color: var(--typeset-muted);
+    font-size: 0.875em;
+    text-align: center;
+    margin-block-start: calc(0.75em / 0.875);
+  }
+  &:where(caption) {
+    caption-side: bottom;
+  }
+
+  /* Tables. Separators sit on cells, not tr:last-child: append-safe.
+     Bare tables stay real tables (keep their semantics) and wrap to fit. */
+  &:where(table) {
+    max-width: 100%;
+    font-size: 1em;
+    line-height: 1.5;
+    font-variant-numeric: tabular-nums;
+    border-collapse: separate;
+    border-spacing: 0;
+    border-block-end: 1px solid var(--typeset-rule);
+    margin-block-start: var(--typeset-flow);
+    margin-block-end: 0;
+  }
+
+  /* Horizontal scroll for any wide block. Wrap it and the wrapper owns the
+     flow margin. Tables shrink to fit, so widen the table to make it scroll
+     instead of compress. */
+  &:where(.typeset-scroll) {
+    overflow-x: auto;
+    margin-block-start: var(--typeset-flow);
+  }
+  &:where(.typeset-scroll > *) {
+    margin-block-start: 0;
+  }
+  &:where(.typeset-scroll table) {
+    width: max-content;
+    max-width: none;
+  }
+  &:where(thead th) {
+    font-weight: 500;
+    text-align: start;
+    white-space: nowrap;
+    padding: 0.65em 1em;
+  }
+  &:where(:is(tbody, tfoot) :is(td, th)) {
+    padding: 0.75em 1em;
+    text-align: start;
+    vertical-align: top;
+    border-block-start: 1px solid var(--typeset-rule);
+  }
+  &:where(tbody th, tfoot th) {
+    font-weight: 500;
+  }
+  &:where(th:first-child, td:first-child) {
+    padding-inline-start: 0;
+  }
+  &:where(th[align="center"], td[align="center"]) {
+    text-align: center;
+  }
+  &:where(th[align="right"], td[align="right"]) {
+    text-align: end;
+  }
+
+  /* Blocks inside list items keep the list's tighter rhythm. */
+  &:where(li > blockquote, li > table, li > figure) {
+    margin-block-start: 0.5em;
+  }
+  &:where(li > pre) {
+    margin-block-start: calc(0.5em / 0.875);
+  }
+
+  @media print {
+    &:where(pre, table, blockquote, figure) {
+      break-inside: avoid;
+    }
+    &:where(h1, h2, h3, h4) {
+      break-after: avoid;
+    }
+  }
+
+  /* Forced colors strips the code background, so give it a border. */
+  @media (forced-colors: active) {
+    &:where(:not(pre) > code) {
+      border: 1px solid;
+    }
   }
 }
 
-@layer typeset {
-  .typeset {
-    font-family: var(--typeset-font-body);
-    font-size: calc(var(--typeset-size) * 1.125);
-    line-height: var(--typeset-leading);
-    color: var(--color-foreground, currentColor);
-    overflow-wrap: break-word;
-    margin-trim: block-start;
-
-    @media (min-width: 48rem), print {
-      font-size: var(--typeset-size);
-    }
-
-    --typeset-muted: var(
-      --color-muted-foreground,
-      color-mix(in oklab, currentColor 60%, transparent)
-    );
-    --typeset-rule: var(
-      --color-border,
-      color-mix(in oklab, currentColor 20%, transparent)
-    );
-  }
-
-  .typeset
-    *:not(
-      :where(
-        .not-typeset,
-        [data-not-typeset],
-        .not-typeset *,
-        [data-not-typeset] *
-      )
-    ) {
-    /* Paragraphs. */
-    &:where(p) {
-      margin-block-start: var(--typeset-flow);
-      margin-block-end: 0;
-    }
-
-    /* Headings. */
-    &:where(h1, h2, h3, h4, h5, h6) {
-      color: var(--color-foreground, currentColor);
-      font-family: var(--typeset-font-heading);
-      font-weight: 600;
-      margin-block-end: 0;
-    }
-    &:where(h1) {
-      font-size: 1.75em;
-      line-height: 1.3;
-      margin-block-start: var(--typeset-flow);
-    }
-    &:where(h2) {
-      font-size: 1.25em;
-      line-height: 1.4;
-      margin-block-start: calc(var(--typeset-flow) * 1.4);
-    }
-    &:where(h3) {
-      font-size: 1.125em;
-      line-height: 1.45;
-      margin-block-start: var(--typeset-flow);
-    }
-    &:where(h4) {
-      font-size: 1em;
-      line-height: 1.5;
-      margin-block-start: var(--typeset-flow);
-    }
-    &:where(h5) {
-      font-size: 0.875em;
-      line-height: 1.5;
-      font-weight: 500;
-      color: var(--typeset-muted);
-      margin-block-start: calc(var(--typeset-flow) / 0.875);
-    }
-    &:where(h6) {
-      font-size: 0.8125em;
-      line-height: 1.5;
-      font-weight: 500;
-      letter-spacing: 0.08em;
-      text-transform: uppercase;
-      color: var(--typeset-muted);
-      margin-block-start: calc(var(--typeset-flow) / 0.8125);
-    }
-    /* Anchors. */
-    &:where([id]) {
-      scroll-margin-block-start: var(--typeset-flow);
-    }
-
-    /* Headings own the space below them. */
-    &:where(h1 + *, h2 + *, h3 + *, h4 + *, h5 + *, h6 + *) {
-      margin-block-start: 1em;
-    }
-    &:where(:is(h1, h2, h3, h4) :is(code)) {
-      font-size: 0.9em;
-    }
-
-    /* Links. */
-    &:where(a) {
-      color: inherit;
-      font-weight: 500;
-      text-decoration-line: underline;
-      text-decoration-color: color-mix(in oklab, currentColor 30%, transparent);
-    }
-    &:where(a:hover) {
-      text-decoration-color: currentColor;
-    }
-    &:where(a:focus-visible) {
-      outline: 2px solid var(--color-ring, currentColor);
-      outline-offset: 2px;
-      border-radius: 0.125em;
-    }
-    &:where(:is(h1, h2, h3, h4, h5, h6) :is(a)) {
-      font-weight: inherit;
-    }
-
-    /* Inline semantics. */
-    &:where(strong, b) {
-      font-weight: 600;
-    }
-    &:where(:is(h1, h2, h3, h4) :is(strong, b)) {
-      font-weight: 600;
-    }
-    &:where(mark) {
-      background-color: color-mix(
-        in oklab,
-        oklch(0.86 0.17 95) 40%,
-        transparent
-      );
-      color: inherit;
-      padding: 0.05em 0.15em;
-      border-radius: 0.2em;
-    }
-    &:where(abbr[title]) {
-      text-decoration-line: underline;
-      text-decoration-style: dotted;
-      text-underline-offset: 0.2em;
-      cursor: help;
-    }
-    &:where(del, s) {
-      color: var(--typeset-muted);
-      text-decoration-line: line-through;
-    }
-    &:where(sup, sub) {
-      font-size: 0.75em;
-      line-height: 0;
-      position: relative;
-      vertical-align: baseline;
-    }
-    &:where(sup) {
-      top: -0.5em;
-    }
-    &:where(sub) {
-      bottom: -0.25em;
-    }
-    &:where(sup a) {
-      text-decoration-line: none;
-      font-weight: 500;
-    }
-
-    /* Lists. */
-    &:where(ul) {
-      list-style-type: disc;
-    }
-    &:where(ol) {
-      list-style-type: decimal;
-    }
-    &:where(ul ul) {
-      list-style-type: circle;
-    }
-    &:where(ul ul ul) {
-      list-style-type: square;
-    }
-    &:where(ol[type="a" i]) {
-      list-style-type: lower-alpha;
-    }
-    &:where(ol[type="i" i]) {
-      list-style-type: lower-roman;
-    }
-    &:where(ol[type="A" s]) {
-      list-style-type: upper-alpha;
-    }
-    &:where(ol[type="I" s]) {
-      list-style-type: upper-roman;
-    }
-    &:where(ul, ol) {
-      margin-block-start: var(--typeset-flow);
-      margin-block-end: 0;
-      padding-inline-start: 1.5em;
-    }
-    &:where(li) {
-      margin-block-start: 0.5em;
-      padding-inline-start: 0.4em;
-    }
-    &:where(li > p, li > ul, li > ol) {
-      margin-block-start: 0.5em;
-    }
-    &:where(ul > li)::marker {
-      color: var(--typeset-muted);
-    }
-    &:where(ol > li)::marker {
-      color: var(--typeset-muted);
-    }
-
-    /* GFM task lists. */
-    &:where(ul.contains-task-list) {
-      list-style-type: none;
-      padding-inline-start: 0.25em;
-    }
-    &:where(li.task-list-item > input[type="checkbox"]) {
-      margin-inline-end: 0.5em;
-      vertical-align: -0.1em;
-      accent-color: var(--color-primary, currentColor);
-    }
-
-    /* Disclosures. */
-    &:where(details) {
-      margin-block-start: var(--typeset-flow);
-      margin-block-end: 0;
-    }
-    &:where(summary) {
-      cursor: pointer;
-      font-weight: 500;
-    }
-    &:where(summary)::marker {
-      color: var(--typeset-muted);
-    }
-
-    /* Keyboard keys. */
-    &:where(kbd) {
-      font-family: inherit;
-      font-size: 0.85em;
-      font-weight: 500;
-      border: 1px solid var(--typeset-rule);
-      border-block-end-width: 2px;
-      border-radius: min(calc(var(--radius, 0.5em) * 0.6), 0.35em);
-      padding: 0.0625em 0.35em;
-    }
-
-    /* Definition lists. */
-    &:where(dl) {
-      margin-block-start: var(--typeset-flow);
-      margin-block-end: 0;
-    }
-    &:where(dt) {
-      font-weight: 500;
-      margin-block-start: 1em;
-    }
-    &:where(dt + dt) {
-      margin-block-start: 0.25em;
-    }
-    &:where(dd) {
-      margin-block-start: 0.25em;
-      margin-inline-start: 0;
-      padding-inline-start: 1em;
-      color: var(--typeset-muted);
-    }
-
-    /* Inline code. */
-    &:where(:not(pre) > code) {
-      background-color: var(
-        --color-muted,
-        color-mix(in oklab, currentColor 8%, transparent)
-      );
-      font-family: var(--typeset-font-mono);
-      font-size: 0.85em;
-      border-radius: min(calc(var(--radius, 0.5em) * 0.6), 0.35em);
-      padding: 0.125em 0.3em;
-    }
-
-    /* Code blocks. */
-    &:where(pre) {
-      background-color: var(
-        --color-muted,
-        color-mix(in oklab, currentColor 8%, transparent)
-      );
-      font-family: var(--typeset-font-mono);
-      font-size: 0.875em;
-      line-height: 1.5;
-      tab-size: 2;
-      direction: ltr;
-      border-radius: var(--radius, 0.5em);
-      padding: 0.75em 1em;
-      overflow-x: auto;
-      margin-block-start: calc(var(--typeset-flow) / 0.875);
-      margin-block-end: 0;
-    }
-    &:where(pre code) {
-      background-color: transparent;
-      font-family: inherit;
-      font-size: inherit;
-      padding: 0;
-      border-radius: 0;
-    }
-
-    /* Blockquote. */
-    &:where(blockquote) {
-      border-inline-start: 2px solid var(--typeset-rule);
-      padding-inline-start: 1em;
-      margin-block-start: var(--typeset-flow);
-      margin-block-end: 0;
-      margin-inline: 0;
-    }
-
-    /* Dividers. */
-    &:where(hr) {
-      border: 0;
-      border-block-start: 1px solid var(--typeset-rule);
-      margin-block-start: calc(var(--typeset-flow) * 2.4);
-      margin-block-end: 0;
-    }
-    &:where(hr + h1, hr + h2, hr + h3, hr + h4) {
-      margin-block-start: var(--typeset-flow);
-    }
-
-    /* GFM footnotes. */
-    &:where(.footnotes, [data-footnotes]) {
-      margin-block-start: calc(var(--typeset-flow) * 2);
-      border-block-start: 1px solid var(--typeset-rule);
-      padding-block-start: var(--typeset-flow);
-      font-size: 0.875em;
-      color: var(--typeset-muted);
-    }
-
-    /* Math. */
-    &:where(math[display="block"]) {
-      margin-block-start: var(--typeset-flow);
-      margin-block-end: 0;
-      overflow-x: auto;
-      overflow-y: hidden;
-      padding-block: 0.25em;
-    }
-
-    /* Media. */
-    &:where(img, video) {
-      border-radius: var(--radius, 0.5em);
-      max-width: 100%;
-      height: auto;
-      margin-block-start: var(--typeset-flow);
-      margin-block-end: 0;
-    }
-    &:where(p img) {
-      margin-block-start: 0;
-    }
-    &:where(figure) {
-      margin-block-start: var(--typeset-flow);
-      margin-block-end: 0;
-      margin-inline: 0;
-    }
-    &:where(figcaption, caption) {
-      color: var(--typeset-muted);
-      font-size: 0.875em;
-      text-align: center;
-      margin-block-start: calc(0.75em / 0.875);
-    }
-    &:where(caption) {
-      caption-side: bottom;
-    }
-
-    /* Tables. Separators sit on cells, not tr:last-child: append-safe.
-       Bare tables stay real tables (keep their semantics) and wrap to fit. */
-    &:where(table) {
-      max-width: 100%;
-      font-size: 1em;
-      line-height: 1.5;
-      font-variant-numeric: tabular-nums;
-      border-collapse: separate;
-      border-spacing: 0;
-      border-block-end: 1px solid var(--typeset-rule);
-      margin-block-start: var(--typeset-flow);
-      margin-block-end: 0;
-    }
-
-    /* Horizontal scroll for any wide block. Wrap it and the wrapper owns the
-       flow margin. Tables shrink to fit, so widen the table to make it scroll
-       instead of compress. */
-    &:where(.typeset-scroll) {
-      overflow-x: auto;
-      margin-block-start: var(--typeset-flow);
-    }
-    &:where(.typeset-scroll > *) {
-      margin-block-start: 0;
-    }
-    &:where(.typeset-scroll table) {
-      width: max-content;
-      max-width: none;
-    }
-    &:where(thead th) {
-      font-weight: 500;
-      text-align: start;
-      white-space: nowrap;
-      padding: 0.65em 1em;
-    }
-    &:where(:is(tbody, tfoot) :is(td, th)) {
-      padding: 0.75em 1em;
-      text-align: start;
-      vertical-align: top;
-      border-block-start: 1px solid var(--typeset-rule);
-    }
-    &:where(tbody th, tfoot th) {
-      font-weight: 500;
-    }
-    &:where(th:first-child, td:first-child) {
-      padding-inline-start: 0;
-    }
-    &:where(th[align="center"], td[align="center"]) {
-      text-align: center;
-    }
-    &:where(th[align="right"], td[align="right"]) {
-      text-align: end;
-    }
-
-    /* Blocks inside list items keep the list's tighter rhythm. */
-    &:where(li > blockquote, li > table, li > figure) {
-      margin-block-start: 0.5em;
-    }
-    &:where(li > pre) {
-      margin-block-start: calc(0.5em / 0.875);
-    }
-
-    @media print {
-      &:where(pre, table, blockquote, figure) {
-        break-inside: avoid;
-      }
-      &:where(h1, h2, h3, h4) {
-        break-after: avoid;
-      }
-    }
-
-    /* Forced colors strips the code background, so give it a border. */
-    @media (forced-colors: active) {
-      &:where(:not(pre) > code) {
-        border: 1px solid;
-      }
-    }
-  }
-
-  /* First child adds no space above. Last so it wins ties. */
-  .typeset
-    > :where(:first-child):not(
-      :where(
-        .not-typeset,
-        [data-not-typeset],
-        .not-typeset *,
-        [data-not-typeset] *
-      )
-    ),
-  .typeset
-    > :where(:first-child)
-    > :where(:first-child):not(
-      :where(
-        .not-typeset,
-        [data-not-typeset],
-        .not-typeset *,
-        [data-not-typeset] *
-      )
-    ),
-  .typeset
+/* First child adds no space above. Last so it wins ties. */
+.typeset
+  > :where(:first-child):not(
     :where(
-      li > :first-child,
-      blockquote > :first-child,
-      td > :first-child,
-      th > :first-child,
-      dd > :first-child,
-      figure > :first-child,
-      figure > picture > img
-    ):not(
-      :where(
-        .not-typeset,
-        [data-not-typeset],
-        .not-typeset *,
-        [data-not-typeset] *
-      )
-    ) {
-    margin-block-start: 0;
-  }
+      .not-typeset,
+      [data-not-typeset],
+      .not-typeset *,
+      [data-not-typeset] *
+    )
+  ),
+.typeset
+  > :where(:first-child)
+  > :where(:first-child):not(
+    :where(
+      .not-typeset,
+      [data-not-typeset],
+      .not-typeset *,
+      [data-not-typeset] *
+    )
+  ),
+.typeset
+  :where(
+    li > :first-child,
+    blockquote > :first-child,
+    td > :first-child,
+    th > :first-child,
+    dd > :first-child,
+    figure > :first-child,
+    figure > picture > img
+  ):not(
+    :where(
+      .not-typeset,
+      [data-not-typeset],
+      .not-typeset *,
+      [data-not-typeset] *
+    )
+  ) {
+  margin-block-start: 0;
 }

--- a/src/app/typeset.css
+++ b/src/app/typeset.css
@@ -1,0 +1,490 @@
+/*
+ * shadcn/typeset
+ * https://ui.shadcn.com/docs/typeset.
+ */
+
+@layer typeset {
+  .typeset {
+    --typeset-font-body: inherit;
+    --typeset-font-heading: var(--font-heading);
+    --typeset-font-mono: var(--font-mono);
+    --typeset-size: 1em;
+    --typeset-leading: 1.75;
+    --typeset-flow: 1.25em;
+  }
+}
+
+@layer typeset {
+  .typeset {
+    font-family: var(--typeset-font-body);
+    font-size: calc(var(--typeset-size) * 1.125);
+    line-height: var(--typeset-leading);
+    color: var(--color-foreground, currentColor);
+    overflow-wrap: break-word;
+    margin-trim: block-start;
+
+    @media (min-width: 48rem), print {
+      font-size: var(--typeset-size);
+    }
+
+    --typeset-muted: var(
+      --color-muted-foreground,
+      color-mix(in oklab, currentColor 60%, transparent)
+    );
+    --typeset-rule: var(
+      --color-border,
+      color-mix(in oklab, currentColor 20%, transparent)
+    );
+  }
+
+  .typeset
+    *:not(
+      :where(
+        .not-typeset,
+        [data-not-typeset],
+        .not-typeset *,
+        [data-not-typeset] *
+      )
+    ) {
+    /* Paragraphs. */
+    &:where(p) {
+      margin-block-start: var(--typeset-flow);
+      margin-block-end: 0;
+    }
+
+    /* Headings. */
+    &:where(h1, h2, h3, h4, h5, h6) {
+      color: var(--color-foreground, currentColor);
+      font-family: var(--typeset-font-heading);
+      font-weight: 600;
+      margin-block-end: 0;
+    }
+    &:where(h1) {
+      font-size: 1.75em;
+      line-height: 1.3;
+      margin-block-start: var(--typeset-flow);
+    }
+    &:where(h2) {
+      font-size: 1.25em;
+      line-height: 1.4;
+      margin-block-start: calc(var(--typeset-flow) * 1.4);
+    }
+    &:where(h3) {
+      font-size: 1.125em;
+      line-height: 1.45;
+      margin-block-start: var(--typeset-flow);
+    }
+    &:where(h4) {
+      font-size: 1em;
+      line-height: 1.5;
+      margin-block-start: var(--typeset-flow);
+    }
+    &:where(h5) {
+      font-size: 0.875em;
+      line-height: 1.5;
+      font-weight: 500;
+      color: var(--typeset-muted);
+      margin-block-start: calc(var(--typeset-flow) / 0.875);
+    }
+    &:where(h6) {
+      font-size: 0.8125em;
+      line-height: 1.5;
+      font-weight: 500;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--typeset-muted);
+      margin-block-start: calc(var(--typeset-flow) / 0.8125);
+    }
+    /* Anchors. */
+    &:where([id]) {
+      scroll-margin-block-start: var(--typeset-flow);
+    }
+
+    /* Headings own the space below them. */
+    &:where(h1 + *, h2 + *, h3 + *, h4 + *, h5 + *, h6 + *) {
+      margin-block-start: 1em;
+    }
+    &:where(:is(h1, h2, h3, h4) :is(code)) {
+      font-size: 0.9em;
+    }
+
+    /* Links. */
+    &:where(a) {
+      color: inherit;
+      font-weight: 500;
+      text-decoration-line: underline;
+      text-decoration-color: color-mix(in oklab, currentColor 30%, transparent);
+    }
+    &:where(a:hover) {
+      text-decoration-color: currentColor;
+    }
+    &:where(a:focus-visible) {
+      outline: 2px solid var(--color-ring, currentColor);
+      outline-offset: 2px;
+      border-radius: 0.125em;
+    }
+    &:where(:is(h1, h2, h3, h4, h5, h6) :is(a)) {
+      font-weight: inherit;
+    }
+
+    /* Inline semantics. */
+    &:where(strong, b) {
+      font-weight: 600;
+    }
+    &:where(:is(h1, h2, h3, h4) :is(strong, b)) {
+      font-weight: 600;
+    }
+    &:where(mark) {
+      background-color: color-mix(
+        in oklab,
+        oklch(0.86 0.17 95) 40%,
+        transparent
+      );
+      color: inherit;
+      padding: 0.05em 0.15em;
+      border-radius: 0.2em;
+    }
+    &:where(abbr[title]) {
+      text-decoration-line: underline;
+      text-decoration-style: dotted;
+      text-underline-offset: 0.2em;
+      cursor: help;
+    }
+    &:where(del, s) {
+      color: var(--typeset-muted);
+      text-decoration-line: line-through;
+    }
+    &:where(sup, sub) {
+      font-size: 0.75em;
+      line-height: 0;
+      position: relative;
+      vertical-align: baseline;
+    }
+    &:where(sup) {
+      top: -0.5em;
+    }
+    &:where(sub) {
+      bottom: -0.25em;
+    }
+    &:where(sup a) {
+      text-decoration-line: none;
+      font-weight: 500;
+    }
+
+    /* Lists. */
+    &:where(ul) {
+      list-style-type: disc;
+    }
+    &:where(ol) {
+      list-style-type: decimal;
+    }
+    &:where(ul ul) {
+      list-style-type: circle;
+    }
+    &:where(ul ul ul) {
+      list-style-type: square;
+    }
+    &:where(ol[type="a" i]) {
+      list-style-type: lower-alpha;
+    }
+    &:where(ol[type="i" i]) {
+      list-style-type: lower-roman;
+    }
+    &:where(ol[type="A" s]) {
+      list-style-type: upper-alpha;
+    }
+    &:where(ol[type="I" s]) {
+      list-style-type: upper-roman;
+    }
+    &:where(ul, ol) {
+      margin-block-start: var(--typeset-flow);
+      margin-block-end: 0;
+      padding-inline-start: 1.5em;
+    }
+    &:where(li) {
+      margin-block-start: 0.5em;
+      padding-inline-start: 0.4em;
+    }
+    &:where(li > p, li > ul, li > ol) {
+      margin-block-start: 0.5em;
+    }
+    &:where(ul > li)::marker {
+      color: var(--typeset-muted);
+    }
+    &:where(ol > li)::marker {
+      color: var(--typeset-muted);
+    }
+
+    /* GFM task lists. */
+    &:where(ul.contains-task-list) {
+      list-style-type: none;
+      padding-inline-start: 0.25em;
+    }
+    &:where(li.task-list-item > input[type="checkbox"]) {
+      margin-inline-end: 0.5em;
+      vertical-align: -0.1em;
+      accent-color: var(--color-primary, currentColor);
+    }
+
+    /* Disclosures. */
+    &:where(details) {
+      margin-block-start: var(--typeset-flow);
+      margin-block-end: 0;
+    }
+    &:where(summary) {
+      cursor: pointer;
+      font-weight: 500;
+    }
+    &:where(summary)::marker {
+      color: var(--typeset-muted);
+    }
+
+    /* Keyboard keys. */
+    &:where(kbd) {
+      font-family: inherit;
+      font-size: 0.85em;
+      font-weight: 500;
+      border: 1px solid var(--typeset-rule);
+      border-block-end-width: 2px;
+      border-radius: min(calc(var(--radius, 0.5em) * 0.6), 0.35em);
+      padding: 0.0625em 0.35em;
+    }
+
+    /* Definition lists. */
+    &:where(dl) {
+      margin-block-start: var(--typeset-flow);
+      margin-block-end: 0;
+    }
+    &:where(dt) {
+      font-weight: 500;
+      margin-block-start: 1em;
+    }
+    &:where(dt + dt) {
+      margin-block-start: 0.25em;
+    }
+    &:where(dd) {
+      margin-block-start: 0.25em;
+      margin-inline-start: 0;
+      padding-inline-start: 1em;
+      color: var(--typeset-muted);
+    }
+
+    /* Inline code. */
+    &:where(:not(pre) > code) {
+      background-color: var(
+        --color-muted,
+        color-mix(in oklab, currentColor 8%, transparent)
+      );
+      font-family: var(--typeset-font-mono);
+      font-size: 0.85em;
+      border-radius: min(calc(var(--radius, 0.5em) * 0.6), 0.35em);
+      padding: 0.125em 0.3em;
+    }
+
+    /* Code blocks. */
+    &:where(pre) {
+      background-color: var(
+        --color-muted,
+        color-mix(in oklab, currentColor 8%, transparent)
+      );
+      font-family: var(--typeset-font-mono);
+      font-size: 0.875em;
+      line-height: 1.5;
+      tab-size: 2;
+      direction: ltr;
+      border-radius: var(--radius, 0.5em);
+      padding: 0.75em 1em;
+      overflow-x: auto;
+      margin-block-start: calc(var(--typeset-flow) / 0.875);
+      margin-block-end: 0;
+    }
+    &:where(pre code) {
+      background-color: transparent;
+      font-family: inherit;
+      font-size: inherit;
+      padding: 0;
+      border-radius: 0;
+    }
+
+    /* Blockquote. */
+    &:where(blockquote) {
+      border-inline-start: 2px solid var(--typeset-rule);
+      padding-inline-start: 1em;
+      margin-block-start: var(--typeset-flow);
+      margin-block-end: 0;
+      margin-inline: 0;
+    }
+
+    /* Dividers. */
+    &:where(hr) {
+      border: 0;
+      border-block-start: 1px solid var(--typeset-rule);
+      margin-block-start: calc(var(--typeset-flow) * 2.4);
+      margin-block-end: 0;
+    }
+    &:where(hr + h1, hr + h2, hr + h3, hr + h4) {
+      margin-block-start: var(--typeset-flow);
+    }
+
+    /* GFM footnotes. */
+    &:where(.footnotes, [data-footnotes]) {
+      margin-block-start: calc(var(--typeset-flow) * 2);
+      border-block-start: 1px solid var(--typeset-rule);
+      padding-block-start: var(--typeset-flow);
+      font-size: 0.875em;
+      color: var(--typeset-muted);
+    }
+
+    /* Math. */
+    &:where(math[display="block"]) {
+      margin-block-start: var(--typeset-flow);
+      margin-block-end: 0;
+      overflow-x: auto;
+      overflow-y: hidden;
+      padding-block: 0.25em;
+    }
+
+    /* Media. */
+    &:where(img, video) {
+      border-radius: var(--radius, 0.5em);
+      max-width: 100%;
+      height: auto;
+      margin-block-start: var(--typeset-flow);
+      margin-block-end: 0;
+    }
+    &:where(p img) {
+      margin-block-start: 0;
+    }
+    &:where(figure) {
+      margin-block-start: var(--typeset-flow);
+      margin-block-end: 0;
+      margin-inline: 0;
+    }
+    &:where(figcaption, caption) {
+      color: var(--typeset-muted);
+      font-size: 0.875em;
+      text-align: center;
+      margin-block-start: calc(0.75em / 0.875);
+    }
+    &:where(caption) {
+      caption-side: bottom;
+    }
+
+    /* Tables. Separators sit on cells, not tr:last-child: append-safe.
+       Bare tables stay real tables (keep their semantics) and wrap to fit. */
+    &:where(table) {
+      max-width: 100%;
+      font-size: 1em;
+      line-height: 1.5;
+      font-variant-numeric: tabular-nums;
+      border-collapse: separate;
+      border-spacing: 0;
+      border-block-end: 1px solid var(--typeset-rule);
+      margin-block-start: var(--typeset-flow);
+      margin-block-end: 0;
+    }
+
+    /* Horizontal scroll for any wide block. Wrap it and the wrapper owns the
+       flow margin. Tables shrink to fit, so widen the table to make it scroll
+       instead of compress. */
+    &:where(.typeset-scroll) {
+      overflow-x: auto;
+      margin-block-start: var(--typeset-flow);
+    }
+    &:where(.typeset-scroll > *) {
+      margin-block-start: 0;
+    }
+    &:where(.typeset-scroll table) {
+      width: max-content;
+      max-width: none;
+    }
+    &:where(thead th) {
+      font-weight: 500;
+      text-align: start;
+      white-space: nowrap;
+      padding: 0.65em 1em;
+    }
+    &:where(:is(tbody, tfoot) :is(td, th)) {
+      padding: 0.75em 1em;
+      text-align: start;
+      vertical-align: top;
+      border-block-start: 1px solid var(--typeset-rule);
+    }
+    &:where(tbody th, tfoot th) {
+      font-weight: 500;
+    }
+    &:where(th:first-child, td:first-child) {
+      padding-inline-start: 0;
+    }
+    &:where(th[align="center"], td[align="center"]) {
+      text-align: center;
+    }
+    &:where(th[align="right"], td[align="right"]) {
+      text-align: end;
+    }
+
+    /* Blocks inside list items keep the list's tighter rhythm. */
+    &:where(li > blockquote, li > table, li > figure) {
+      margin-block-start: 0.5em;
+    }
+    &:where(li > pre) {
+      margin-block-start: calc(0.5em / 0.875);
+    }
+
+    @media print {
+      &:where(pre, table, blockquote, figure) {
+        break-inside: avoid;
+      }
+      &:where(h1, h2, h3, h4) {
+        break-after: avoid;
+      }
+    }
+
+    /* Forced colors strips the code background, so give it a border. */
+    @media (forced-colors: active) {
+      &:where(:not(pre) > code) {
+        border: 1px solid;
+      }
+    }
+  }
+
+  /* First child adds no space above. Last so it wins ties. */
+  .typeset
+    > :where(:first-child):not(
+      :where(
+        .not-typeset,
+        [data-not-typeset],
+        .not-typeset *,
+        [data-not-typeset] *
+      )
+    ),
+  .typeset
+    > :where(:first-child)
+    > :where(:first-child):not(
+      :where(
+        .not-typeset,
+        [data-not-typeset],
+        .not-typeset *,
+        [data-not-typeset] *
+      )
+    ),
+  .typeset
+    :where(
+      li > :first-child,
+      blockquote > :first-child,
+      td > :first-child,
+      th > :first-child,
+      dd > :first-child,
+      figure > :first-child,
+      figure > picture > img
+    ):not(
+      :where(
+        .not-typeset,
+        [data-not-typeset],
+        .not-typeset *,
+        [data-not-typeset] *
+      )
+    ) {
+    margin-block-start: 0;
+  }
+}

--- a/src/components/ContactUsForm.tsx
+++ b/src/components/ContactUsForm.tsx
@@ -42,12 +42,12 @@ export default function ContactUsForm() {
       return;
     }
     if (!service?.trim()) {
-      setError("Vennligst velg hvilken tjeneste henvendelsen gjelder.");
+      setError("Velg hvilken tjeneste henvendelsen gjelder.");
       return;
     }
     // Basic email validation (can be more sophisticated)
     if (!/\S+@\S+\.\S+/.test(email)) {
-      setError("Vennligst oppgi en gyldig e-postadresse.");
+      setError("Oppgi en gyldig e-postadresse.");
       return;
     }
 
@@ -73,10 +73,15 @@ export default function ContactUsForm() {
         setMessage("");
         trackContactSubmitted();
       } else {
-        setError(result.error || "Innsending feilet. Vennligst prøv igjen.");
+        setError(
+          result.error ||
+            "Vi fikk ikke sendt henvendelsen. Prøv igjen om litt, eller ring oss på +47 984 53 571.",
+        );
       }
     } catch {
-      setError("En uventet feil oppstod. Vennligst prøv igjen.");
+      setError(
+        "Noe gikk galt, og henvendelsen ble ikke sendt. Prøv igjen om litt, eller ring oss på +47 984 53 571.",
+      );
     } finally {
       setIsSubmitting(false);
       submitting.current = false;

--- a/src/components/blog/mdx.tsx
+++ b/src/components/blog/mdx.tsx
@@ -653,9 +653,12 @@ interface MDXProps {
   code: string
   images?: { alt: string; src: string; blurDataURL: string }[]
   className?: string
+  /** "editorial" = .ks-prose design-system typography (default, used by
+   *  kunder/integrasjoner/eiendommer); "typeset" = shadcn typeset (blog/help). */
+  typography?: "editorial" | "typeset"
 }
 
-export function MDX({ code, images, className }: MDXProps) {
+export function MDX({ code, images, className, typography = "editorial" }: MDXProps) {
   const MDXImage = (props: any) => {
     const blurDataURL = images
       ? images.find((image) => image.src === props.src)?.blurDataURL
@@ -667,7 +670,11 @@ export function MDX({ code, images, className }: MDXProps) {
   return (
     <article
       data-mdx-container
-      className={cx("ks-prose max-w-none", className)}
+      className={cx(
+        typography === "typeset" ? "typeset typeset-docs" : "ks-prose",
+        "max-w-none",
+        className,
+      )}
     >
       <MDXContent
         code={code}

--- a/src/components/site/ProseShell.tsx
+++ b/src/components/site/ProseShell.tsx
@@ -1,9 +1,8 @@
 import type { ReactNode } from "react";
 
 /**
- * Wrapper that applies the editorial long-form prose styling (`.ks-prose`
- * from the design system). Used by help articles and customer case studies
- * in Phase 2 to host rendered MDX.
+ * Wrapper that applies shadcn typeset typography to rendered MDX.
+ * Used by the location (næringsmegler) pages.
  */
 export function ProseShell({
   children,
@@ -13,7 +12,11 @@ export function ProseShell({
   className?: string;
 }) {
   return (
-    <div className={className ? `ks-prose ${className}` : "ks-prose"}>
+    <div
+      className={
+        className ? `typeset typeset-docs ${className}` : "typeset typeset-docs"
+      }
+    >
       {children}
     </div>
   );

--- a/src/lib/email/subscribe.ts
+++ b/src/lib/email/subscribe.ts
@@ -116,7 +116,11 @@ export async function subscribe(input: SubscribeInput): Promise<SubscribeResult>
     console.error(
       "subscribe(): no destinations configured (Resend, Discord, Supabase all unset).",
     )
-    return { ok: false, error: "Tjenesten er midlertidig utilgjengelig." }
+    return {
+      ok: false,
+      error:
+        "Tjenesten er midlertidig utilgjengelig. Prøv igjen om litt, eller ring oss på +47 984 53 571.",
+    }
   }
 
   const results: DestinationResult[] = []
@@ -240,7 +244,11 @@ export async function subscribe(input: SubscribeInput): Promise<SubscribeResult>
     console.error(
       `subscribe(): all configured destinations failed for source "${input.source}".`,
     )
-    return { ok: false, error: "Tjenesten er midlertidig utilgjengelig." }
+    return {
+      ok: false,
+      error:
+        "Tjenesten er midlertidig utilgjengelig. Prøv igjen om litt, eller ring oss på +47 984 53 571.",
+    }
   }
 
   if (HIGH_INTENT.includes(input.source)) {
@@ -251,7 +259,11 @@ export async function subscribe(input: SubscribeInput): Promise<SubscribeResult>
       console.error(
         `subscribe(): high-intent lead had no durable destination for source "${input.source}".`,
       )
-      return { ok: false, error: "Tjenesten er midlertidig utilgjengelig." }
+      return {
+      ok: false,
+      error:
+        "Tjenesten er midlertidig utilgjengelig. Prøv igjen om litt, eller ring oss på +47 984 53 571.",
+    }
     }
   }
 

--- a/tests/unit/naringsmegler.test.ts
+++ b/tests/unit/naringsmegler.test.ts
@@ -162,12 +162,14 @@ describe("submitCityLead", () => {
   it("propagates a subscribe() failure to the caller", async () => {
     subscribeMock.mockResolvedValueOnce({
       ok: false,
-      error: "Tjenesten er midlertidig utilgjengelig.",
+      error:
+        "Tjenesten er midlertidig utilgjengelig. Prøv igjen om litt, eller ring oss på +47 984 53 571.",
     })
     const result = await submitCityLead(leadForm())
     expect(result).toEqual({
       ok: false,
-      error: "Tjenesten er midlertidig utilgjengelig.",
+      error:
+        "Tjenesten er midlertidig utilgjengelig. Prøv igjen om litt, eller ring oss på +47 984 53 571.",
     })
   })
 

--- a/tests/unit/subscribe.test.ts
+++ b/tests/unit/subscribe.test.ts
@@ -111,7 +111,8 @@ describe("subscribe", () => {
 
     expect(result).toEqual({
       ok: false,
-      error: "Tjenesten er midlertidig utilgjengelig.",
+      error:
+        "Tjenesten er midlertidig utilgjengelig. Prøv igjen om litt, eller ring oss på +47 984 53 571.",
     })
   })
 


### PR DESCRIPTION
## What

- **shadcn/typeset install** — typeset.css imported in globals.css, Geist/Geist Mono loaded as scoped font variables (site-wide type stays Inter), `.typeset-docs` preset added.
- **Applied to three surfaces**, replacing `.ks-prose` there per review decision:
  - Blog posts + help articles via a new `typography="typeset"` prop on the shared `MDX` component
  - `/naringsmegler/[slug]` via `ProseShell`
  - kunder / integrasjoner / eiendommer untouched (still `.ks-prose`)
- **QA fix (ISSUE-001):** typeset.css `@layer` wrappers unwrapped — native cascade layers lose to Tailwind v3's unlayered preflight, which left headings/lists/tables unstyled. Unlayered rules win by specificity.
- Also carries the pre-existing error-message audit WIP from this branch (16 files).

## QA

/qa (diff-aware) on blog, help, location + control pages: 1 issue found and fixed, health 82 → 97, no regressions on `.ks-prose` surfaces or homepage. Report: `.gstack/qa-reports/qa-report-localhost-3000-2026-07-11.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added improved typesetting for blog posts and help articles, including enhanced headings, lists, tables, code, and media presentation.
  - Added clearer empty-state links to relevant blog and help content.
  - Added additional font styling for improved readability.

- **Bug Fixes**
  - Improved validation guidance for contact, property, and valuation forms.
  - Added clearer retry and contact instructions when submissions fail.
  - Improved clipboard failure guidance with manual HEX copying instructions.

- **Localization**
  - Updated help, blog, and image-generation messages with clearer Norwegian wording.
  - Improved document and not-found error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->