### PR TITLE
feat: complete typeset conversion — all prose surfaces, ks-prose removed

### DIFF
--- a/src/app/(blog)/blog/(post)/[slug]/page.tsx
+++ b/src/app/(blog)/blog/(post)/[slug]/page.tsx
@@ -243,7 +243,6 @@ export default async function BlogArticle({
           <div className="ks-article">
             <article className="ks-art-body" id="art-main">
               <MDX
-                typography="typeset"
                 code={data.mdx}
                 images={images.map((image) => ({
                   ...image,

--- a/src/app/(help)/help/article/[slug]/page.tsx
+++ b/src/app/(help)/help/article/[slug]/page.tsx
@@ -226,7 +226,7 @@ export default async function HelpArticle({
                 </div>
               )}
 
-              <MDX typography="typeset" code={data.mdx} images={images} />
+              <MDX code={data.mdx} images={images} />
 
               {data.faq && data.faq.length >= 2 && (
                 <div className="ks-faq">

--- a/src/app/personer/[slug]/page.tsx
+++ b/src/app/personer/[slug]/page.tsx
@@ -167,7 +167,7 @@ export default async function PersonPage({ params }: PersonPageProps) {
         <div className="wrap">
           <div className="pe-body">
             {/* MAIN */}
-            <article className="pe-main">
+            <article className="pe-main typeset typeset-docs">
               <PersonMDX code={person.mdx} />
 
               {person.specializations.length > 0 && (

--- a/src/app/personer/[slug]/person-mdx.tsx
+++ b/src/app/personer/[slug]/person-mdx.tsx
@@ -21,8 +21,8 @@ const CustomLink = (props: any) => {
   return <a target="_blank" rel="noopener noreferrer" {...props} />;
 };
 
-// Plain elements so the editorial `.pe-main` typography from the design
-// stylesheet applies (h2 / p / ul styling defined globally).
+// Plain elements so the shared `typeset typeset-docs` typography on the
+// `.pe-main` wrapper applies (h2 / p / ul styled by the typeset layer).
 const components = {
   a: (props: any) => <CustomLink {...props} />,
 };

--- a/src/components/blog/mdx.tsx
+++ b/src/components/blog/mdx.tsx
@@ -667,7 +667,10 @@ export function MDX({ code, images, className }: MDXProps) {
   return (
     <article
       data-mdx-container
-      className={cx("typeset typeset-docs", "max-w-none", className)}
+      // w-full: under shrink-to-fit parents (legal's items-center flex column)
+      // the article must fill the wrapper, not grow to its widest table —
+      // .ae-table-scroll clamps against the article's width.
+      className={cx("typeset typeset-docs", "w-full max-w-none", className)}
     >
       <MDXContent
         code={code}

--- a/src/components/blog/mdx.tsx
+++ b/src/components/blog/mdx.tsx
@@ -577,9 +577,9 @@ function Figure(props: {
 }
 
 // Base markdown (h2/h3/p/ul/table…) intentionally has NO per-element
-// className overrides — typography is inherited from `.ks-prose` on the
-// <article> wrapper so blog, help, kunder, integrasjoner and eiendommer all
-// share one editorial type system. Only the custom components below are mapped.
+// className overrides — typography is inherited from the `typeset typeset-docs`
+// classes on the <article> wrapper so blog, help, kunder, integrasjoner and
+// eiendommer all share one type system. Only the custom components below are mapped.
 const components = {
   a: CustomLink,
   Note,
@@ -653,12 +653,9 @@ interface MDXProps {
   code: string
   images?: { alt: string; src: string; blurDataURL: string }[]
   className?: string
-  /** "editorial" = .ks-prose design-system typography (default, used by
-   *  kunder/integrasjoner/eiendommer); "typeset" = shadcn typeset (blog/help). */
-  typography?: "editorial" | "typeset"
 }
 
-export function MDX({ code, images, className, typography = "editorial" }: MDXProps) {
+export function MDX({ code, images, className }: MDXProps) {
   const MDXImage = (props: any) => {
     const blurDataURL = images
       ? images.find((image) => image.src === props.src)?.blurDataURL
@@ -670,11 +667,7 @@ export function MDX({ code, images, className, typography = "editorial" }: MDXPr
   return (
     <article
       data-mdx-container
-      className={cx(
-        typography === "typeset" ? "typeset typeset-docs" : "ks-prose",
-        "max-w-none",
-        className,
-      )}
+      className={cx("typeset typeset-docs", "max-w-none", className)}
     >
       <MDXContent
         code={code}

--- a/src/components/eiendommer/ListingProse.tsx
+++ b/src/components/eiendommer/ListingProse.tsx
@@ -45,8 +45,10 @@ function renderInline(text: string, keyBase: string): ReactNode[] {
 
 export function ListingProse({ body }: { body: string }) {
   const blocks = body.trim().split(/\n{2,}/)
+  // Wrap in the shared `typeset typeset-docs` container so CRM bodies inherit
+  // the same type system as the MDX branch (which wraps via <MDX>'s article).
   return (
-    <>
+    <div className="typeset typeset-docs">
       {blocks.map((raw, bi) => {
         const block = raw.trim()
         if (!block) return null
@@ -80,7 +82,7 @@ export function ListingProse({ body }: { body: string }) {
           </p>
         )
       })}
-    </>
+    </div>
   )
 }
 

--- a/src/components/locations/LocationMdx.tsx
+++ b/src/components/locations/LocationMdx.tsx
@@ -32,8 +32,8 @@ const CustomLink = ({
   );
 };
 
-// Plain elements so the editorial `.ks-prose` typography from the design
-// stylesheet applies (h2 / h3 / p / ul styling defined globally).
+// Plain elements so the `typeset` typography from the parent ProseShell
+// applies (h2 / h3 / p / ul styling defined globally).
 const components = {
   a: (props: any) => <CustomLink {...props} />,
 };

--- a/src/styles/advanti-design.css
+++ b/src/styles/advanti-design.css
@@ -4591,76 +4591,6 @@ h1, h2, h3 {
   color: var(--warm-grey-85);
 }
 
-/* Article prose — long-form typography */
-.ks-prose {
-  font-size: 17px;
-  line-height: 1.7;
-  color: var(--warm-grey);
-  overflow-wrap: break-word;
-}
-.ks-prose > * + * { margin-top: 1.1em; }
-.ks-prose img { max-width: 100%; height: auto; }
-.ks-prose pre { max-width: 100%; overflow-x: auto; }
-.ks-prose h2 {
-  font-family: var(--font-display);
-  font-size: 36px;
-  font-weight: 400;
-  letter-spacing: -0.02em;
-  line-height: 1.1;
-  margin-top: 64px !important;
-  margin-bottom: 24px;
-  scroll-margin-top: 100px;
-}
-.ks-prose h2 .italic { font-style: italic; font-weight: 300; color: var(--warm-grey-85); }
-.ks-prose h3 {
-  font-family: var(--font-display);
-  font-size: 26px;
-  font-weight: 400;
-  letter-spacing: -0.015em;
-  line-height: 1.15;
-  margin-top: 48px !important;
-  margin-bottom: 16px;
-  scroll-margin-top: 100px;
-}
-.ks-prose p { text-wrap: pretty; color: var(--warm-grey-85); }
-.ks-prose p strong { color: var(--warm-grey); font-weight: 500; }
-.ks-prose a {
-  color: var(--warm-grey);
-  border-bottom: 1px solid var(--warm-grey-85);
-  transition: border-color 0.15s;
-}
-.ks-prose a:hover { border-color: var(--accent); }
-.ks-prose ul, .ks-prose ol {
-  padding-left: 24px;
-  color: var(--warm-grey-85);
-}
-.ks-prose li {
-  margin-bottom: 8px;
-  text-wrap: pretty;
-}
-.ks-prose li::marker {
-  color: var(--warm-grey-75);
-}
-.ks-prose blockquote {
-  border-left: 3px solid var(--accent);
-  padding: 8px 0 8px 24px;
-  margin: 32px 0;
-  font-family: var(--font-display);
-  font-size: 22px;
-  font-style: italic;
-  font-weight: 300;
-  line-height: 1.45;
-  color: var(--warm-grey);
-}
-.ks-prose code {
-  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
-  font-size: 0.88em;
-  background: var(--accent-soft);
-  padding: 2px 7px;
-  border-radius: 3px;
-  color: var(--warm-grey);
-}
-
 /* Formula block */
 
 /* Note callout */
@@ -5356,14 +5286,6 @@ h1, h2, h3 {
 }
 
 @media (max-width: 700px) {
-  /* Wide data tables scroll horizontally inside the article instead of
-     stretching the whole page. */
-  .ks-prose table {
-    display: block;
-    max-width: 100%;
-    overflow-x: auto;
-    -webkit-overflow-scrolling: touch;
-  }
   /* The article title is the next thing on screen — drop it from the
      breadcrumb so a long title does not wrap to four lines. */
   .crumb-article .here,
@@ -5581,24 +5503,6 @@ h1, h2, h3 {
   border-top: var(--hairline);
 }
 .pe-main { max-width: 720px; }
-.pe-main h2 {
-  font-family: var(--font-display);
-  font-size: 32px;
-  font-weight: 400;
-  letter-spacing: -0.018em;
-  margin-top: 48px;
-  margin-bottom: 20px;
-}
-.pe-main h2:first-child { margin-top: 0; }
-.pe-main h2 .italic { font-style: italic; font-weight: 300; color: var(--warm-grey-85); }
-.pe-main p {
-  font-size: 16.5px;
-  color: var(--warm-grey-85);
-  line-height: 1.7;
-  margin-bottom: 16px;
-  text-wrap: pretty;
-}
-.pe-main p strong { color: var(--warm-grey); font-weight: 500; }
 
 /* Specializations list (numbered, no icons) */
 .pe-spec {
@@ -6539,7 +6443,7 @@ h1, h2, h3 {
   .footer-col ul { gap: 4px; }
 }
 
-/* Blog article body — reuses .ks-prose with a hero image on top */
+/* Blog article body — typeset prose with a hero image on top */
 .bg-art-hero {
   margin-bottom: 56px;
 }
@@ -6556,32 +6460,6 @@ h1, h2, h3 {
   letter-spacing: 0.04em;
   font-style: italic;
 }
-
-/* Data table inside article prose */
-.ks-prose table {
-  width: 100%;
-  border-collapse: collapse;
-  margin: 32px 0;
-  font-size: 14px;
-  font-variant-numeric: tabular-nums;
-}
-.ks-prose table thead th {
-  text-align: left;
-  font-weight: 500;
-  font-size: 11px;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-  color: var(--warm-grey-85);
-  padding: 12px 14px;
-  border-bottom: 1px solid var(--warm-grey-75);
-}
-.ks-prose table tbody td {
-  padding: 14px;
-  border-bottom: var(--hairline);
-  color: var(--warm-grey-85);
-}
-.ks-prose table tbody tr:hover td { background: var(--accent-faint); }
-.ks-prose table tbody td:first-child { color: var(--warm-grey); font-weight: 500; }
 
 /* ============================================================
    BLOG · Editorial MDX components  (.ae-*)
@@ -8338,14 +8216,6 @@ h1, h2, h3 {
   text-wrap: pretty;
 }
 .ed-body .lead .italic { font-style: italic; font-weight: 300; color: var(--warm-grey-85); }
-.ed-body p {
-  font-size: 16px;
-  color: var(--warm-grey-85);
-  line-height: 1.65;
-  margin-bottom: 18px;
-  max-width: 62ch;
-}
-.ed-body p strong { color: var(--warm-grey); font-weight: 500; }
 
 /* Megler card */
 .ed-megler {


### PR DESCRIPTION
## What

Completes the typeset migration started in #99. All long-form prose now renders in one typography system.

- **Shared `MDX` component**: `typography` prop removed, always renders `typeset typeset-docs` → kunder, integrasjoner, eiendommer (MDX branch) and legal (/privacy, /terms) converted in one move
- **CRM listings**: `ListingProse` wraps its output in typeset (bodies previously had *unstyled* bare h2/lists — this is a net styling gain)
- **People pages**: `.pe-main` article carries typeset for the bio prose
- **Changelog**: no live route consumes `ChangelogPost` — nothing to convert
- **CSS cleanup**: entire `.ks-prose` block deleted (~130 lines, zero consumers), plus legacy `.ed-body p` / `.pe-main p, h2` rules that fought typeset on source order. `.ed-body .lead` kept (renders outside the typeset wrapper).

## QA

Browser-verified all five newly converted surfaces (kunder, integrasjoner, eiendommer, personer, privacy — all Geist headings/body), regression-checked the #99 surfaces and homepage (Inter display type untouched). tsc clean. Screenshots in `.gstack/qa-reports/screenshots/conversion-*.png`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)